### PR TITLE
feat: Skills + Memory ドメイン + 動的ターゲット追加

### DIFF
--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -12,6 +12,8 @@ const (
 	EventComplete EventType = "complete"
 	// EventError はループ内でリカバリー不能なエラーが発生したとき。
 	EventError EventType = "error"
+	// EventAddTarget は横展開で新ターゲットを追加するとき。
+	EventAddTarget EventType = "add_target"
 )
 
 // Event は Agent ループから TUI へ送るメッセージ。
@@ -21,4 +23,5 @@ type Event struct {
 	Source   LogSource // EventLog 時に使用
 	Message  string
 	Proposal *Proposal // EventProposal 時に使用
+	NewHost  string    // EventAddTarget 時に使用
 }

--- a/internal/agent/target.go
+++ b/internal/agent/target.go
@@ -64,10 +64,11 @@ type Proposal struct {
 }
 
 // Target represents a discovered host and the full state of its pentest session.
+// Host は IP アドレスまたはドメイン名（例: "10.0.0.5", "example.com"）。
 type Target struct {
-	ID       int
-	IP       string
-	Status   Status
+	ID     int
+	Host   string // IP アドレスまたはドメイン名
+	Status Status
 	Logs     []LogEntry
 	Proposal *Proposal
 	// Entities はツール出力から抽出された発見済みエンティティ（ナレッジグラフ）。
@@ -90,11 +91,12 @@ func (t *Target) AddEntities(entities []tools.Entity) {
 	}
 }
 
-// NewTarget creates a new Target with default idle state.
-func NewTarget(id int, ip string) *Target {
+// NewTarget は新しい Target をデフォルト状態で作成する。
+// host は IP アドレスまたはドメイン名（例: "10.0.0.5", "example.com"）。
+func NewTarget(id int, host string) *Target {
 	return &Target{
 		ID:     id,
-		IP:     ip,
+		Host:   host,
 		Status: StatusIdle,
 		Logs:   make([]LogEntry, 0),
 	}

--- a/internal/agent/target_test.go
+++ b/internal/agent/target_test.go
@@ -12,8 +12,8 @@ func TestNewTarget_InitialState(t *testing.T) {
 	if tgt.ID != 1 {
 		t.Errorf("ID: got %d, want 1", tgt.ID)
 	}
-	if tgt.IP != "10.0.0.1" {
-		t.Errorf("IP: got %s, want 10.0.0.1", tgt.IP)
+	if tgt.Host != "10.0.0.1" {
+		t.Errorf("Host: got %s, want 10.0.0.1", tgt.Host)
 	}
 	if tgt.Status != agent.StatusIdle {
 		t.Errorf("Status: got %s, want %s", tgt.Status, agent.StatusIdle)

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -1,0 +1,112 @@
+// Package memory は Brain の発見物（脆弱性・認証情報・アーティファクト）を
+// ホストごとの Markdown ファイルに永続化する。
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// Store はメモリファイルの読み書きを管理する。
+type Store struct {
+	dir string // メモリファイルを保存するディレクトリ
+}
+
+// NewStore は指定ディレクトリを使う Store を返す。
+// ディレクトリが存在しない場合は Record 時に自動作成する。
+func NewStore(dir string) *Store {
+	return &Store{dir: dir}
+}
+
+// Record は発見物を host に対応するファイルに追記する。
+// ファイルが存在しない場合は新規作成してヘッダーを書く。
+func (s *Store) Record(host string, m *schema.Memory) error {
+	if err := os.MkdirAll(s.dir, 0o750); err != nil {
+		return fmt.Errorf("memory: mkdir: %w", err)
+	}
+
+	// ファイル名: memory/<host>.md（ホスト名の特殊文字はそのまま）
+	filename := sanitizeFilename(host) + ".md"
+	path := filepath.Join(s.dir, filename)
+
+	// ファイルが存在しなければヘッダーを書く
+	isNew := false
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		isNew = true
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("memory: open file: %w", err)
+	}
+	defer f.Close()
+
+	if isNew {
+		header := fmt.Sprintf("# Pentecter Memory: %s\n\nGenerated: %s\n\n", host, time.Now().Format("2006-01-02 15:04:05"))
+		if _, err := f.WriteString(header); err != nil {
+			return fmt.Errorf("memory: write header: %w", err)
+		}
+	}
+
+	entry := formatEntry(m)
+	if _, err := f.WriteString(entry); err != nil {
+		return fmt.Errorf("memory: write entry: %w", err)
+	}
+	return nil
+}
+
+// Read は host のメモリファイル全文を返す。ファイルが存在しない場合は空文字列。
+func (s *Store) Read(host string) string {
+	filename := sanitizeFilename(host) + ".md"
+	data, err := os.ReadFile(filepath.Join(s.dir, filename))
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// formatEntry は Memory を Markdown エントリに変換する。
+func formatEntry(m *schema.Memory) string {
+	ts := time.Now().Format("15:04:05")
+
+	switch m.Type {
+	case schema.MemoryVulnerability:
+		severity := strings.ToUpper(m.Severity)
+		if severity == "" {
+			severity = "INFO"
+		}
+		return fmt.Sprintf("## [%s] %s\n- **時刻**: %s\n- **説明**: %s\n\n",
+			severity, m.Title, ts, m.Description)
+
+	case schema.MemoryCredential:
+		return fmt.Sprintf("## 🔑 認証情報: %s\n- **時刻**: %s\n- **詳細**: %s\n\n",
+			m.Title, ts, m.Description)
+
+	case schema.MemoryArtifact:
+		return fmt.Sprintf("## 📄 アーティファクト: %s\n- **時刻**: %s\n- **詳細**: %s\n\n",
+			m.Title, ts, m.Description)
+
+	default: // MemoryNote
+		return fmt.Sprintf("## 📝 ノート: %s\n- **時刻**: %s\n- **内容**: %s\n\n",
+			m.Title, ts, m.Description)
+	}
+}
+
+// sanitizeFilename はホスト名をファイル名として安全な形式に変換する。
+// IP アドレスとドメイン名はそのまま使用できる。
+// セキュリティ: パストラバーサルを防ぐため / と \ を除去する。
+func sanitizeFilename(host string) string {
+	// パス区切り文字を除去（パストラバーサル防止）
+	host = strings.ReplaceAll(host, "/", "_")
+	host = strings.ReplaceAll(host, "\\", "_")
+	host = strings.ReplaceAll(host, "..", "_")
+	if host == "" {
+		host = "unknown"
+	}
+	return host
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,0 +1,83 @@
+package memory_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0x6d61/pentecter/internal/memory"
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+func TestStore_Record_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	err := s.Record("10.0.0.5", &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "CVE-2021-41773",
+		Description: "Apache 2.4.49 Path Traversal confirmed",
+		Severity:    "critical",
+	})
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	path := filepath.Join(dir, "10.0.0.5.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("File not created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "CVE-2021-41773") {
+		t.Errorf("File should contain CVE title, got:\n%s", content)
+	}
+	if !strings.Contains(strings.ToLower(content), "critical") {
+		t.Errorf("File should contain severity, got:\n%s", content)
+	}
+}
+
+func TestStore_Record_Appends(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	_ = s.Record("10.0.0.5", &schema.Memory{
+		Type:  schema.MemoryVulnerability,
+		Title: "CVE-2021-41773",
+	})
+	_ = s.Record("10.0.0.5", &schema.Memory{
+		Type:  schema.MemoryCredential,
+		Title: "MySQL: root / empty password",
+	})
+
+	data, _ := os.ReadFile(filepath.Join(dir, "10.0.0.5.md"))
+	content := string(data)
+
+	if !strings.Contains(content, "CVE-2021-41773") {
+		t.Error("First entry missing")
+	}
+	if !strings.Contains(content, "MySQL") {
+		t.Error("Second entry missing")
+	}
+}
+
+func TestStore_Record_DomainHost(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	err := s.Record("example.com", &schema.Memory{
+		Type:  schema.MemoryNote,
+		Title: "Domain target",
+	})
+	if err != nil {
+		t.Fatalf("Domain host record: %v", err)
+	}
+
+	// ファイル名の . はそのまま（ホスト名として有効）
+	_, err = os.ReadFile(filepath.Join(dir, "example.com.md"))
+	if err != nil {
+		t.Fatalf("File not found for domain host: %v", err)
+	}
+}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,143 @@
+// Package skills はペンテスト手順テンプレート（スキル）を管理する。
+//
+// スキルは Markdown + YAML frontmatter 形式で定義する:
+//
+//	---
+//	name: web-recon
+//	description: Webアプリ初期偵察
+//	---
+//
+//	Perform web application reconnaissance...
+//
+// ユーザーが "/web-recon" と入力するとスキルのプロンプトが Brain のコンテキストに追加される。
+package skills
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Skill はペンテスト手順テンプレートを定義する。
+type Skill struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	// Prompt は Brain に追加注入するプロンプトテキスト（Markdown 本文）。
+	Prompt string
+}
+
+// Registry はロード済みスキルを管理する。
+type Registry struct {
+	skills map[string]*Skill // key: skill name（スラッシュなし）
+}
+
+// NewRegistry は空の Registry を返す。
+func NewRegistry() *Registry {
+	return &Registry{skills: make(map[string]*Skill)}
+}
+
+// LoadDir は dir 以下の *.md ファイルをロードする（*.yaml も後方互換で対応）。
+// ディレクトリが存在しなくてもエラーにはしない。
+func (r *Registry) LoadDir(dir string) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		switch {
+		case strings.HasSuffix(path, ".md"):
+			if sk := parseMDSkill(path); sk != nil {
+				r.skills[sk.Name] = sk
+			}
+		case strings.HasSuffix(path, ".yaml"):
+			if sk := parseYAMLSkill(path); sk != nil {
+				r.skills[sk.Name] = sk
+			}
+		}
+		return nil
+	})
+}
+
+// parseMDSkill は Markdown + frontmatter 形式のスキルファイルをパースする。
+func parseMDSkill(path string) *Skill {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	content := string(data)
+
+	// frontmatter を分離（--- で囲まれた YAML 部分）
+	if !strings.HasPrefix(content, "---") {
+		return nil
+	}
+	parts := strings.SplitN(content, "---", 3)
+	if len(parts) < 3 {
+		return nil
+	}
+
+	var sk Skill
+	if err := yaml.Unmarshal([]byte(parts[1]), &sk); err != nil || sk.Name == "" {
+		return nil
+	}
+	sk.Prompt = strings.TrimSpace(parts[2])
+	return &sk
+}
+
+// parseYAMLSkill は後方互換のために YAML 形式もサポートする。
+func parseYAMLSkill(path string) *Skill {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	// YAML の prompt フィールドを含む旧形式
+	var raw struct {
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
+		Prompt      string `yaml:"prompt"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil || raw.Name == "" {
+		return nil
+	}
+	return &Skill{Name: raw.Name, Description: raw.Description, Prompt: raw.Prompt}
+}
+
+
+// Get はスキル名でスキルを検索する。
+func (r *Registry) Get(name string) (*Skill, bool) {
+	sk, ok := r.skills[strings.TrimPrefix(name, "/")]
+	return sk, ok
+}
+
+// Expand はユーザー入力を検査し、スキル呼び出し（/skill-name）なら
+// スキルのプロンプトを返す。通常の入力はそのまま返す。
+func (r *Registry) Expand(input string) string {
+	input = strings.TrimSpace(input)
+	if !strings.HasPrefix(input, "/") {
+		return input
+	}
+	name := strings.TrimPrefix(input, "/")
+	// スペースで区切られた追加引数は無視（将来の拡張用）
+	name = strings.Fields(name)[0]
+
+	if sk, ok := r.skills[name]; ok {
+		return strings.TrimSpace(sk.Prompt)
+	}
+	// 未知のスラッシュコマンドはそのまま返す
+	return input
+}
+
+// All は登録済みの全スキルを返す。
+func (r *Registry) All() []*Skill {
+	result := make([]*Skill, 0, len(r.skills))
+	for _, sk := range r.skills {
+		result = append(result, sk)
+	}
+	return result
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,79 @@
+package skills_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0x6d61/pentecter/internal/skills"
+)
+
+func TestRegistry_Load(t *testing.T) {
+	dir := t.TempDir()
+
+	md := `---
+name: web-recon
+description: "Webアプリ初期偵察"
+---
+
+Perform web application reconnaissance.
+Steps: nmap → nikto → wpscan
+`
+	if err := os.WriteFile(filepath.Join(dir, "web-recon.md"), []byte(md), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := skills.NewRegistry()
+	if err := reg.LoadDir(dir); err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+
+	sk, ok := reg.Get("web-recon")
+	if !ok {
+		t.Fatal("web-recon not found")
+	}
+	if sk.Name != "web-recon" {
+		t.Errorf("Name: got %q", sk.Name)
+	}
+	if sk.Prompt == "" {
+		t.Error("Prompt should not be empty")
+	}
+}
+
+func TestRegistry_Invoke_AddsPromptToContext(t *testing.T) {
+	dir := t.TempDir()
+
+	md := "---\nname: sqli\ndescription: \"SQLi チェック\"\n---\n\nTest for SQL injection vulnerabilities on the target."
+	if err := os.WriteFile(filepath.Join(dir, "sqli.md"), []byte(md), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := skills.NewRegistry()
+	_ = reg.LoadDir(dir)
+
+	// /sqli というユーザー入力からスキルを検出・展開
+	expanded := reg.Expand("/sqli")
+	if expanded == "" {
+		t.Error("Expand('/sqli') should return skill prompt")
+	}
+	if expanded != "Test for SQL injection vulnerabilities on the target." {
+		t.Errorf("Expand: got %q", expanded)
+	}
+}
+
+func TestRegistry_Expand_NonSkill_ReturnsOriginal(t *testing.T) {
+	reg := skills.NewRegistry()
+	input := "focus on port 445 only"
+	got := reg.Expand(input)
+	if got != input {
+		t.Errorf("Non-skill input should be returned as-is: got %q", got)
+	}
+}
+
+func TestRegistry_LoadDir_Missing_NoError(t *testing.T) {
+	reg := skills.NewRegistry()
+	err := reg.LoadDir("/nonexistent/skills/dir")
+	if err != nil {
+		t.Errorf("Missing dir should not error: %v", err)
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -59,7 +59,7 @@ func (m Model) renderStatusBar() string {
 	if t != nil {
 		targetInfo = fmt.Sprintf(
 			"フォーカス: %s [%s]",
-			lipgloss.NewStyle().Foreground(colorWarning).Render(t.IP),
+			lipgloss.NewStyle().Foreground(colorWarning).Render(t.Host),
 			t.Status,
 		)
 	} else {

--- a/pkg/schema/action.go
+++ b/pkg/schema/action.go
@@ -21,6 +21,10 @@ const (
 
 	// ActionMemory は脆弱性・認証情報・アーティファクトを memory に記録する。
 	ActionMemory ActionType = "memory"
+
+	// ActionAddTarget は横展開時に新ターゲットを追加する。
+	// Brain がネットワーク内の別ホストを発見した際に使用する。
+	ActionAddTarget ActionType = "add_target"
 )
 
 // Action is the JSON payload emitted by the Brain (LLM).
@@ -37,6 +41,7 @@ type Action struct {
 	Action  ActionType `json:"action"`
 	Command string     `json:"command,omitempty"` // ActionRun / ActionPropose
 	Memory  *Memory    `json:"memory,omitempty"`  // ActionMemory
+	Target  string     `json:"target,omitempty"`  // ActionAddTarget: 追加するホスト
 }
 
 // Memory は Brain がナレッジグラフに記録する発見物。

--- a/skills/full-scan.md
+++ b/skills/full-scan.md
@@ -1,0 +1,13 @@
+---
+name: full-scan
+description: フルポートスキャン + サービス検出
+---
+
+Perform a comprehensive port scan and service enumeration.
+
+1. Full TCP port scan: nmap -sV -p- --open <target>
+2. For each discovered service, perform targeted enumeration
+3. Check for default credentials on discovered services
+4. Record all open ports, services, and versions with memory action
+
+Be thorough but efficient — focus on high-value findings.

--- a/skills/full-scan.yaml
+++ b/skills/full-scan.yaml
@@ -1,0 +1,9 @@
+name: full-scan
+description: "フルポートスキャン + サービス検出"
+prompt: |
+  Perform a comprehensive port scan and service enumeration.
+  1. Full TCP port scan: nmap -sV -p- --open <target>
+  2. For each discovered service, perform targeted enumeration
+  3. Check for default credentials on discovered services
+  4. Record all open ports, services, and versions with memory action.
+  Be thorough but efficient — focus on high-value findings.

--- a/skills/sqli-check.md
+++ b/skills/sqli-check.md
@@ -1,0 +1,13 @@
+---
+name: sqli-check
+description: SQLインジェクション確認
+---
+
+Check for SQL injection vulnerabilities on the target web application.
+
+1. Identify injectable parameters via curl
+2. Test for error-based SQLi: append `'` to parameters
+3. Test for boolean-based: `param=1 AND 1=1` vs `AND 1=2`
+4. If SQLi confirmed, propose sqlmap for full exploitation (requires approval)
+
+Record confirmed SQLi vulnerabilities with memory action (severity: high or critical).

--- a/skills/sqli-check.yaml
+++ b/skills/sqli-check.yaml
@@ -1,0 +1,9 @@
+name: sqli-check
+description: "SQLインジェクション確認"
+prompt: |
+  Check for SQL injection vulnerabilities on the target web application.
+  1. Identify injectable parameters via curl
+  2. Test for error-based SQLi: append ' to parameters
+  3. Test for boolean-based: parameter=1 AND 1=1 vs AND 1=2
+  4. If SQLi confirmed, propose sqlmap for full exploitation (requires approval)
+  Record confirmed SQLi vulnerabilities with memory action (severity: high or critical).

--- a/skills/web-recon.md
+++ b/skills/web-recon.md
@@ -1,0 +1,15 @@
+---
+name: web-recon
+description: Webアプリケーション初期偵察
+---
+
+Perform comprehensive web application reconnaissance on the target.
+
+Follow this sequence:
+1. Port scan: nmap -sV -p 80,443,8080,8443
+2. Web vulnerability scan: nikto -h http://<target>/
+3. If WordPress detected: wpscan --url http://<target>/
+4. Check for common paths: curl -si http://<target>/admin/
+
+Record all discovered vulnerabilities and interesting findings with memory action.
+Focus: web vulnerabilities, exposed admin panels, outdated software versions.

--- a/skills/web-recon.yaml
+++ b/skills/web-recon.yaml
@@ -1,0 +1,11 @@
+name: web-recon
+description: "Webアプリケーション初期偵察"
+prompt: |
+  Perform comprehensive web application reconnaissance on the target.
+  Follow this sequence:
+  1. Port scan: nmap -sV -p 80,443,8080,8443,8888 <target>
+  2. Web vulnerability scan: nikto -h http://<target>/
+  3. If WordPress detected: wpscan --url http://<target>/
+  4. Check for common paths: curl -si http://<target>/admin/ http://<target>/phpmyadmin/
+  Record all discovered vulnerabilities and interesting findings with memory action.
+  Focus: web vulnerabilities, exposed admin panels, outdated software versions.


### PR DESCRIPTION
## Summary
- **Skills**: Markdown+frontmatter 形式のペンテスト手順テンプレート（`/web-recon`, `/full-scan`, `/sqli-check`）をチャットから実行可能に
- **Memory**: ホスト別 Markdown ファイルに脆弱性・認証情報・アーティファクトを永続化。Brain が過去の発見物を参照して判断に活用
- **動的ターゲット追加**: チャットで IP 入力 or `/target <host>` でターゲット追加。AI が `add_target` アクションで横展開時に自律追加
- **起動簡素化**: `--provider` と `--model` のみ残し、不要フラグを削除。ターゲットなしでも起動可能

## Changes
| ファイル | 内容 |
|---|---|
| `internal/memory/` | Memory Store（Record/Read + パストラバーサル防止） |
| `internal/skills/` | Skills Registry（LoadDir/Expand/All） |
| `skills/` | 3つの初期スキルテンプレート |
| `pkg/schema/action.go` | `ActionAddTarget` + `Action.Target` フィールド |
| `internal/agent/event.go` | `EventAddTarget` + `Event.NewHost` |
| `internal/agent/team.go` | `TeamConfig` + `AddTarget()` ファクトリメソッド |
| `internal/agent/loop.go` | Memory コンテキスト統合 + `add_target` アクション処理 |
| `internal/tui/update.go` | `parseTargetInput` + `addTarget` + `EventAddTarget` ハンドリング |
| `cmd/pentecter/main.go` | フラグ削除 + TeamConfig ベース初期化 |

## Test plan
- [x] `go build ./...` ビルド成功
- [x] `go vet ./...` 静的解析クリーン
- [x] `go test ./internal/...` 全33テスト PASS
  - `TestLoop_Run_Memory_RecordAndSnapshot` — Memory が Brain snapshot に含まれる
  - `TestLoop_Run_AddTarget_EmitsEvent` — `add_target` → `EventAddTarget` 発行
  - `TestTeam_AddTarget_DynamicStart` — 動的追加した Loop が即座に起動

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)