### PR TITLE
feat: Ctrl+C 終了確認ダイアログ

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -310,12 +310,7 @@ func (l *Loop) waitForUserMsg(ctx context.Context) string {
 // evaluateResult はコマンド実行結果を評価し、成功/失敗を判定する。
 // 3つのシグナルで判定: exit code, 出力パターン, コマンド繰り返し。
 func (l *Loop) evaluateResult() {
-	failed := false
-
-	// Signal A: exit code != 0 → 失敗
-	if l.lastExitCode != 0 {
-		failed = true
-	}
+	failed := l.lastExitCode != 0
 
 	// Signal B: 出力パターンマッチ
 	if isFailedOutput(l.lastToolOutput) {

--- a/internal/brain/prompt.go
+++ b/internal/brain/prompt.go
@@ -137,7 +137,7 @@ func buildPrompt(input Input) string {
 	}
 
 	if input.TurnCount > 0 {
-		sb.WriteString(fmt.Sprintf("\n## Turn\nThis is turn %d of the assessment.\n", input.TurnCount))
+		fmt.Fprintf(&sb, "\n## Turn\nThis is turn %d of the assessment.\n", input.TurnCount)
 		if input.TurnCount > 10 {
 			sb.WriteString("You have been running autonomously for many turns. Consider if you should propose actions for human review.\n")
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -32,8 +32,9 @@ const (
 type InputMode int
 
 const (
-	InputNormal InputMode = iota // normal text input
-	InputSelect                  // interactive selection UI
+	InputNormal     InputMode = iota // normal text input
+	InputSelect                      // interactive selection UI
+	InputConfirmQuit                 // quit confirmation dialog
 )
 
 // SelectOption represents a single option in the select UI.

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -57,6 +57,12 @@ var proposalBoxStyle = lipgloss.NewStyle().
 	BorderForeground(colorWarning).
 	Padding(0, 1)
 
+// Quit confirmation dialog (centered overlay)
+var confirmQuitBoxStyle = lipgloss.NewStyle().
+	Border(lipgloss.DoubleBorder()).
+	BorderForeground(colorDanger).
+	Padding(0, 2)
+
 // Log source label styles
 var (
 	sourceAIStyle   = lipgloss.NewStyle().Foreground(colorSecondary).Bold(true)

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -582,6 +582,41 @@ func TestTargetListItem_Title_UnknownStatus(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// renderConfirmQuit overlay
+// ---------------------------------------------------------------------------
+
+func TestView_ConfirmQuit_ShowsOverlay(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.inputMode = InputConfirmQuit
+
+	output := m.View()
+
+	if !strings.Contains(output, "Quit Pentecter?") {
+		t.Error("expected 'Quit Pentecter?' in confirm dialog overlay")
+	}
+	if !strings.Contains(output, "[Y]") {
+		t.Error("expected '[Y]' hint in confirm dialog")
+	}
+	if !strings.Contains(output, "[N]") {
+		t.Error("expected '[N]' hint in confirm dialog")
+	}
+}
+
+func TestRenderConfirmQuit_Content(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(80, 30)
+	m.ready = true
+
+	output := m.renderConfirmQuit()
+
+	if !strings.Contains(output, "Quit Pentecter?") {
+		t.Errorf("expected title in confirm dialog, got %q", output)
+	}
+}
+
 func TestTargetListItem_Description_AllStatuses(t *testing.T) {
 	statuses := []agent.Status{
 		agent.StatusIdle,


### PR DESCRIPTION
## Summary
- Ctrl+C で即終了せず、画面中央に確認モーダルを表示
- Y で終了、N/Esc でキャンセルして通常操作に復帰
- Select モード中でも Ctrl+C で確認ダイアログが表示される
- 既存の staticcheck 警告 2 件も修正

Closes #29

## Test plan
- [x] `go test ./internal/tui/...` — 全テスト PASS
- [x] `go test ./internal/...` — 全テスト PASS
- [x] `golangci-lint run` — 0 issues
- [x] `go build ./...` — ビルド成功
- [x] `go vet ./...` — 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)