### PR TITLE
feat: Brain コンテキスト改善 + Memory リストラクチャ + 多言語対応

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -210,15 +210,20 @@ func TestLoop_Run_Memory_RecordAndSnapshot(t *testing.T) {
 		select {
 		case e := <-events:
 			if e.Type == agent.EventComplete {
-				// 3回目の Think() に渡された snapshot に memory が含まれるか検証
+				// 3回目の Think() に渡された Memory フィールドに CVE が含まれるか検証
 				// inputs[0] = 1回目(memory記録), inputs[1] = 2回目(think), inputs[2] = 3回目(complete)
 				if len(mb.inputs) < 3 {
 					t.Fatalf("expected at least 3 Think() calls, got %d", len(mb.inputs))
 				}
-				// 2回目以降の snapshot に CVE が含まれるはず
+				// 2回目以降の Memory フィールドに CVE が含まれるはず
+				mem := mb.inputs[2].Memory
+				if !strings.Contains(mem, "CVE-2021-41773") {
+					t.Errorf("Memory field should contain CVE content, got:\n%s", mem)
+				}
+				// snapshot には memory が含まれないこと（独立フィールドに分離済み）
 				snapshot := mb.inputs[2].TargetSnapshot
-				if !strings.Contains(snapshot, "CVE-2021-41773") {
-					t.Errorf("snapshot should contain memory content, got:\n%s", snapshot)
+				if strings.Contains(snapshot, "CVE-2021-41773") {
+					t.Errorf("TargetSnapshot should NOT contain memory content after separation, got:\n%s", snapshot)
 				}
 				return
 			}

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -63,6 +63,8 @@ type Input struct {
 	UserMessage string
 	// TurnCount は現在のターン番号（1始まり）。自律ループの進行度を Brain に伝える。
 	TurnCount int
+	// Memory は対象ホストの過去の発見物テキスト。空でも可。
+	Memory string
 }
 
 // Brain は LLM との対話インターフェース。

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -1,5 +1,12 @@
 // Package memory は Brain の発見物（脆弱性・認証情報・アーティファクト）を
-// ホストごとの Markdown ファイルに永続化する。
+// ホストごとのディレクトリに型別ファイルとして永続化する。
+//
+// ディレクトリ構造:
+//
+//	memory/<host>/vulnerability.txt
+//	memory/<host>/credential.txt
+//	memory/<host>/artifact.txt
+//	memory/<host>/finding.txt
 package memory
 
 import (
@@ -12,9 +19,28 @@ import (
 	"github.com/0x6d61/pentecter/pkg/schema"
 )
 
+// 型別ファイル名の定義
+const (
+	fileVulnerability = "vulnerability.txt"
+	fileCredential    = "credential.txt"
+	fileArtifact      = "artifact.txt"
+	fileFinding       = "finding.txt"
+)
+
+// sectionOrder は Read 時のセクション出力順序を定義する。
+var sectionOrder = []struct {
+	header   string
+	filename string
+}{
+	{"## Vulnerabilities", fileVulnerability},
+	{"## Credentials", fileCredential},
+	{"## Artifacts", fileArtifact},
+	{"## Findings", fileFinding},
+}
+
 // Store はメモリファイルの読み書きを管理する。
 type Store struct {
-	dir string // メモリファイルを保存するディレクトリ
+	dir string // メモリファイルを保存するベースディレクトリ
 }
 
 // NewStore は指定ディレクトリを使う Store を返す。
@@ -23,35 +49,22 @@ func NewStore(dir string) *Store {
 	return &Store{dir: dir}
 }
 
-// Record は発見物を host に対応するファイルに追記する。
-// ファイルが存在しない場合は新規作成してヘッダーを書く。
+// Record は発見物を host に対応する型別ファイルに追記する。
+// ホストディレクトリが存在しない場合は自動作成する。
 func (s *Store) Record(host string, m *schema.Memory) error {
-	if err := os.MkdirAll(s.dir, 0o750); err != nil {
+	hostDir := filepath.Join(s.dir, sanitizeFilename(host))
+	if err := os.MkdirAll(hostDir, 0o750); err != nil {
 		return fmt.Errorf("memory: mkdir: %w", err)
 	}
 
-	// ファイル名: memory/<host>.md（ホスト名の特殊文字はそのまま）
-	filename := sanitizeFilename(host) + ".md"
-	path := filepath.Join(s.dir, filename)
-
-	// ファイルが存在しなければヘッダーを書く
-	isNew := false
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		isNew = true
-	}
+	filename := typeToFilename(m.Type)
+	path := filepath.Join(hostDir, filename)
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("memory: open file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-
-	if isNew {
-		header := fmt.Sprintf("# Pentecter Memory: %s\n\nGenerated: %s\n\n", host, time.Now().Format("2006-01-02 15:04:05"))
-		if _, err := f.WriteString(header); err != nil {
-			return fmt.Errorf("memory: write header: %w", err)
-		}
-	}
 
 	entry := formatEntry(m)
 	if _, err := f.WriteString(entry); err != nil {
@@ -60,19 +73,50 @@ func (s *Store) Record(host string, m *schema.Memory) error {
 	return nil
 }
 
-// Read は host のメモリファイル全文を返す。ファイルが存在しない場合は空文字列。
+// Read は host のすべての型別ファイルを読み込み、セクションヘッダー付きで結合して返す。
+// ホストディレクトリが存在しない場合は空文字列を返す。
+// 存在しないファイルや空ファイルのセクションはスキップする。
 func (s *Store) Read(host string) string {
-	filename := sanitizeFilename(host) + ".md"
-	data, err := os.ReadFile(filepath.Join(s.dir, filename))
-	if err != nil {
+	hostDir := filepath.Join(s.dir, sanitizeFilename(host))
+
+	// ホストディレクトリが存在しなければ空文字列
+	if _, err := os.Stat(hostDir); os.IsNotExist(err) {
 		return ""
 	}
-	return string(data)
+
+	var sb strings.Builder
+	for _, sec := range sectionOrder {
+		data, err := os.ReadFile(filepath.Join(hostDir, sec.filename))
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(sec.header)
+		sb.WriteString("\n")
+		sb.Write(data)
+	}
+	return sb.String()
 }
 
-// formatEntry は Memory を Markdown エントリに変換する。
+// typeToFilename は MemoryType を対応するファイル名に変換する。
+func typeToFilename(t schema.MemoryType) string {
+	switch t {
+	case schema.MemoryVulnerability:
+		return fileVulnerability
+	case schema.MemoryCredential:
+		return fileCredential
+	case schema.MemoryArtifact:
+		return fileArtifact
+	default: // MemoryNote → finding.txt
+		return fileFinding
+	}
+}
+
+// formatEntry は Memory をタイムスタンプ付きのテキストエントリに変換する。
 func formatEntry(m *schema.Memory) string {
-	ts := time.Now().Format("15:04:05")
+	ts := time.Now().Format("2006-01-02 15:04:05")
 
 	switch m.Type {
 	case schema.MemoryVulnerability:
@@ -80,24 +124,20 @@ func formatEntry(m *schema.Memory) string {
 		if severity == "" {
 			severity = "INFO"
 		}
-		return fmt.Sprintf("## [%s] %s\n- **Time**: %s\n- **Description**: %s\n\n",
-			severity, m.Title, ts, m.Description)
+		return fmt.Sprintf("[%s] [%s] %s\n%s\n\n", ts, severity, m.Title, m.Description)
 
 	case schema.MemoryCredential:
-		return fmt.Sprintf("## Credential: %s\n- **Time**: %s\n- **Details**: %s\n\n",
-			m.Title, ts, m.Description)
+		return fmt.Sprintf("[%s] %s\n%s\n\n", ts, m.Title, m.Description)
 
 	case schema.MemoryArtifact:
-		return fmt.Sprintf("## Artifact: %s\n- **Time**: %s\n- **Details**: %s\n\n",
-			m.Title, ts, m.Description)
+		return fmt.Sprintf("[%s] %s\n%s\n\n", ts, m.Title, m.Description)
 
 	default: // MemoryNote
-		return fmt.Sprintf("## Note: %s\n- **Time**: %s\n- **Content**: %s\n\n",
-			m.Title, ts, m.Description)
+		return fmt.Sprintf("[%s] %s\n%s\n\n", ts, m.Title, m.Description)
 	}
 }
 
-// sanitizeFilename はホスト名をファイル名として安全な形式に変換する。
+// sanitizeFilename はホスト名をディレクトリ名として安全な形式に変換する。
 // IP アドレスとドメイン名はそのまま使用できる。
 // セキュリティ: パストラバーサルを防ぐため / と \ を除去する。
 func sanitizeFilename(host string) string {

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -10,189 +10,108 @@ import (
 	"github.com/0x6d61/pentecter/pkg/schema"
 )
 
-func TestStore_Record_CreatesFile(t *testing.T) {
+// --- Record: 型別ファイル振り分けテスト ---
+
+func TestStore_Record_WritesToCorrectFile(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	tests := []struct {
+		name     string
+		mem      *schema.Memory
+		wantFile string // host dir 内の期待されるファイル名
+	}{
+		{
+			name: "vulnerability goes to vulnerability.txt",
+			mem: &schema.Memory{
+				Type:        schema.MemoryVulnerability,
+				Title:       "CVE-2021-41773 Apache Path Traversal",
+				Description: "Apache 2.4.49 vulnerable to path traversal allowing remote code execution.",
+				Severity:    "critical",
+			},
+			wantFile: "vulnerability.txt",
+		},
+		{
+			name: "credential goes to credential.txt",
+			mem: &schema.Memory{
+				Type:        schema.MemoryCredential,
+				Title:       "FTP Admin Credentials",
+				Description: "user:password found in vsftpd banner",
+			},
+			wantFile: "credential.txt",
+		},
+		{
+			name: "artifact goes to artifact.txt",
+			mem: &schema.Memory{
+				Type:        schema.MemoryArtifact,
+				Title:       "etc/passwd",
+				Description: "Downloaded /etc/passwd via path traversal",
+			},
+			wantFile: "artifact.txt",
+		},
+		{
+			name: "note goes to finding.txt",
+			mem: &schema.Memory{
+				Type:        schema.MemoryNote,
+				Title:       "Initial assessment",
+				Description: "Target appears to be a web server",
+			},
+			wantFile: "finding.txt",
+		},
+	}
+
+	host := "10.0.0.5"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := s.Record(host, tt.mem)
+			if err != nil {
+				t.Fatalf("Record: %v", err)
+			}
+
+			path := filepath.Join(dir, host, tt.wantFile)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("Expected file %s to exist: %v", tt.wantFile, err)
+			}
+
+			content := string(data)
+			if !strings.Contains(content, tt.mem.Title) {
+				t.Errorf("File %s should contain title %q, got:\n%s", tt.wantFile, tt.mem.Title, content)
+			}
+			if !strings.Contains(content, tt.mem.Description) {
+				t.Errorf("File %s should contain description %q, got:\n%s", tt.wantFile, tt.mem.Description, content)
+			}
+		})
+	}
+}
+
+func TestStore_Record_VulnerabilityFormat(t *testing.T) {
 	dir := t.TempDir()
 	s := memory.NewStore(dir)
 
 	err := s.Record("10.0.0.5", &schema.Memory{
 		Type:        schema.MemoryVulnerability,
-		Title:       "CVE-2021-41773",
-		Description: "Apache 2.4.49 Path Traversal confirmed",
+		Title:       "CVE-2021-41773 Apache Path Traversal",
+		Description: "Apache 2.4.49 vulnerable to path traversal.",
 		Severity:    "critical",
 	})
 	if err != nil {
 		t.Fatalf("Record: %v", err)
 	}
 
-	path := filepath.Join(dir, "10.0.0.5.md")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("File not created: %v", err)
-	}
-
-	content := string(data)
-	if !strings.Contains(content, "CVE-2021-41773") {
-		t.Errorf("File should contain CVE title, got:\n%s", content)
-	}
-	if !strings.Contains(strings.ToLower(content), "critical") {
-		t.Errorf("File should contain severity, got:\n%s", content)
-	}
-}
-
-func TestStore_Record_Appends(t *testing.T) {
-	dir := t.TempDir()
-	s := memory.NewStore(dir)
-
-	_ = s.Record("10.0.0.5", &schema.Memory{
-		Type:  schema.MemoryVulnerability,
-		Title: "CVE-2021-41773",
-	})
-	_ = s.Record("10.0.0.5", &schema.Memory{
-		Type:  schema.MemoryCredential,
-		Title: "MySQL: root / empty password",
-	})
-
-	data, _ := os.ReadFile(filepath.Join(dir, "10.0.0.5.md"))
+	data, _ := os.ReadFile(filepath.Join(dir, "10.0.0.5", "vulnerability.txt"))
 	content := string(data)
 
-	if !strings.Contains(content, "CVE-2021-41773") {
-		t.Error("First entry missing")
+	// タイムスタンプ形式: [YYYY-MM-DD HH:MM:SS]
+	if !strings.Contains(content, "[CRITICAL]") {
+		t.Errorf("Expected [CRITICAL] severity tag, got:\n%s", content)
 	}
-	if !strings.Contains(content, "MySQL") {
-		t.Error("Second entry missing")
-	}
-}
-
-func TestStore_Record_DomainHost(t *testing.T) {
-	dir := t.TempDir()
-	s := memory.NewStore(dir)
-
-	err := s.Record("example.com", &schema.Memory{
-		Type:  schema.MemoryNote,
-		Title: "Domain target",
-	})
-	if err != nil {
-		t.Fatalf("Domain host record: %v", err)
-	}
-
-	// ファイル名の . はそのまま（ホスト名として有効）
-	_, err = os.ReadFile(filepath.Join(dir, "example.com.md"))
-	if err != nil {
-		t.Fatalf("File not found for domain host: %v", err)
+	if !strings.Contains(content, "CVE-2021-41773 Apache Path Traversal") {
+		t.Errorf("Expected title in entry, got:\n%s", content)
 	}
 }
 
-// --- Read テスト ---
-
-func TestStore_Read_RecordedContent(t *testing.T) {
-	dir := t.TempDir()
-	s := memory.NewStore(dir)
-
-	// 記録してから Read で読み返す
-	err := s.Record("192.168.1.1", &schema.Memory{
-		Type:        schema.MemoryVulnerability,
-		Title:       "Open SSH",
-		Description: "SSH port 22 is open with weak config",
-		Severity:    "high",
-	})
-	if err != nil {
-		t.Fatalf("Record: %v", err)
-	}
-
-	content := s.Read("192.168.1.1")
-	if content == "" {
-		t.Fatal("Read returned empty string after Record")
-	}
-	if !strings.Contains(content, "Open SSH") {
-		t.Errorf("Read content should contain title 'Open SSH', got:\n%s", content)
-	}
-	if !strings.Contains(content, "SSH port 22 is open with weak config") {
-		t.Errorf("Read content should contain description, got:\n%s", content)
-	}
-	if !strings.Contains(content, "Pentecter Memory: 192.168.1.1") {
-		t.Errorf("Read content should contain header, got:\n%s", content)
-	}
-}
-
-func TestStore_Read_NonexistentHost(t *testing.T) {
-	dir := t.TempDir()
-	s := memory.NewStore(dir)
-
-	content := s.Read("nonexistent-host")
-	if content != "" {
-		t.Errorf("Read on nonexistent host should return empty string, got: %q", content)
-	}
-}
-
-// --- formatEntry テスト（各 MemoryType） ---
-
-func TestStore_FormatEntry_Credential(t *testing.T) {
-	dir := t.TempDir()
-	s := memory.NewStore(dir)
-
-	err := s.Record("10.0.0.10", &schema.Memory{
-		Type:        schema.MemoryCredential,
-		Title:       "MySQL root",
-		Description: "root:password123",
-	})
-	if err != nil {
-		t.Fatalf("Record: %v", err)
-	}
-
-	content := s.Read("10.0.0.10")
-	if !strings.Contains(content, "Credential: MySQL root") {
-		t.Errorf("Expected 'Credential: MySQL root' in content, got:\n%s", content)
-	}
-	if !strings.Contains(content, "root:password123") {
-		t.Errorf("Expected credential details in content, got:\n%s", content)
-	}
-}
-
-func TestStore_FormatEntry_Artifact(t *testing.T) {
-	dir := t.TempDir()
-	s := memory.NewStore(dir)
-
-	err := s.Record("10.0.0.20", &schema.Memory{
-		Type:        schema.MemoryArtifact,
-		Title:       "etc/passwd",
-		Description: "Downloaded /etc/passwd via path traversal",
-	})
-	if err != nil {
-		t.Fatalf("Record: %v", err)
-	}
-
-	content := s.Read("10.0.0.20")
-	if !strings.Contains(content, "Artifact: etc/passwd") {
-		t.Errorf("Expected 'Artifact: etc/passwd' in content, got:\n%s", content)
-	}
-	if !strings.Contains(content, "Downloaded /etc/passwd via path traversal") {
-		t.Errorf("Expected artifact details in content, got:\n%s", content)
-	}
-}
-
-func TestStore_FormatEntry_Note(t *testing.T) {
-	dir := t.TempDir()
-	s := memory.NewStore(dir)
-
-	err := s.Record("10.0.0.30", &schema.Memory{
-		Type:        schema.MemoryNote,
-		Title:       "Initial assessment",
-		Description: "Target appears to be a web server",
-	})
-	if err != nil {
-		t.Fatalf("Record: %v", err)
-	}
-
-	content := s.Read("10.0.0.30")
-	if !strings.Contains(content, "Note: Initial assessment") {
-		t.Errorf("Expected 'Note: Initial assessment' in content, got:\n%s", content)
-	}
-	if !strings.Contains(content, "Target appears to be a web server") {
-		t.Errorf("Expected note content in content, got:\n%s", content)
-	}
-}
-
-func TestStore_FormatEntry_VulnerabilityDefaultSeverity(t *testing.T) {
+func TestStore_Record_VulnerabilityDefaultSeverity(t *testing.T) {
 	dir := t.TempDir()
 	s := memory.NewStore(dir)
 
@@ -207,9 +126,206 @@ func TestStore_FormatEntry_VulnerabilityDefaultSeverity(t *testing.T) {
 		t.Fatalf("Record: %v", err)
 	}
 
-	content := s.Read("10.0.0.40")
+	data, _ := os.ReadFile(filepath.Join(dir, "10.0.0.40", "vulnerability.txt"))
+	content := string(data)
 	if !strings.Contains(content, "[INFO]") {
 		t.Errorf("Expected '[INFO]' for empty severity, got:\n%s", content)
+	}
+}
+
+func TestStore_Record_CreatesHostDirectory(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	host := "192.168.1.100"
+	err := s.Record(host, &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "Test Vuln",
+		Description: "Test description",
+		Severity:    "high",
+	})
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	// ホストディレクトリが自動作成されることを確認
+	hostDir := filepath.Join(dir, host)
+	info, err := os.Stat(hostDir)
+	if err != nil {
+		t.Fatalf("Host directory should be created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("Expected %s to be a directory", hostDir)
+	}
+}
+
+func TestStore_Record_AppendsToSameFile(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	host := "10.0.0.5"
+	_ = s.Record(host, &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "CVE-2021-41773",
+		Description: "First vuln",
+		Severity:    "critical",
+	})
+	_ = s.Record(host, &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "CVE-2022-12345",
+		Description: "Second vuln",
+		Severity:    "high",
+	})
+
+	data, _ := os.ReadFile(filepath.Join(dir, host, "vulnerability.txt"))
+	content := string(data)
+
+	if !strings.Contains(content, "CVE-2021-41773") {
+		t.Error("First entry missing from vulnerability.txt")
+	}
+	if !strings.Contains(content, "CVE-2022-12345") {
+		t.Error("Second entry missing from vulnerability.txt")
+	}
+}
+
+// --- Read テスト ---
+
+func TestStore_Read_CombinesSections(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	host := "192.168.1.1"
+
+	// 各タイプのエントリを記録
+	_ = s.Record(host, &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "Open SSH",
+		Description: "SSH port 22 is open with weak config",
+		Severity:    "high",
+	})
+	_ = s.Record(host, &schema.Memory{
+		Type:        schema.MemoryCredential,
+		Title:       "MySQL root",
+		Description: "root:password123",
+	})
+	_ = s.Record(host, &schema.Memory{
+		Type:        schema.MemoryArtifact,
+		Title:       "etc/passwd",
+		Description: "Downloaded /etc/passwd",
+	})
+	_ = s.Record(host, &schema.Memory{
+		Type:        schema.MemoryNote,
+		Title:       "Initial scan",
+		Description: "Host appears to be Linux",
+	})
+
+	content := s.Read(host)
+	if content == "" {
+		t.Fatal("Read returned empty string after Record")
+	}
+
+	// セクションヘッダーが正しい順序で含まれること
+	if !strings.Contains(content, "## Vulnerabilities") {
+		t.Errorf("Expected '## Vulnerabilities' section header, got:\n%s", content)
+	}
+	if !strings.Contains(content, "## Credentials") {
+		t.Errorf("Expected '## Credentials' section header, got:\n%s", content)
+	}
+	if !strings.Contains(content, "## Artifacts") {
+		t.Errorf("Expected '## Artifacts' section header, got:\n%s", content)
+	}
+	if !strings.Contains(content, "## Findings") {
+		t.Errorf("Expected '## Findings' section header, got:\n%s", content)
+	}
+
+	// 各エントリの内容が含まれること
+	if !strings.Contains(content, "Open SSH") {
+		t.Errorf("Expected vulnerability title, got:\n%s", content)
+	}
+	if !strings.Contains(content, "MySQL root") {
+		t.Errorf("Expected credential title, got:\n%s", content)
+	}
+	if !strings.Contains(content, "etc/passwd") {
+		t.Errorf("Expected artifact title, got:\n%s", content)
+	}
+	if !strings.Contains(content, "Initial scan") {
+		t.Errorf("Expected finding title, got:\n%s", content)
+	}
+}
+
+func TestStore_Read_SkipsEmptyFiles(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	host := "10.0.0.99"
+
+	// vulnerability だけ記録
+	_ = s.Record(host, &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "Only Vuln",
+		Description: "The only entry",
+		Severity:    "low",
+	})
+
+	content := s.Read(host)
+
+	// Vulnerabilities セクションだけ含まれる
+	if !strings.Contains(content, "## Vulnerabilities") {
+		t.Errorf("Expected '## Vulnerabilities', got:\n%s", content)
+	}
+
+	// 他のセクションは含まれない（ファイルが存在しないため）
+	if strings.Contains(content, "## Credentials") {
+		t.Errorf("Should not contain '## Credentials' when no credential file exists, got:\n%s", content)
+	}
+	if strings.Contains(content, "## Artifacts") {
+		t.Errorf("Should not contain '## Artifacts' when no artifact file exists, got:\n%s", content)
+	}
+	if strings.Contains(content, "## Findings") {
+		t.Errorf("Should not contain '## Findings' when no finding file exists, got:\n%s", content)
+	}
+}
+
+func TestStore_Read_NonexistentHost(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	content := s.Read("nonexistent-host")
+	if content != "" {
+		t.Errorf("Read on nonexistent host should return empty string, got: %q", content)
+	}
+}
+
+func TestStore_Record_DomainHost(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	err := s.Record("example.com", &schema.Memory{
+		Type:        schema.MemoryNote,
+		Title:       "Domain target",
+		Description: "Testing domain host",
+	})
+	if err != nil {
+		t.Fatalf("Domain host record: %v", err)
+	}
+
+	// ドメインホスト名のディレクトリが作成されること
+	hostDir := filepath.Join(dir, "example.com")
+	info, err := os.Stat(hostDir)
+	if err != nil {
+		t.Fatalf("Host directory not found for domain host: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("Expected directory for domain host")
+	}
+
+	// finding.txt が存在すること
+	data, err := os.ReadFile(filepath.Join(hostDir, "finding.txt"))
+	if err != nil {
+		t.Fatalf("finding.txt not found: %v", err)
+	}
+	if !strings.Contains(string(data), "Domain target") {
+		t.Errorf("finding.txt should contain the title")
 	}
 }
 
@@ -221,8 +337,9 @@ func TestStore_SanitizeFilename_PathTraversal(t *testing.T) {
 
 	// パストラバーサル攻撃を含むホスト名
 	err := s.Record("../../etc/passwd", &schema.Memory{
-		Type:  schema.MemoryNote,
-		Title: "Traversal test",
+		Type:        schema.MemoryNote,
+		Title:       "Traversal test",
+		Description: "Should be sanitized",
 	})
 	if err != nil {
 		t.Fatalf("Record: %v", err)
@@ -234,16 +351,19 @@ func TestStore_SanitizeFilename_PathTraversal(t *testing.T) {
 		t.Fatalf("ReadDir: %v", err)
 	}
 	if len(entries) != 1 {
-		t.Fatalf("expected 1 file in dir, got %d", len(entries))
+		t.Fatalf("expected 1 directory in dir, got %d", len(entries))
 	}
 
-	// サニタイズされたファイル名であること
-	fname := entries[0].Name()
-	if strings.Contains(fname, "..") {
-		t.Errorf("filename should not contain '..': got %q", fname)
+	// サニタイズされたディレクトリ名であること
+	dname := entries[0].Name()
+	if strings.Contains(dname, "..") {
+		t.Errorf("directory name should not contain '..': got %q", dname)
 	}
-	if strings.Contains(fname, "/") || strings.Contains(fname, "\\") {
-		t.Errorf("filename should not contain path separators: got %q", fname)
+	if strings.Contains(dname, "/") || strings.Contains(dname, "\\") {
+		t.Errorf("directory name should not contain path separators: got %q", dname)
+	}
+	if !entries[0].IsDir() {
+		t.Errorf("expected a directory, got a file: %q", dname)
 	}
 }
 
@@ -252,8 +372,9 @@ func TestStore_SanitizeFilename_Backslashes(t *testing.T) {
 	s := memory.NewStore(dir)
 
 	err := s.Record(`host\with\backslashes`, &schema.Memory{
-		Type:  schema.MemoryNote,
-		Title: "Backslash test",
+		Type:        schema.MemoryNote,
+		Title:       "Backslash test",
+		Description: "Should be sanitized",
 	})
 	if err != nil {
 		t.Fatalf("Record: %v", err)
@@ -271,8 +392,9 @@ func TestStore_SanitizeFilename_EmptyHost(t *testing.T) {
 	s := memory.NewStore(dir)
 
 	err := s.Record("", &schema.Memory{
-		Type:  schema.MemoryNote,
-		Title: "Empty host test",
+		Type:        schema.MemoryNote,
+		Title:       "Empty host test",
+		Description: "Should go to unknown dir",
 	})
 	if err != nil {
 		t.Fatalf("Record: %v", err)
@@ -287,9 +409,36 @@ func TestStore_SanitizeFilename_EmptyHost(t *testing.T) {
 		t.Errorf("File should contain the recorded entry, got:\n%s", content)
 	}
 
-	// unknown.md が存在することを確認
-	_, err = os.ReadFile(filepath.Join(dir, "unknown.md"))
+	// unknown ディレクトリが存在することを確認
+	unknownDir := filepath.Join(dir, "unknown")
+	info, err := os.Stat(unknownDir)
 	if err != nil {
-		t.Fatalf("unknown.md should exist for empty host: %v", err)
+		t.Fatalf("unknown directory should exist for empty host: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("Expected unknown to be a directory")
+	}
+}
+
+func TestStore_Record_TimestampFormat(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	err := s.Record("10.0.0.1", &schema.Memory{
+		Type:        schema.MemoryCredential,
+		Title:       "FTP Admin Credentials",
+		Description: "user:password found in vsftpd banner",
+	})
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "10.0.0.1", "credential.txt"))
+	content := string(data)
+
+	// タイムスタンプが [YYYY-MM-DD HH:MM:SS] 形式であること
+	// 正確な時刻は検証できないので、パターンの存在を確認
+	if !strings.Contains(content, "[20") {
+		t.Errorf("Expected timestamp starting with [20, got:\n%s", content)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,6 +16,7 @@ import (
 	"github.com/0x6d61/pentecter/internal/agent"
 	"github.com/0x6d61/pentecter/internal/brain"
 	"github.com/0x6d61/pentecter/internal/tools"
+	"github.com/mattn/go-runewidth"
 )
 
 // FocusState tracks which pane has keyboard focus.
@@ -71,7 +72,7 @@ type Model struct {
 	// Runner is the CommandRunner used for /approve command (auto-approve toggle).
 	Runner *tools.CommandRunner
 
-	// multilineBuffer は Ctrl+Enter で蓄積された複数行入力。
+	// multilineBuffer は Alt+Enter（または Ctrl+Enter）で蓄積された複数行入力。
 	// Enter 送信時に現在の入力と結合して全テキストを送信する。
 	multilineBuffer []string
 
@@ -287,7 +288,7 @@ func (m *Model) rebuildViewport() {
 			msgMaxW = 20
 		}
 
-		if len(entry.Message) <= msgMaxW {
+		if runewidth.StringWidth(entry.Message) <= msgMaxW {
 			fmt.Fprintf(&sb, "%s %s  %s\n", styledTs, srcLabel, entry.Message)
 		} else {
 			wrapped := softWrap(entry.Message, msgMaxW)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -140,12 +140,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case FocusInput:
 			switch msg.String() {
-			case "ctrl+enter":
+			case "alt+enter", "ctrl+enter":
 				// Accumulate current line and clear input for next line
 				if text := m.input.Value(); text != "" {
 					m.multilineBuffer = append(m.multilineBuffer, text)
 					m.input.SetValue("")
-					m.input.Placeholder = fmt.Sprintf("[%d lines] Continue typing or Enter to send...", len(m.multilineBuffer))
+					m.input.Placeholder = fmt.Sprintf("[%d lines] Continue typing or Alt+Enter for more...", len(m.multilineBuffer))
 				}
 			case "esc":
 				if len(m.multilineBuffer) > 0 {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/0x6d61/pentecter/internal/agent"
+	"github.com/mattn/go-runewidth"
 )
 
 // ---------------------------------------------------------------------------
@@ -342,6 +343,76 @@ func TestSoftWrap_EmptyString(t *testing.T) {
 	result := softWrap("", 40)
 	if result != "" {
 		t.Errorf("empty string should return empty, got %q", result)
+	}
+}
+
+func TestSoftWrap_CJKText(t *testing.T) {
+	// Each CJK character takes 2 display columns
+	// "日本語テスト" = 6 chars × 2 columns = 12 columns
+	result := softWrap("日本語テスト データ", 10)
+	lines := strings.Split(result, "\n")
+	for _, line := range lines {
+		w := runewidth.StringWidth(line)
+		if w > 10 {
+			t.Errorf("CJK line exceeds maxWidth: %q (display width=%d)", line, w)
+		}
+	}
+	if len(lines) < 2 {
+		t.Errorf("expected CJK text to wrap, got single line: %q", result)
+	}
+}
+
+func TestSoftWrap_CJKSingleLongWord(t *testing.T) {
+	// CJK text without spaces should be force-broken at display width
+	result := softWrap("日本語テストデータ確認中", 8)
+	lines := strings.Split(result, "\n")
+	for _, line := range lines {
+		w := runewidth.StringWidth(line)
+		if w > 8 {
+			t.Errorf("CJK line exceeds maxWidth after force-break: %q (display width=%d)", line, w)
+		}
+	}
+	if len(lines) < 2 {
+		t.Errorf("expected CJK long word to be force-broken, got single line: %q", result)
+	}
+}
+
+func TestSoftWrap_MixedASCIICJK(t *testing.T) {
+	// Mixed ASCII and CJK text
+	result := softWrap("ポート80 open HTTP Apache httpd 2.4.49", 20)
+	lines := strings.Split(result, "\n")
+	for _, line := range lines {
+		w := runewidth.StringWidth(line)
+		if w > 20 {
+			t.Errorf("mixed line exceeds maxWidth: %q (display width=%d)", line, w)
+		}
+	}
+}
+
+func TestTruncateToWidth(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxWidth int
+		wantLen  int // expected display width of chunk
+	}{
+		{"hello", 3, 3},
+		{"日本語", 4, 4},        // 日本 (2+2=4)
+		{"日本語", 3, 2},        // 日 (2) — can't fit 本 (would be 4)
+		{"abc日本", 5, 5},       // abc日 (1+1+1+2=5)
+	}
+	for _, tt := range tests {
+		chunk, rest := truncateToWidth(tt.input, tt.maxWidth)
+		w := runewidth.StringWidth(chunk)
+		if w > tt.maxWidth {
+			t.Errorf("truncateToWidth(%q, %d): chunk %q has width %d > %d", tt.input, tt.maxWidth, chunk, w, tt.maxWidth)
+		}
+		if w != tt.wantLen {
+			t.Errorf("truncateToWidth(%q, %d): chunk %q has width %d, want %d", tt.input, tt.maxWidth, chunk, w, tt.wantLen)
+		}
+		// chunk + rest should reconstruct original
+		if chunk+rest != tt.input {
+			t.Errorf("truncateToWidth(%q, %d): chunk+rest = %q, want %q", tt.input, tt.maxWidth, chunk+rest, tt.input)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Memory リストラクチャ**: per-host ディレクトリ構造 (`memory/<host>/{vulnerability,credential,artifact,finding}.txt`) に変更し、Brain プロンプトに `## Previous Findings` セクションとして独立表示
- **Brain コンテキスト改善**: コマンド履歴に出力サマリー追加、Memory 記録の強制ルール追加、nmap 重複実行を防止
- **多言語対応**: ユーザーの入力言語に合わせて Brain が応答する LANGUAGE セクション + `hasNonASCII()` 言語検知
- **CJK 幅修正**: `softWrap()` と `rebuildViewport()` を `runewidth` ベースに修正し、日本語テキストでの UI 崩壊を解消
- **Alt+Enter 複数行入力**: Ctrl+Enter に加え Alt+Enter でも複数行入力をサポート

## Test plan
- [x] `go build ./...` ビルド通過
- [x] `go vet ./...` 静的解析通過
- [x] `go test ./internal/...` 全テストグリーン (brain, agent, memory, tui, skills, tools)
- [x] CJK テキスト折り返しテスト (`TestSoftWrap_CJKText`, `TestSoftWrap_CJKSingleLongWord`, `TestSoftWrap_MixedASCIICJK`)
- [x] `truncateToWidth` テスト（マルチバイト文字安全分割）
- [x] 言語検知テスト (`TestHasNonASCII`, `TestBuildPrompt_NonASCII_LanguageHint`)
- [x] Memory リストラクチャテスト（per-host ディレクトリ、Read/Record/Clear）
- [x] Alt+Enter 複数行入力テスト

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)