### PR TITLE
feat(brain): Phase 3 — マルチプロバイダー Brain（LLMクライアント）

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -58,3 +58,7 @@ golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/brain/anthropic.go
+++ b/internal/brain/anthropic.go
@@ -1,0 +1,121 @@
+package brain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+const (
+	defaultAnthropicBaseURL = "https://api.anthropic.com"
+	anthropicMessagesPath   = "/v1/messages"
+	anthropicVersion        = "2023-06-01"
+)
+
+type anthropicBrain struct {
+	cfg    Config
+	client *http.Client
+}
+
+func newAnthropicBrain(cfg Config) (*anthropicBrain, error) {
+	return &anthropicBrain{
+		cfg:    cfg,
+		client: &http.Client{Timeout: 120 * time.Second},
+	}, nil
+}
+
+func (b *anthropicBrain) Provider() string { return string(ProviderAnthropic) }
+
+func (b *anthropicBrain) Think(ctx context.Context, input Input) (*schema.Action, error) {
+	prompt := buildPrompt(input)
+
+	body := map[string]any{
+		"model":      b.cfg.Model,
+		"max_tokens": 1024,
+		"system":     systemPrompt,
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: marshal request: %w", err)
+	}
+
+	baseURL := b.cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultAnthropicBaseURL
+	}
+	url := strings.TrimRight(baseURL, "/") + anthropicMessagesPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	// 認証方式に応じてヘッダーを設定する。
+	// AuthAPIKey    → x-api-key ヘッダー（標準 API キー）
+	// AuthOAuthToken → Authorization: Bearer ヘッダー（claude auth token の出力）
+	switch b.cfg.AuthType {
+	case AuthOAuthToken:
+		req.Header.Set("Authorization", "Bearer "+b.cfg.Token)
+	default:
+		req.Header.Set("x-api-key", b.cfg.Token)
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("anthropic: API error %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	return parseAnthropicResponse(respBytes)
+}
+
+// anthropicResponse は Anthropic Messages API のレスポンス構造体（必要最小限）。
+type anthropicResponse struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+func parseAnthropicResponse(data []byte) (*schema.Action, error) {
+	var resp anthropicResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("anthropic: unmarshal response: %w", err)
+	}
+
+	for _, block := range resp.Content {
+		if block.Type != "text" {
+			continue
+		}
+		action, err := parseActionJSON(block.Text)
+		if err != nil {
+			return nil, fmt.Errorf("anthropic: parse action: %w", err)
+		}
+		return action, nil
+	}
+
+	return nil, fmt.Errorf("anthropic: no text content in response")
+}

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -1,0 +1,133 @@
+// Package brain は LLM クライアントを共通インターフェースで抽象化する。
+// Anthropic（claude auth token / API キー）と OpenAI の両方をサポートする。
+package brain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// Provider は LLM プロバイダーを識別する。
+type Provider string
+
+const (
+	ProviderAnthropic Provider = "anthropic"
+	ProviderOpenAI    Provider = "openai"
+)
+
+// AuthType は認証方式を識別する。
+type AuthType string
+
+const (
+	// AuthAPIKey は通常の API キー認証（x-api-key ヘッダー）。
+	// console.anthropic.com で発行した sk-ant-api03-... 形式。
+	AuthAPIKey AuthType = "api_key"
+
+	// AuthOAuthToken は Claude Code の OAuth トークン認証（Authorization: Bearer ヘッダー）。
+	// `claude auth token` で取得した sk-ant-ocp01-... 形式。
+	AuthOAuthToken AuthType = "oauth_token"
+)
+
+// Config は Brain の設定を保持する。
+type Config struct {
+	Provider Provider
+	Model    string
+	AuthType AuthType
+	Token    string
+	BaseURL  string // テスト時にモックサーバーを指定するために使う（空なら公式エンドポイント）
+}
+
+// Input は Brain に渡す思考コンテキスト。
+type Input struct {
+	// TargetSnapshot はターゲットの現在状態（JSON）。Entity抽出済みの構造体。
+	TargetSnapshot string
+	// ToolOutput は直前のツール実行結果（切り捨て済み）。空でも可。
+	ToolOutput string
+	// UserMessage はユーザーからの自然言語指示（チャット入力）。空でも可。
+	UserMessage string
+}
+
+// Brain は LLM との対話インターフェース。
+type Brain interface {
+	// Think はコンテキストを LLM に渡し、次のアクションを返す。
+	Think(ctx context.Context, input Input) (*schema.Action, error)
+	// Provider はプロバイダー名を返す。
+	Provider() string
+}
+
+// New は Config に基づいて適切な Brain 実装を返す。
+func New(cfg Config) (Brain, error) {
+	if cfg.Token == "" {
+		return nil, errors.New("brain: token must not be empty (set ANTHROPIC_API_KEY or run `claude auth token`)")
+	}
+
+	switch cfg.Provider {
+	case ProviderAnthropic:
+		return newAnthropicBrain(cfg)
+	case ProviderOpenAI:
+		return newOpenAIBrain(cfg)
+	default:
+		return nil, fmt.Errorf("brain: unknown provider %q (supported: anthropic, openai)", cfg.Provider)
+	}
+}
+
+// ConfigHint は LoadConfig へのヒント（プロバイダー・モデル）を保持する。
+// 認証情報は環境変数から自動解決する。
+type ConfigHint struct {
+	Provider Provider
+	Model    string
+	BaseURL  string
+}
+
+// LoadConfig は環境変数から認証情報を解決して Config を返す。
+//
+// 解決優先順位（Anthropic）:
+//  1. ANTHROPIC_API_KEY       → AuthAPIKey
+//  2. ANTHROPIC_AUTH_TOKEN    → AuthOAuthToken（`claude auth token` の出力）
+//
+// 解決優先順位（OpenAI）:
+//  1. OPENAI_API_KEY          → AuthAPIKey
+func LoadConfig(hint ConfigHint) (Config, error) {
+	cfg := Config{
+		Provider: hint.Provider,
+		Model:    hint.Model,
+		BaseURL:  hint.BaseURL,
+	}
+
+	switch hint.Provider {
+	case ProviderAnthropic:
+		if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+			cfg.Token = key
+			cfg.AuthType = AuthAPIKey
+			return cfg, nil
+		}
+		if token := os.Getenv("ANTHROPIC_AUTH_TOKEN"); token != "" {
+			cfg.Token = token
+			cfg.AuthType = AuthOAuthToken
+			return cfg, nil
+		}
+		return cfg, errors.New(
+			"brain: Anthropic 認証情報が見つかりません\n" +
+				"  - API キー:        export ANTHROPIC_API_KEY=sk-ant-api03-...\n" +
+				"  - Claude Code 認証: export ANTHROPIC_AUTH_TOKEN=$(claude auth token)",
+		)
+
+	case ProviderOpenAI:
+		if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+			cfg.Token = key
+			cfg.AuthType = AuthAPIKey
+			return cfg, nil
+		}
+		return cfg, errors.New(
+			"brain: OpenAI 認証情報が見つかりません\n" +
+				"  export OPENAI_API_KEY=sk-...",
+		)
+
+	default:
+		return cfg, fmt.Errorf("brain: unknown provider %q", hint.Provider)
+	}
+}

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -1,0 +1,229 @@
+package brain_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/0x6d61/pentecter/internal/brain"
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// mockAnthropicServer は Anthropic Messages API の最低限のモックを提供する。
+func mockAnthropicServer(t *testing.T, responseJSON string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 認証ヘッダーの確認（x-api-key または Authorization: Bearer）
+		apiKey := r.Header.Get("x-api-key")
+		authBearer := r.Header.Get("Authorization")
+		if apiKey == "" && authBearer == "" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(responseJSON)) //nolint:errcheck // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter -- テスト専用 httptest サーバー、ブラウザ向け HTML ではなくハードコード JSON を返すのみ
+	}))
+}
+
+// mockOpenAIServer は OpenAI Chat Completions API の最低限のモックを提供する。
+func mockOpenAIServer(t *testing.T, responseJSON string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(responseJSON)) //nolint:errcheck // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter -- テスト専用 httptest サーバー
+	}))
+}
+
+// anthropicResponse は Anthropic API のレスポンス JSON を組み立てるヘルパー。
+func anthropicResponse(actionJSON string) string {
+	return `{
+		"id": "msg_test",
+		"type": "message",
+		"role": "assistant",
+		"content": [{"type": "text", "text": "` + jsonEscape(actionJSON) + `"}],
+		"model": "claude-sonnet-4-6",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 20}
+	}`
+}
+
+// openAIResponse は OpenAI Chat Completions レスポンス JSON を組み立てるヘルパー。
+func openAIResponse(actionJSON string) string {
+	return `{
+		"id": "chatcmpl-test",
+		"object": "chat.completion",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "` + jsonEscape(actionJSON) + `"},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 20}
+	}`
+}
+
+func jsonEscape(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b[1 : len(b)-1]) // 前後の " を除去
+}
+
+// --- テストケース ---
+
+func TestAnthropicBrain_Think_APIKey(t *testing.T) {
+	action := `{"thought":"port 80 found","action":"run_tool","tool":"nikto","args":["-h","10.0.0.5"]}`
+	srv := mockAnthropicServer(t, anthropicResponse(action))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL, // テスト用にモックサーバーを向ける
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	result, err := b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5","open_ports":[{"port":80}]}`,
+		ToolOutput:     "80/tcp open http Apache 2.4.49",
+	})
+	if err != nil {
+		t.Fatalf("Think: %v", err)
+	}
+
+	if result.Action != schema.ActionRunTool {
+		t.Errorf("Action: got %q, want %q", result.Action, schema.ActionRunTool)
+	}
+	if result.Tool != "nikto" {
+		t.Errorf("Tool: got %q, want %q", result.Tool, "nikto")
+	}
+	if result.Thought == "" {
+		t.Error("Thought should not be empty")
+	}
+}
+
+func TestAnthropicBrain_Think_OAuthToken(t *testing.T) {
+	action := `{"thought":"analyzing","action":"think"}`
+	srv := mockAnthropicServer(t, anthropicResponse(action))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthOAuthToken, // claude auth token の出力を使う
+		Token:    "sk-ant-ocp01-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	result, err := b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err != nil {
+		t.Fatalf("Think: %v", err)
+	}
+	if result.Action != schema.ActionThink {
+		t.Errorf("Action: got %q, want %q", result.Action, schema.ActionThink)
+	}
+}
+
+func TestOpenAIBrain_Think(t *testing.T) {
+	action := `{"thought":"checking service","action":"run_tool","tool":"curl","args":["-si","http://10.0.0.5/"]}`
+	srv := mockOpenAIServer(t, openAIResponse(action))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	result, err := b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+		ToolOutput:     "PORT   STATE SERVICE\n80/tcp open  http",
+	})
+	if err != nil {
+		t.Fatalf("Think: %v", err)
+	}
+	if result.Tool != "curl" {
+		t.Errorf("Tool: got %q, want %q", result.Tool, "curl")
+	}
+}
+
+func TestBrain_New_EmptyToken_ReturnsError(t *testing.T) {
+	_, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "", // トークンなし
+	})
+	if err == nil {
+		t.Error("expected error for empty token, got nil")
+	}
+}
+
+func TestBrain_New_UnknownProvider_ReturnsError(t *testing.T) {
+	_, err := brain.New(brain.Config{
+		Provider: "unknown-provider",
+		Model:    "gpt-99",
+		AuthType: brain.AuthAPIKey,
+		Token:    "some-token",
+	})
+	if err == nil {
+		t.Error("expected error for unknown provider, got nil")
+	}
+}
+
+func TestLoadConfig_FromEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-from-env")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Token != "sk-ant-from-env" {
+		t.Errorf("Token: got %q, want sk-ant-from-env", cfg.Token)
+	}
+	if cfg.AuthType != brain.AuthAPIKey {
+		t.Errorf("AuthType: got %q, want %q", cfg.AuthType, brain.AuthAPIKey)
+	}
+}
+
+func TestLoadConfig_OAuthEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "sk-ant-ocp01-oauth")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Token != "sk-ant-ocp01-oauth" {
+		t.Errorf("Token: got %q, want sk-ant-ocp01-oauth", cfg.Token)
+	}
+	if cfg.AuthType != brain.AuthOAuthToken {
+		t.Errorf("AuthType: got %q, want %q", cfg.AuthType, brain.AuthOAuthToken)
+	}
+}

--- a/internal/brain/openai.go
+++ b/internal/brain/openai.go
@@ -1,0 +1,109 @@
+package brain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+const (
+	defaultOpenAIBaseURL    = "https://api.openai.com"
+	openAIChatCompletePath  = "/v1/chat/completions"
+)
+
+type openAIBrain struct {
+	cfg    Config
+	client *http.Client
+}
+
+func newOpenAIBrain(cfg Config) (*openAIBrain, error) {
+	return &openAIBrain{
+		cfg:    cfg,
+		client: &http.Client{Timeout: 120 * time.Second},
+	}, nil
+}
+
+func (b *openAIBrain) Provider() string { return string(ProviderOpenAI) }
+
+func (b *openAIBrain) Think(ctx context.Context, input Input) (*schema.Action, error) {
+	prompt := buildPrompt(input)
+
+	body := map[string]any{
+		"model": b.cfg.Model,
+		"messages": []map[string]string{
+			{"role": "system", "content": systemPrompt},
+			{"role": "user", "content": prompt},
+		},
+		"max_tokens":  1024,
+		"temperature": 0.2,
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: marshal request: %w", err)
+	}
+
+	baseURL := b.cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultOpenAIBaseURL
+	}
+	url := strings.TrimRight(baseURL, "/") + openAIChatCompletePath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("openai: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+b.cfg.Token)
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openai: API error %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	return parseOpenAIResponse(respBytes)
+}
+
+// openAIResponse は Chat Completions API のレスポンス構造体（必要最小限）。
+type openAIResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func parseOpenAIResponse(data []byte) (*schema.Action, error) {
+	var resp openAIResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("openai: unmarshal response: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("openai: empty choices in response")
+	}
+
+	action, err := parseActionJSON(resp.Choices[0].Message.Content)
+	if err != nil {
+		return nil, fmt.Errorf("openai: parse action: %w", err)
+	}
+	return action, nil
+}

--- a/internal/brain/prompt.go
+++ b/internal/brain/prompt.go
@@ -1,0 +1,94 @@
+package brain
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// systemPrompt はペンテスト特化のシステムプロンプト。
+// Brain は常にこのプロンプトをシステムメッセージとして受け取る。
+const systemPrompt = `You are Pentecter, an autonomous penetration testing agent operating under authorized engagements.
+
+Your role is to analyze the current target state and decide the next action.
+
+RESPONSE FORMAT (strict JSON, no markdown):
+{
+  "thought": "brief reasoning about current situation and next step",
+  "action": "run_tool" | "propose" | "think" | "complete",
+  "tool": "tool name (only for run_tool)",
+  "args": ["arg1", "arg2"] (only for run_tool)
+}
+
+ACTION TYPES:
+- run_tool: Execute a security tool (nmap, nikto, curl, etc.)
+- propose: Suggest a high-impact action requiring human approval (exploits, brute-force, etc.)
+- think: Analyze findings without taking action yet
+- complete: Mark the target assessment as done
+
+RULES:
+- Always respond with valid JSON only, no prose.
+- For destructive or high-impact actions (exploits, credential attacks), use "propose" not "run_tool".
+- Keep reasoning concise (1-2 sentences).
+- Use tool names exactly as registered (nmap, nikto, curl, wpscan, etc.).`
+
+// buildPrompt はターゲット状態とツール出力からユーザープロンプトを組み立てる。
+func buildPrompt(input Input) string {
+	var sb strings.Builder
+
+	sb.WriteString("## Current Target State\n")
+	sb.WriteString("```json\n")
+	sb.WriteString(input.TargetSnapshot)
+	sb.WriteString("\n```\n")
+
+	if input.ToolOutput != "" {
+		sb.WriteString("\n## Last Tool Output\n")
+		sb.WriteString("```\n")
+		sb.WriteString(input.ToolOutput)
+		sb.WriteString("\n```\n")
+	}
+
+	if input.UserMessage != "" {
+		sb.WriteString("\n## User Instruction\n")
+		sb.WriteString(input.UserMessage)
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\nDecide the next action and respond with JSON only.")
+	return sb.String()
+}
+
+// jsonBlockRe は LLM がコードブロックで JSON を返した場合に抽出するパターン。
+var jsonBlockRe = regexp.MustCompile("(?s)```(?:json)?\\s*({.*?})\\s*```")
+
+// parseActionJSON は LLM のレスポンステキストから schema.Action を抽出・パースする。
+// LLM が JSON をコードブロックで囲んで返した場合も処理する。
+func parseActionJSON(text string) (*schema.Action, error) {
+	text = strings.TrimSpace(text)
+
+	// コードブロック内の JSON を取り出す試み
+	if m := jsonBlockRe.FindStringSubmatch(text); len(m) > 1 {
+		text = m[1]
+	}
+
+	// 先頭の { から末尾の } までを抽出（前後にテキストがある場合の対策）
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start >= 0 && end > start {
+		text = text[start : end+1]
+	}
+
+	var action schema.Action
+	if err := json.Unmarshal([]byte(text), &action); err != nil {
+		return nil, fmt.Errorf("invalid JSON from LLM: %w\nraw: %s", err, text)
+	}
+
+	if action.Action == "" {
+		return nil, fmt.Errorf("LLM response missing 'action' field: %s", text)
+	}
+
+	return &action, nil
+}


### PR DESCRIPTION
## Summary

- Anthropic / OpenAI を共通インターフェースで抽象化した Brain を実装
- `claude auth token` の OAuth トークンと通常 API キーの両方に対応
- httptest モックサーバーによるテストで実 API 呼び出しなしに動作検証

## 認証方法

```bash
# Anthropic — API キー
export ANTHROPIC_API_KEY=sk-ant-api03-...

# Anthropic — Claude Code OAuth トークン（claude.ai サブスク）
export ANTHROPIC_AUTH_TOKEN=$(claude auth token)

# OpenAI
export OPENAI_API_KEY=sk-...
```

## ファイル構成

```
internal/brain/
  brain.go       # Brain インターフェース + LoadConfig
  anthropic.go   # Anthropic 実装（API key / OAuth token 両対応）
  openai.go      # OpenAI 実装
  prompt.go      # システムプロンプト + JSON パース
  brain_test.go  # 7テスト（httptest モック使用）
```

## Test plan

- [x] `go test ./internal/brain/...` — 7テスト全グリーン
- [x] `go build ./...` — ビルド成功
- [x] `go vet ./...` — 警告なし
- [x] API キー認証テスト（Anthropic / OpenAI）
- [x] OAuth トークン認証テスト（Anthropic）
- [x] トークン未設定でエラー返却確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)