### PR TITLE
feat: MCP (Model Context Protocol) 統合

### DIFF
--- a/config/mcp.yaml
+++ b/config/mcp.yaml
@@ -1,0 +1,18 @@
+# MCP Server Configuration
+# Each server is started as a subprocess using stdio transport.
+# Add servers here to extend pentecter's capabilities.
+#
+# Fields:
+#   name:              Server identifier (referenced by Brain)
+#   command:           Executable to start the server
+#   args:              Command line arguments
+#   env:               Environment variables (${VAR} expanded from host env)
+#   proposal_required: Whether Brain needs user approval to call tools (default: false)
+
+servers: []
+# Example:
+#  - name: playwright
+#    command: npx
+#    args: ["@playwright/mcp@latest"]
+#    env: {}
+#    proposal_required: false

--- a/docs/architecture_design/mcp-integration.md
+++ b/docs/architecture_design/mcp-integration.md
@@ -1,0 +1,238 @@
+# MCP（Model Context Protocol）統合設計
+
+## 概要
+
+pentecter に MCP クライアントを統合し、外部 MCP サーバー（@playwright/mcp 等）の機能を Brain から呼び出せるようにする。
+
+## 背景
+
+- Web アプリ操作（リンククリック、フォーム入力、ページ読み取り）ができない問題の解決
+- `design-philosophy.md` で既に `call_mcp` アクションの方向性を定義済み
+- MCP はツールスキーマを持つため Brain が引数を自律生成できる
+
+---
+
+## アーキテクチャ
+
+```
+cmd/pentecter/main.go
+  │
+  ├─ mcp.NewManager(configPath)     ← MCP サーバー管理
+  │    ├─ StartAll()               ← サーバープロセス起動
+  │    ├─ ListAllTools() → schemas ← Brain に注入するスキーマ一覧
+  │    └─ CallTool(server, tool, args) → result
+  │
+  ├─ brain.New(cfg)                ← ToolNames + MCP schemas を注入
+  │
+  └─ agent.NewTeam(cfg)            ← MCPManager を渡す
+       └─ Loop.Run()
+            └─ case ActionCallMCP  ← MCP ツール呼び出しディスパッチ
+```
+
+---
+
+## 新パッケージ: internal/mcp/
+
+| ファイル | 責務 |
+|---------|------|
+| types.go | MCP 関連の型定義（ToolSchema, CallResult, ServerConfig 等） |
+| config.go | YAML 設定の読み込み・バリデーション |
+| client.go | MCPClient — 1サーバーとの JSON-RPC 2.0 stdio 通信 |
+| manager.go | MCPManager — サーバーのライフサイクル管理 |
+
+---
+
+## MCP 通信方式
+
+### なぜ自前実装か
+
+mark3labs/mcp-go は便利だが依存が大きい。pentecter に必要な MCP 操作は3つだけ:
+
+1. `initialize` — ハンドシェイク
+2. `tools/list` — ツール一覧取得
+3. `tools/call` — ツール実行
+
+JSON-RPC 2.0 over stdio は約 150 行で実装でき、外部依存を増やさずに済む。
+
+### MCPClient インターフェース
+
+```go
+type MCPClient struct {
+    cmd    *exec.Cmd
+    stdin  io.WriteCloser
+    stdout *bufio.Reader
+    nextID int64
+}
+
+func NewStdioClient(command string, args []string, env []string) (*MCPClient, error)
+func (c *MCPClient) Initialize(ctx context.Context) error
+func (c *MCPClient) ListTools(ctx context.Context) ([]ToolSchema, error)
+func (c *MCPClient) CallTool(ctx context.Context, name string, args map[string]any) (*CallResult, error)
+func (c *MCPClient) Close() error
+```
+
+### JSON-RPC 2.0 プロトコル
+
+リクエスト:
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+```
+
+レスポンス:
+
+```json
+{"jsonrpc": "2.0", "id": 1, "result": {"tools": [...]}}
+```
+
+---
+
+## MCP サーバー設定
+
+### 設定ファイル: config/mcp.yaml
+
+```yaml
+servers:
+  - name: playwright
+    command: npx
+    args: ["@playwright/mcp@latest"]
+    env:
+      DISPLAY: ":0"
+    proposal_required: false
+
+  - name: shodan
+    command: python3
+    args: ["-m", "shodan_mcp"]
+    env:
+      SHODAN_API_KEY: "${SHODAN_API_KEY}"
+    proposal_required: true
+```
+
+### ServerConfig フィールド一覧
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| name | string | サーバー識別子（Brain が参照する名前） |
+| command | string | 実行コマンド（npx, python3 等） |
+| args | []string | コマンド引数 |
+| env | map[string]string | 環境変数（`${VAR}` は展開される） |
+| proposal_required | *bool | 承認要否（nil = false） |
+
+---
+
+## MCPManager
+
+```go
+type MCPManager struct {
+    clients map[string]*MCPClient
+    configs []ServerConfig
+}
+
+func NewManager(configPath string) (*MCPManager, error)
+func (m *MCPManager) StartAll(ctx context.Context) error
+func (m *MCPManager) ListAllTools() []ToolSchema
+func (m *MCPManager) CallTool(ctx context.Context, server, tool string, args map[string]any) (*CallResult, error)
+func (m *MCPManager) Close() error
+```
+
+---
+
+## schema.Action の拡張
+
+```go
+const ActionCallMCP ActionType = "call_mcp"
+
+type Action struct {
+    Thought   string         `json:"thought"`
+    Action    ActionType     `json:"action"`
+    Command   string         `json:"command,omitempty"`
+    Memory    *Memory        `json:"memory,omitempty"`
+    Target    string         `json:"target,omitempty"`
+    MCPServer string         `json:"mcp_server,omitempty"`
+    MCPTool   string         `json:"mcp_tool,omitempty"`
+    MCPArgs   map[string]any `json:"mcp_args,omitempty"`
+}
+```
+
+---
+
+## Brain プロンプトへの MCP スキーマ注入
+
+`buildSystemPrompt()` に MCP ツール情報セクションを追加する。
+MCP サーバーから取得したツールスキーマを整形して Brain のシステムプロンプトに埋め込む:
+
+```
+MCP TOOLS:
+Server: playwright
+  - browser_navigate(url: string): Navigate to URL
+  - browser_click(element: string, ref: string): Click an element
+  - browser_type(element: string, ref: string, text: string): Type text
+  - browser_snapshot(): Get page accessibility snapshot
+
+To use MCP tools, respond with:
+{
+  "thought": "...",
+  "action": "call_mcp",
+  "mcp_server": "playwright",
+  "mcp_tool": "browser_navigate",
+  "mcp_args": {"url": "http://target/login"}
+}
+```
+
+---
+
+## Agent Loop のディスパッチ
+
+```go
+case schema.ActionCallMCP:
+    l.callMCP(ctx, action)
+    l.evaluateResult()
+```
+
+`callMCP()` の処理フロー:
+
+1. `MCPManager.CallTool()` を呼び出し
+2. 結果を ToolResult 互換形式に変換
+3. TUI にログ出力（source: SourceTool）
+4. Brain への次回入力に結果を含める
+
+---
+
+## 承認ゲート
+
+MCP サーバー設定の `proposal_required` フィールドで制御する:
+
+- **false**: Brain が `call_mcp` で直接実行（ブラウザ操作等）
+- **true**: Brain が `propose` アクション + MCP 情報で提案 → ユーザー承認後に実行（API 課金あり等）
+
+---
+
+## main.go の起動フロー変更
+
+```go
+mcpMgr, err := mcp.NewManager("config/mcp.yaml")
+if err != nil { /* MCP なしで続行（警告ログ出力） */ }
+if mcpMgr != nil {
+    mcpMgr.StartAll(ctx)
+    defer mcpMgr.Close()
+    brainCfg.MCPTools = mcpMgr.ListAllTools()
+}
+teamCfg.MCPManager = mcpMgr
+```
+
+MCP 設定ファイルが存在しない場合やパースに失敗した場合は、MCP 機能なしで pentecter を起動する。
+これにより MCP は完全にオプショナルな拡張として機能する。
+
+---
+
+## 関連ファイル
+
+| ファイル | 関連 |
+|---------|------|
+| `docs/architecture_design/design-philosophy.md` | MCP との組み合わせセクション |
+| `docs/architecture_design/execution-model.md` | コマンド実行モデル |
+| `pkg/schema/action.go` | Action 型定義 |
+| `internal/brain/brain.go` | Brain インターフェース |
+| `internal/brain/prompt.go` | システムプロンプト構築 |
+| `internal/agent/loop.go` | Agent Loop ディスパッチ |
+| `cmd/pentecter/main.go` | 起動フロー |

--- a/internal/brain/anthropic.go
+++ b/internal/brain/anthropic.go
@@ -39,7 +39,7 @@ func (b *anthropicBrain) Think(ctx context.Context, input Input) (*schema.Action
 	body := map[string]any{
 		"model":      b.cfg.Model,
 		"max_tokens": 1024,
-		"system":     buildSystemPrompt(b.cfg.ToolNames),
+		"system":     buildSystemPrompt(b.cfg.ToolNames, b.cfg.MCPTools),
 		"messages": []map[string]string{
 			{"role": "user", "content": prompt},
 		},

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -37,6 +37,15 @@ const (
 	AuthNone AuthType = "none"
 )
 
+// MCPToolInfo は Brain のシステムプロンプトに注入する MCP ツール情報。
+// internal/mcp パッケージに依存しないよう、Brain パッケージ独自の型として定義。
+type MCPToolInfo struct {
+	Server      string
+	Name        string
+	Description string
+	InputSchema map[string]any
+}
+
 // Config は Brain の設定を保持する。
 type Config struct {
 	Provider  Provider
@@ -45,6 +54,8 @@ type Config struct {
 	Token     string
 	BaseURL   string   // テスト時にモックサーバーを指定するために使う（空なら公式エンドポイント）
 	ToolNames []string // Registry から読み込んだ登録済みツール名（システムプロンプトに注入）
+	// MCPTools は MCP サーバーから取得したツールスキーマ（システムプロンプトに注入）。
+	MCPTools []MCPToolInfo
 }
 
 // Input は Brain に渡す思考コンテキスト。

--- a/internal/brain/openai.go
+++ b/internal/brain/openai.go
@@ -38,7 +38,7 @@ func (b *openAIBrain) Think(ctx context.Context, input Input) (*schema.Action, e
 	body := map[string]any{
 		"model": b.cfg.Model,
 		"messages": []map[string]string{
-			{"role": "system", "content": buildSystemPrompt(b.cfg.ToolNames)},
+			{"role": "system", "content": buildSystemPrompt(b.cfg.ToolNames, b.cfg.MCPTools)},
 			{"role": "user", "content": prompt},
 		},
 		"max_tokens":  1024,

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1,0 +1,277 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// JSON-RPC 2.0 メッセージ型
+
+type jsonRPCRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// MCPClient は MCP サーバーとの JSON-RPC 2.0 over stdio 通信を管理する
+type MCPClient struct {
+	stdin   io.WriteCloser
+	stdout  io.ReadCloser
+	scanner *bufio.Scanner
+	cmd     *exec.Cmd // サブプロセスモード時のみ非 nil
+
+	mu     sync.Mutex // stdin/stdout 操作の排他制御
+	nextID atomic.Int64
+	closed atomic.Bool
+}
+
+// NewStdioClient は MCP サーバーをサブプロセスとして起動し、クライアントを返す。
+// env は "KEY=VALUE" 形式の環境変数リスト。
+func NewStdioClient(command string, args []string, env []string) (*MCPClient, error) {
+	cmd := exec.Command(command, args...) // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command -- command は管理者が設定した mcp.yaml から読み込まれる（ユーザー入力ではない）
+	if len(env) > 0 {
+		cmd.Env = env
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: failed to create stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("mcp: failed to create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("mcp: failed to start server %s: %w", command, err)
+	}
+
+	c := &MCPClient{
+		stdin:   stdin,
+		stdout:  stdout,
+		scanner: bufio.NewScanner(stdout),
+		cmd:     cmd,
+	}
+	return c, nil
+}
+
+// newClientFromPipes はテスト用に io.Pipe ベースのクライアントを作成する
+func newClientFromPipes(stdin io.WriteCloser, stdout io.ReadCloser) *MCPClient {
+	return &MCPClient{
+		stdin:   stdin,
+		stdout:  stdout,
+		scanner: bufio.NewScanner(stdout),
+	}
+}
+
+// Initialize は MCP プロトコルのハンドシェイクを行う。
+// initialize リクエスト → レスポンス受信 → notifications/initialized 通知の順に実行する。
+func (c *MCPClient) Initialize(ctx context.Context) error {
+	if c.closed.Load() {
+		return fmt.Errorf("mcp: client is closed")
+	}
+
+	// initialize リクエスト送信
+	result, err := c.sendRequest(ctx, "initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "pentecter",
+			"version": "0.1.0",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("mcp: initialize failed: %w", err)
+	}
+	_ = result // サーバーの capabilities は現時点では使わない
+
+	// notifications/initialized 通知を送信（id なし）
+	if err := c.sendNotification("notifications/initialized"); err != nil {
+		return fmt.Errorf("mcp: failed to send initialized notification: %w", err)
+	}
+
+	return nil
+}
+
+// ListTools は MCP サーバーからツール一覧を取得する
+func (c *MCPClient) ListTools(ctx context.Context) ([]ToolSchema, error) {
+	if c.closed.Load() {
+		return nil, fmt.Errorf("mcp: client is closed")
+	}
+
+	result, err := c.sendRequest(ctx, "tools/list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: tools/list failed: %w", err)
+	}
+
+	// レスポンスの tools フィールドをパース
+	var resp struct {
+		Tools []ToolSchema `json:"tools"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse tools/list response: %w", err)
+	}
+
+	return resp.Tools, nil
+}
+
+// CallTool は MCP サーバーのツールを呼び出す
+func (c *MCPClient) CallTool(ctx context.Context, name string, args map[string]any) (*CallResult, error) {
+	if c.closed.Load() {
+		return nil, fmt.Errorf("mcp: client is closed")
+	}
+
+	params := map[string]any{
+		"name": name,
+	}
+	if args != nil {
+		params["arguments"] = args
+	}
+
+	result, err := c.sendRequest(ctx, "tools/call", params)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: tools/call failed: %w", err)
+	}
+
+	var callResult CallResult
+	if err := json.Unmarshal(result, &callResult); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse tools/call response: %w", err)
+	}
+
+	return &callResult, nil
+}
+
+// Close はクライアントを閉じ、サブプロセスを終了させる
+func (c *MCPClient) Close() error {
+	if c.closed.Swap(true) {
+		return nil // 既に閉じている
+	}
+
+	// stdin を閉じてサーバーに EOF を通知
+	_ = c.stdin.Close()
+	_ = c.stdout.Close()
+
+	// サブプロセスがある場合は待機（タイムアウト付き）
+	if c.cmd != nil {
+		done := make(chan error, 1)
+		go func() {
+			done <- c.cmd.Wait()
+		}()
+
+		select {
+		case <-done:
+			// 正常終了
+		case <-time.After(5 * time.Second):
+			// タイムアウト — プロセスを強制終了
+			_ = c.cmd.Process.Kill()
+			<-done
+		}
+	}
+
+	return nil
+}
+
+// sendRequest は JSON-RPC リクエストを送信し、レスポンスを待つ
+func (c *MCPClient) sendRequest(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	id := c.nextID.Add(1)
+
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  params,
+	}
+
+	// リクエストを送信
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	data = append(data, '\n')
+
+	if _, err := c.stdin.Write(data); err != nil {
+		return nil, fmt.Errorf("failed to write request: %w", err)
+	}
+
+	// レスポンスを読み取る（コンテキストキャンセル対応）
+	type scanResult struct {
+		resp jsonRPCResponse
+		err  error
+	}
+	ch := make(chan scanResult, 1)
+	go func() {
+		if !c.scanner.Scan() {
+			err := c.scanner.Err()
+			if err == nil {
+				err = fmt.Errorf("unexpected EOF")
+			}
+			ch <- scanResult{err: err}
+			return
+		}
+		var resp jsonRPCResponse
+		if err := json.Unmarshal(c.scanner.Bytes(), &resp); err != nil {
+			ch <- scanResult{err: fmt.Errorf("failed to parse response: %w", err)}
+			return
+		}
+		ch <- scanResult{resp: resp}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case sr := <-ch:
+		if sr.err != nil {
+			return nil, sr.err
+		}
+		if sr.resp.Error != nil {
+			return nil, fmt.Errorf("JSON-RPC error %d: %s", sr.resp.Error.Code, sr.resp.Error.Message)
+		}
+		return sr.resp.Result, nil
+	}
+}
+
+// sendNotification は JSON-RPC 通知を送信する（id なし、レスポンス不要）
+func (c *MCPClient) sendNotification(method string) error {
+	// 通知は id フィールドを含まない
+	msg := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  method,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification: %w", err)
+	}
+	data = append(data, '\n')
+
+	if _, err := c.stdin.Write(data); err != nil {
+		return fmt.Errorf("failed to write notification: %w", err)
+	}
+
+	return nil
+}

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,0 +1,468 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockMCPServer はテスト用のモック MCP サーバーをシミュレートする。
+// クライアントの stdin に書き込まれた JSON-RPC リクエストを読み取り、
+// クライアントの stdout へ JSON-RPC レスポンスを返す。
+type mockMCPServer struct {
+	// clientStdinReader はクライアントが stdin に書き込んだデータを読み取る側
+	clientStdinReader io.ReadCloser
+	// clientStdoutWriter はクライアントの stdout へデータを書き込む側
+	clientStdoutWriter io.WriteCloser
+	scanner            *bufio.Scanner
+}
+
+// newMockMCPServer はパイプベースのモック MCP サーバーを作成し、
+// テスト用の MCPClient とともに返す。
+func newMockMCPServer(t *testing.T) (*mockMCPServer, *MCPClient) {
+	t.Helper()
+
+	// クライアント stdin: クライアントが書く → サーバーが読む
+	stdinReader, stdinWriter := io.Pipe()
+	// クライアント stdout: サーバーが書く → クライアントが読む
+	stdoutReader, stdoutWriter := io.Pipe()
+
+	mock := &mockMCPServer{
+		clientStdinReader:  stdinReader,
+		clientStdoutWriter: stdoutWriter,
+		scanner:            bufio.NewScanner(stdinReader),
+	}
+
+	client := newClientFromPipes(stdinWriter, stdoutReader)
+
+	return mock, client
+}
+
+// readRequest はクライアントから1行の JSON-RPC リクエストを読み取る
+func (m *mockMCPServer) readRequest(t *testing.T) jsonRPCRequest {
+	t.Helper()
+	if !m.scanner.Scan() {
+		t.Fatal("mock server: failed to read request from client stdin")
+	}
+	var req jsonRPCRequest
+	if err := json.Unmarshal(m.scanner.Bytes(), &req); err != nil {
+		t.Fatalf("mock server: failed to parse request: %v, raw: %s", err, m.scanner.Text())
+	}
+	return req
+}
+
+// readNotification はクライアントから通知（id なし）を読み取る
+func (m *mockMCPServer) readNotification(t *testing.T) map[string]any {
+	t.Helper()
+	if !m.scanner.Scan() {
+		t.Fatal("mock server: failed to read notification from client stdin")
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(m.scanner.Bytes(), &msg); err != nil {
+		t.Fatalf("mock server: failed to parse notification: %v", err)
+	}
+	return msg
+}
+
+// writeResponse はクライアントの stdout へ JSON-RPC レスポンスを書き込む
+func (m *mockMCPServer) writeResponse(t *testing.T, id int64, result any) {
+	t.Helper()
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("mock server: failed to marshal result: %v", err)
+	}
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  json.RawMessage(resultBytes),
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("mock server: failed to marshal response: %v", err)
+	}
+	data = append(data, '\n')
+	if _, err := m.clientStdoutWriter.Write(data); err != nil {
+		t.Fatalf("mock server: failed to write response: %v", err)
+	}
+}
+
+// writeErrorResponse はクライアントの stdout へ JSON-RPC エラーレスポンスを書き込む
+func (m *mockMCPServer) writeErrorResponse(t *testing.T, id int64, code int, message string) {
+	t.Helper()
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &jsonRPCError{
+			Code:    code,
+			Message: message,
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("mock server: failed to marshal error response: %v", err)
+	}
+	data = append(data, '\n')
+	if _, err := m.clientStdoutWriter.Write(data); err != nil {
+		t.Fatalf("mock server: failed to write error response: %v", err)
+	}
+}
+
+// close はモックサーバーのリソースを解放する
+func (m *mockMCPServer) close() {
+	m.clientStdinReader.Close()
+	m.clientStdoutWriter.Close()
+}
+
+func TestClient_Initialize(t *testing.T) {
+	mock, client := newMockMCPServer(t)
+	defer mock.close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Initialize を非同期で呼び出す
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.Initialize(ctx)
+	}()
+
+	// initialize リクエストを読み取る
+	req := mock.readRequest(t)
+	if req.Method != "initialize" {
+		t.Fatalf("expected method 'initialize', got '%s'", req.Method)
+	}
+	if req.JSONRPC != "2.0" {
+		t.Fatalf("expected jsonrpc '2.0', got '%s'", req.JSONRPC)
+	}
+
+	// params を検証
+	paramsBytes, _ := json.Marshal(req.Params)
+	var params map[string]any
+	json.Unmarshal(paramsBytes, &params)
+	if params["protocolVersion"] != "2024-11-05" {
+		t.Errorf("expected protocolVersion '2024-11-05', got '%v'", params["protocolVersion"])
+	}
+	clientInfo, ok := params["clientInfo"].(map[string]any)
+	if !ok {
+		t.Fatal("expected clientInfo in params")
+	}
+	if clientInfo["name"] != "pentecter" {
+		t.Errorf("expected clientInfo.name 'pentecter', got '%v'", clientInfo["name"])
+	}
+
+	// initialize レスポンスを返す
+	mock.writeResponse(t, req.ID, map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"serverInfo": map[string]any{
+			"name":    "test-server",
+			"version": "1.0.0",
+		},
+	})
+
+	// notifications/initialized を読み取る
+	notif := mock.readNotification(t)
+	if notif["method"] != "notifications/initialized" {
+		t.Fatalf("expected method 'notifications/initialized', got '%v'", notif["method"])
+	}
+	// 通知には id がないことを確認
+	if _, hasID := notif["id"]; hasID {
+		t.Error("notification should not have id field")
+	}
+
+	// Initialize が成功したことを確認
+	if err := <-errCh; err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+}
+
+func TestClient_ListTools(t *testing.T) {
+	mock, client := newMockMCPServer(t)
+	defer mock.close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	var tools []ToolSchema
+	go func() {
+		var err error
+		tools, err = client.ListTools(ctx)
+		errCh <- err
+	}()
+
+	// tools/list リクエストを読み取る
+	req := mock.readRequest(t)
+	if req.Method != "tools/list" {
+		t.Fatalf("expected method 'tools/list', got '%s'", req.Method)
+	}
+
+	// レスポンスを返す
+	mock.writeResponse(t, req.ID, map[string]any{
+		"tools": []map[string]any{
+			{
+				"name":        "browser_navigate",
+				"description": "Navigate to a URL",
+				"inputSchema": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"url": map[string]any{
+							"type":        "string",
+							"description": "URL to navigate to",
+						},
+					},
+					"required": []string{"url"},
+				},
+			},
+			{
+				"name":        "browser_click",
+				"description": "Click an element",
+				"inputSchema": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"selector": map[string]any{
+							"type": "string",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("ListTools returned error: %v", err)
+	}
+
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+	if tools[0].Name != "browser_navigate" {
+		t.Errorf("expected tool name 'browser_navigate', got '%s'", tools[0].Name)
+	}
+	if tools[0].Description != "Navigate to a URL" {
+		t.Errorf("unexpected description: '%s'", tools[0].Description)
+	}
+	if tools[1].Name != "browser_click" {
+		t.Errorf("expected tool name 'browser_click', got '%s'", tools[1].Name)
+	}
+}
+
+func TestClient_CallTool(t *testing.T) {
+	mock, client := newMockMCPServer(t)
+	defer mock.close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	var result *CallResult
+	go func() {
+		var err error
+		result, err = client.CallTool(ctx, "browser_navigate", map[string]any{
+			"url": "https://example.com",
+		})
+		errCh <- err
+	}()
+
+	// tools/call リクエストを読み取る
+	req := mock.readRequest(t)
+	if req.Method != "tools/call" {
+		t.Fatalf("expected method 'tools/call', got '%s'", req.Method)
+	}
+
+	// params を検証
+	paramsBytes, _ := json.Marshal(req.Params)
+	var params map[string]any
+	json.Unmarshal(paramsBytes, &params)
+	if params["name"] != "browser_navigate" {
+		t.Errorf("expected tool name 'browser_navigate', got '%v'", params["name"])
+	}
+	args, ok := params["arguments"].(map[string]any)
+	if !ok {
+		t.Fatal("expected arguments in params")
+	}
+	if args["url"] != "https://example.com" {
+		t.Errorf("expected url 'https://example.com', got '%v'", args["url"])
+	}
+
+	// レスポンスを返す
+	mock.writeResponse(t, req.ID, map[string]any{
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": "Navigated to https://example.com",
+			},
+		},
+		"isError": false,
+	})
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("CallTool returned error: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("expected 1 content block, got %d", len(result.Content))
+	}
+	if result.Content[0].Type != "text" {
+		t.Errorf("expected content type 'text', got '%s'", result.Content[0].Type)
+	}
+	if result.Content[0].Text != "Navigated to https://example.com" {
+		t.Errorf("unexpected text: '%s'", result.Content[0].Text)
+	}
+	if result.IsError {
+		t.Error("expected isError=false")
+	}
+}
+
+func TestClient_CallTool_Error(t *testing.T) {
+	mock, client := newMockMCPServer(t)
+	defer mock.close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.CallTool(ctx, "nonexistent_tool", nil)
+		errCh <- err
+	}()
+
+	req := mock.readRequest(t)
+	// JSON-RPC エラーレスポンスを返す
+	mock.writeErrorResponse(t, req.ID, -32601, "Method not found")
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error for JSON-RPC error response")
+	}
+	if !strings.Contains(err.Error(), "Method not found") {
+		t.Errorf("expected error to contain 'Method not found', got: %v", err)
+	}
+}
+
+func TestClient_CallTool_ToolError(t *testing.T) {
+	// ツール自体がエラーを返した場合（isError=true）
+	mock, client := newMockMCPServer(t)
+	defer mock.close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	var result *CallResult
+	go func() {
+		var err error
+		result, err = client.CallTool(ctx, "browser_navigate", map[string]any{
+			"url": "invalid://url",
+		})
+		errCh <- err
+	}()
+
+	req := mock.readRequest(t)
+	mock.writeResponse(t, req.ID, map[string]any{
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": "Invalid URL format",
+			},
+		},
+		"isError": true,
+	})
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("CallTool returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.IsError {
+		t.Error("expected isError=true")
+	}
+	if result.Content[0].Text != "Invalid URL format" {
+		t.Errorf("unexpected error text: '%s'", result.Content[0].Text)
+	}
+}
+
+func TestClient_Close(t *testing.T) {
+	mock, client := newMockMCPServer(t)
+	_ = mock // mock のクリーンアップはクライアント側で行う
+
+	err := client.Close()
+	if err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	// Close 後の呼び出しはエラーになるべき
+	ctx := context.Background()
+	_, err = client.ListTools(ctx)
+	if err == nil {
+		t.Error("expected error when calling ListTools after Close")
+	}
+}
+
+func TestClient_ContextCancellation(t *testing.T) {
+	mock, client := newMockMCPServer(t)
+	defer mock.close()
+	defer client.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.Initialize(ctx)
+	}()
+
+	// リクエストが送信されるのを待つ
+	_ = mock.readRequest(t)
+
+	// レスポンスを返す前にキャンセル
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error on context cancellation")
+	}
+}
+
+func TestClient_IncrementingIDs(t *testing.T) {
+	// 連続したリクエストで ID がインクリメントされることを確認
+	mock, client := newMockMCPServer(t)
+	defer mock.close()
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// 1つ目のリクエスト
+	go func() {
+		client.ListTools(ctx) //nolint:errcheck
+	}()
+	req1 := mock.readRequest(t)
+
+	// 2つ目のリクエスト（1つ目のレスポンスを返してから）
+	mock.writeResponse(t, req1.ID, map[string]any{"tools": []any{}})
+	// 少し待ってから次のリクエスト
+	time.Sleep(50 * time.Millisecond)
+
+	go func() {
+		client.ListTools(ctx) //nolint:errcheck
+	}()
+	req2 := mock.readRequest(t)
+	mock.writeResponse(t, req2.ID, map[string]any{"tools": []any{}})
+
+	if req2.ID <= req1.ID {
+		t.Errorf("expected incrementing IDs: first=%d, second=%d", req1.ID, req2.ID)
+	}
+}

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+// envVarPattern は ${VAR_NAME} 形式の環境変数参照にマッチする正規表現
+var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// LoadConfig は指定パスから MCP 設定ファイルを読み込む。
+// ファイルが存在しない場合は nil, nil を返す（graceful skip）。
+// env フィールドの値に含まれる ${VAR} はホスト環境変数から展開される。
+func LoadConfig(path string) (*MCPConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("mcp: failed to read config %s: %w", path, err)
+	}
+
+	var cfg MCPConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("mcp: failed to parse config %s: %w", path, err)
+	}
+
+	// 環境変数を展開
+	for i := range cfg.Servers {
+		expandEnvVars(cfg.Servers[i].Env)
+	}
+
+	return &cfg, nil
+}
+
+// expandEnvVars は map 内の値に含まれる ${VAR} をホスト環境変数で展開する
+func expandEnvVars(env map[string]string) {
+	for k, v := range env {
+		env[k] = envVarPattern.ReplaceAllStringFunc(v, func(match string) string {
+			// ${VAR_NAME} から VAR_NAME を抽出
+			varName := match[2 : len(match)-1]
+			return os.Getenv(varName)
+		})
+	}
+}

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_ValidYAML(t *testing.T) {
+	// 正常な YAML ファイルを読み込めること
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.yaml")
+	content := `servers:
+  - name: playwright
+    command: npx
+    args: ["@playwright/mcp@latest"]
+    env:
+      API_KEY: "test-key"
+    proposal_required: true
+  - name: filesystem
+    command: node
+    args: ["server.js", "/tmp"]
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadConfig returned nil config")
+	}
+	if len(cfg.Servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(cfg.Servers))
+	}
+
+	// 1つ目のサーバー確認
+	s := cfg.Servers[0]
+	if s.Name != "playwright" {
+		t.Errorf("expected name 'playwright', got '%s'", s.Name)
+	}
+	if s.Command != "npx" {
+		t.Errorf("expected command 'npx', got '%s'", s.Command)
+	}
+	if len(s.Args) != 1 || s.Args[0] != "@playwright/mcp@latest" {
+		t.Errorf("unexpected args: %v", s.Args)
+	}
+	if s.Env["API_KEY"] != "test-key" {
+		t.Errorf("expected env API_KEY='test-key', got '%s'", s.Env["API_KEY"])
+	}
+	if s.ProposalRequired == nil || !*s.ProposalRequired {
+		t.Error("expected proposal_required=true")
+	}
+
+	// 2つ目のサーバー確認
+	s2 := cfg.Servers[1]
+	if s2.Name != "filesystem" {
+		t.Errorf("expected name 'filesystem', got '%s'", s2.Name)
+	}
+	if s2.ProposalRequired != nil {
+		t.Errorf("expected proposal_required=nil, got %v", *s2.ProposalRequired)
+	}
+}
+
+func TestLoadConfig_EnvVarExpansion(t *testing.T) {
+	// ${VAR} が os.Getenv(VAR) に展開されること
+	t.Setenv("TEST_MCP_SECRET", "expanded-value")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.yaml")
+	content := `servers:
+  - name: test-server
+    command: echo
+    args: []
+    env:
+      SECRET: "${TEST_MCP_SECRET}"
+      PLAIN: "no-expansion"
+      MIXED: "prefix-${TEST_MCP_SECRET}-suffix"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	env := cfg.Servers[0].Env
+	if env["SECRET"] != "expanded-value" {
+		t.Errorf("expected 'expanded-value', got '%s'", env["SECRET"])
+	}
+	if env["PLAIN"] != "no-expansion" {
+		t.Errorf("expected 'no-expansion', got '%s'", env["PLAIN"])
+	}
+	if env["MIXED"] != "prefix-expanded-value-suffix" {
+		t.Errorf("expected 'prefix-expanded-value-suffix', got '%s'", env["MIXED"])
+	}
+}
+
+func TestLoadConfig_EnvVarExpansion_Undefined(t *testing.T) {
+	// 未定義の環境変数は空文字列に展開される
+	t.Setenv("TEST_MCP_UNDEFINED_CHECK", "") // 明示的にクリア
+	os.Unsetenv("TEST_MCP_UNDEFINED_CHECK")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.yaml")
+	content := `servers:
+  - name: test-server
+    command: echo
+    args: []
+    env:
+      MISSING: "${TEST_MCP_UNDEFINED_CHECK}"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if cfg.Servers[0].Env["MISSING"] != "" {
+		t.Errorf("expected empty string for undefined var, got '%s'", cfg.Servers[0].Env["MISSING"])
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	// 存在しないファイルの場合は nil, nil を返す（graceful skip）
+	cfg, err := LoadConfig("/nonexistent/path/mcp.yaml")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("expected nil config for missing file")
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	// 不正な YAML はエラーを返す
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.yaml")
+	content := `{{{invalid yaml`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoadConfig_EmptyServers(t *testing.T) {
+	// servers が空配列の場合も正常に読み込めること
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.yaml")
+	content := `servers: []
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if len(cfg.Servers) != 0 {
+		t.Fatalf("expected 0 servers, got %d", len(cfg.Servers))
+	}
+}

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -1,0 +1,162 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+)
+
+// MCPManager は複数の MCP サーバーを管理し、ツールの集約・ルーティングを行う
+type MCPManager struct {
+	clients map[string]*MCPClient   // サーバー名 → クライアント
+	configs []ServerConfig          // 設定されたサーバー一覧
+	tools   map[string][]ToolSchema // サーバー名 → ツール一覧
+}
+
+// NewManager は設定ファイルからマネージャーを作成する。
+// 設定ファイルが存在しない場合は nil, nil を返す（graceful skip）。
+func NewManager(configPath string) (*MCPManager, error) {
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: failed to load config: %w", err)
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+
+	return &MCPManager{
+		clients: make(map[string]*MCPClient),
+		configs: cfg.Servers,
+		tools:   make(map[string][]ToolSchema),
+	}, nil
+}
+
+// StartAll は全サーバーを起動し、Initialize と ListTools を実行する。
+// 個別のサーバー起動に失敗した場合はログに警告を出して続行する。
+func (m *MCPManager) StartAll(ctx context.Context) error {
+	for _, cfg := range m.configs {
+		// 環境変数を "KEY=VALUE" 形式に変換
+		var env []string
+		if len(cfg.Env) > 0 {
+			// ホスト環境を引き継ぎつつ追加する
+			env = os.Environ()
+			for k, v := range cfg.Env {
+				env = append(env, k+"="+v)
+			}
+		}
+
+		client, err := NewStdioClient(cfg.Command, cfg.Args, env)
+		if err != nil {
+			log.Printf("[mcp] WARNING: failed to start server %q: %v", cfg.Name, err)
+			continue
+		}
+		m.clients[cfg.Name] = client
+
+		// Initialize ハンドシェイク
+		if err := client.Initialize(ctx); err != nil {
+			log.Printf("[mcp] WARNING: failed to initialize server %q: %v", cfg.Name, err)
+			_ = client.Close()
+			delete(m.clients, cfg.Name)
+			continue
+		}
+
+		// ツール一覧を取得
+		tools, err := client.ListTools(ctx)
+		if err != nil {
+			log.Printf("[mcp] WARNING: failed to list tools from server %q: %v", cfg.Name, err)
+			_ = client.Close()
+			delete(m.clients, cfg.Name)
+			continue
+		}
+
+		// サーバー名を各ツールに設定
+		for i := range tools {
+			tools[i].Server = cfg.Name
+		}
+		m.tools[cfg.Name] = tools
+	}
+
+	return nil
+}
+
+// startAllWithClients は既に注入済みのクライアントに対して Initialize と ListTools を実行する。
+// テスト用のメソッド。
+func (m *MCPManager) startAllWithClients(ctx context.Context) error {
+	for _, cfg := range m.configs {
+		client, ok := m.clients[cfg.Name]
+		if !ok {
+			continue
+		}
+
+		// Initialize ハンドシェイク
+		if err := client.Initialize(ctx); err != nil {
+			log.Printf("[mcp] WARNING: failed to initialize server %q: %v", cfg.Name, err)
+			_ = client.Close()
+			delete(m.clients, cfg.Name)
+			continue
+		}
+
+		// ツール一覧を取得
+		tools, err := client.ListTools(ctx)
+		if err != nil {
+			log.Printf("[mcp] WARNING: failed to list tools from server %q: %v", cfg.Name, err)
+			_ = client.Close()
+			delete(m.clients, cfg.Name)
+			continue
+		}
+
+		// サーバー名を各ツールに設定
+		for i := range tools {
+			tools[i].Server = cfg.Name
+		}
+		m.tools[cfg.Name] = tools
+	}
+
+	return nil
+}
+
+// ListAllTools は全サーバーのツールを集約して返す
+func (m *MCPManager) ListAllTools() []ToolSchema {
+	var all []ToolSchema
+	for _, tools := range m.tools {
+		all = append(all, tools...)
+	}
+	return all
+}
+
+// CallTool は指定されたサーバーのツールを呼び出す
+func (m *MCPManager) CallTool(ctx context.Context, server, tool string, args map[string]any) (*CallResult, error) {
+	client, ok := m.clients[server]
+	if !ok {
+		return nil, fmt.Errorf("mcp: unknown server %q", server)
+	}
+	return client.CallTool(ctx, tool, args)
+}
+
+// IsProposalRequired は指定サーバーがユーザー承認を要求するかどうかを返す。
+// デフォルトは false。
+func (m *MCPManager) IsProposalRequired(server string) bool {
+	for _, cfg := range m.configs {
+		if cfg.Name == server {
+			if cfg.ProposalRequired != nil {
+				return *cfg.ProposalRequired
+			}
+			return false
+		}
+	}
+	return false
+}
+
+// Close は全 MCP サーバーのプロセスを終了させる
+func (m *MCPManager) Close() error {
+	var lastErr error
+	for name, client := range m.clients {
+		if err := client.Close(); err != nil {
+			log.Printf("[mcp] WARNING: failed to close server %q: %v", name, err)
+			lastErr = err
+		}
+		delete(m.clients, name)
+	}
+	return lastErr
+}

--- a/internal/mcp/manager_test.go
+++ b/internal/mcp/manager_test.go
@@ -1,0 +1,335 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// mockServerPair はテスト用のモックサーバーと対応するクライアントのペア
+type mockServerPair struct {
+	mock   *mockMCPServer
+	client *MCPClient
+}
+
+// newTestManager はテスト用の MCPManager をモッククライアント付きで作成する。
+// 各サーバー設定に対してモック MCP サーバーを起動し、マネージャーに注入する。
+func newTestManager(t *testing.T, configs []ServerConfig) (*MCPManager, []*mockServerPair) {
+	t.Helper()
+
+	pairs := make([]*mockServerPair, len(configs))
+	clients := make(map[string]*MCPClient, len(configs))
+
+	for i, cfg := range configs {
+		mock, client := newMockMCPServer(t)
+		pairs[i] = &mockServerPair{mock: mock, client: client}
+		clients[cfg.Name] = client
+	}
+
+	m := &MCPManager{
+		clients: clients,
+		configs: configs,
+		tools:   make(map[string][]ToolSchema),
+	}
+
+	return m, pairs
+}
+
+func TestManager_NewManager_NoConfigFile(t *testing.T) {
+	// 設定ファイルが存在しない場合は nil, nil を返す
+	m, err := NewManager("/nonexistent/path/mcp.yaml")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if m != nil {
+		t.Fatal("expected nil manager for missing config file")
+	}
+}
+
+func TestManager_NewManager_EmptyServers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.yaml")
+	if err := os.WriteFile(path, []byte("servers: []\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := NewManager(path)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if len(m.ListAllTools()) != 0 {
+		t.Error("expected no tools for empty servers config")
+	}
+}
+
+func TestManager_NewManager_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.yaml")
+	content := `servers:
+  - name: test-server
+    command: echo
+    args: ["hello"]
+    proposal_required: true
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := NewManager(path)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if len(m.configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(m.configs))
+	}
+	if m.configs[0].Name != "test-server" {
+		t.Errorf("expected server name 'test-server', got '%s'", m.configs[0].Name)
+	}
+}
+
+func TestManager_ListAllTools_Aggregation(t *testing.T) {
+	// 複数サーバーのツールが集約されること
+	configs := []ServerConfig{
+		{Name: "server-a", Command: "echo"},
+		{Name: "server-b", Command: "echo"},
+	}
+	mgr, pairs := newTestManager(t, configs)
+	defer func() {
+		for _, p := range pairs {
+			p.mock.close()
+			p.client.Close()
+		}
+	}()
+
+	// 手動でツールを登録（StartAll をスキップして直接テスト）
+	mgr.tools["server-a"] = []ToolSchema{
+		{Server: "server-a", Name: "tool_a1", Description: "Tool A1"},
+		{Server: "server-a", Name: "tool_a2", Description: "Tool A2"},
+	}
+	mgr.tools["server-b"] = []ToolSchema{
+		{Server: "server-b", Name: "tool_b1", Description: "Tool B1"},
+	}
+
+	tools := mgr.ListAllTools()
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+
+	// サーバー名が正しく設定されているか確認
+	names := map[string]bool{}
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	for _, expected := range []string{"tool_a1", "tool_a2", "tool_b1"} {
+		if !names[expected] {
+			t.Errorf("expected tool '%s' in aggregated list", expected)
+		}
+	}
+}
+
+func TestManager_CallTool_Routing(t *testing.T) {
+	// 正しいサーバーにルーティングされること
+	configs := []ServerConfig{
+		{Name: "server-a", Command: "echo"},
+	}
+	mgr, pairs := newTestManager(t, configs)
+	defer func() {
+		for _, p := range pairs {
+			p.mock.close()
+			p.client.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	var result *CallResult
+	go func() {
+		var err error
+		result, err = mgr.CallTool(ctx, "server-a", "my_tool", map[string]any{"key": "value"})
+		errCh <- err
+	}()
+
+	// モックサーバーでリクエストを処理
+	req := pairs[0].mock.readRequest(t)
+	if req.Method != "tools/call" {
+		t.Fatalf("expected method 'tools/call', got '%s'", req.Method)
+	}
+
+	// params を検証
+	paramsBytes, _ := json.Marshal(req.Params)
+	var params map[string]any
+	json.Unmarshal(paramsBytes, &params)
+	if params["name"] != "my_tool" {
+		t.Errorf("expected tool name 'my_tool', got '%v'", params["name"])
+	}
+
+	pairs[0].mock.writeResponse(t, req.ID, map[string]any{
+		"content": []map[string]any{
+			{"type": "text", "text": "result from server-a"},
+		},
+	})
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("CallTool returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Content[0].Text != "result from server-a" {
+		t.Errorf("unexpected result text: '%s'", result.Content[0].Text)
+	}
+}
+
+func TestManager_CallTool_UnknownServer(t *testing.T) {
+	// 存在しないサーバーへのルーティングはエラー
+	configs := []ServerConfig{
+		{Name: "server-a", Command: "echo"},
+	}
+	mgr, pairs := newTestManager(t, configs)
+	defer func() {
+		for _, p := range pairs {
+			p.mock.close()
+			p.client.Close()
+		}
+	}()
+
+	ctx := context.Background()
+	_, err := mgr.CallTool(ctx, "nonexistent-server", "tool", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown server")
+	}
+}
+
+func TestManager_IsProposalRequired(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	configs := []ServerConfig{
+		{Name: "safe-server", Command: "echo", ProposalRequired: &trueVal},
+		{Name: "fast-server", Command: "echo", ProposalRequired: &falseVal},
+		{Name: "default-server", Command: "echo"},
+	}
+	mgr, pairs := newTestManager(t, configs)
+	defer func() {
+		for _, p := range pairs {
+			p.mock.close()
+			p.client.Close()
+		}
+	}()
+
+	if !mgr.IsProposalRequired("safe-server") {
+		t.Error("expected proposal required for safe-server")
+	}
+	if mgr.IsProposalRequired("fast-server") {
+		t.Error("expected proposal not required for fast-server")
+	}
+	if mgr.IsProposalRequired("default-server") {
+		t.Error("expected proposal not required for default-server (default)")
+	}
+	if mgr.IsProposalRequired("unknown-server") {
+		t.Error("expected proposal not required for unknown server")
+	}
+}
+
+func TestManager_Close(t *testing.T) {
+	configs := []ServerConfig{
+		{Name: "server-a", Command: "echo"},
+		{Name: "server-b", Command: "echo"},
+	}
+	mgr, _ := newTestManager(t, configs)
+
+	// Close はエラーなく完了するべき
+	err := mgr.Close()
+	if err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	// Close 後の CallTool はエラー
+	ctx := context.Background()
+	_, err = mgr.CallTool(ctx, "server-a", "tool", nil)
+	if err == nil {
+		t.Error("expected error after Close")
+	}
+}
+
+func TestManager_StartAll_WithMock(t *testing.T) {
+	// StartAll がイニシャライズとツール一覧取得を行うことを確認
+	configs := []ServerConfig{
+		{Name: "mock-server", Command: "echo"},
+	}
+	mgr, pairs := newTestManager(t, configs)
+	defer func() {
+		for _, p := range pairs {
+			p.mock.close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.startAllWithClients(ctx)
+	}()
+
+	mock := pairs[0].mock
+
+	// 1. initialize リクエストを処理
+	req := mock.readRequest(t)
+	if req.Method != "initialize" {
+		t.Fatalf("expected method 'initialize', got '%s'", req.Method)
+	}
+	mock.writeResponse(t, req.ID, map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"serverInfo":      map[string]any{"name": "mock", "version": "1.0"},
+	})
+
+	// 2. notifications/initialized を読み取る
+	notif := mock.readNotification(t)
+	if notif["method"] != "notifications/initialized" {
+		t.Fatalf("expected notifications/initialized, got '%v'", notif["method"])
+	}
+
+	// 3. tools/list リクエストを処理
+	req = mock.readRequest(t)
+	if req.Method != "tools/list" {
+		t.Fatalf("expected method 'tools/list', got '%s'", req.Method)
+	}
+	mock.writeResponse(t, req.ID, map[string]any{
+		"tools": []map[string]any{
+			{
+				"name":        "mock_tool",
+				"description": "A mock tool",
+				"inputSchema": map[string]any{"type": "object"},
+			},
+		},
+	})
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("startAllWithClients returned error: %v", err)
+	}
+
+	// ツールが正しく登録されたか確認
+	tools := mgr.ListAllTools()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Name != "mock_tool" {
+		t.Errorf("expected tool name 'mock_tool', got '%s'", tools[0].Name)
+	}
+	if tools[0].Server != "mock-server" {
+		t.Errorf("expected server 'mock-server', got '%s'", tools[0].Server)
+	}
+}

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -1,0 +1,52 @@
+// Package mcp は MCP (Model Context Protocol) クライアントを提供する。
+// JSON-RPC 2.0 over stdio で MCP サーバーと通信し、
+// ツールの列挙・呼び出しを行う。
+package mcp
+
+// ToolSchema は MCP サーバーの tools/list レスポンスにおけるツール定義
+type ToolSchema struct {
+	// Server はこのツールが所属する MCP サーバー名
+	Server string `json:"-"`
+	// Name はツールの一意な名前
+	Name string `json:"name"`
+	// Description はツールの説明
+	Description string `json:"description"`
+	// InputSchema はツール引数の JSON Schema
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+// CallResult は MCP tools/call の実行結果
+type CallResult struct {
+	// Content はレスポンスのコンテンツブロック群
+	Content []ContentBlock `json:"content"`
+	// IsError はツール実行がエラーだったかどうか
+	IsError bool `json:"isError,omitempty"`
+}
+
+// ContentBlock は MCP レスポンス内の単一コンテンツブロック
+type ContentBlock struct {
+	// Type はコンテンツの種類（"text", "image", "resource"）
+	Type string `json:"type"`
+	// Text はテキストコンテンツ（Type が "text" の場合）
+	Text string `json:"text,omitempty"`
+}
+
+// ServerConfig は YAML 設定ファイルにおける MCP サーバー定義
+type ServerConfig struct {
+	// Name はサーバーの識別名
+	Name string `yaml:"name"`
+	// Command は起動するコマンド
+	Command string `yaml:"command"`
+	// Args はコマンドライン引数
+	Args []string `yaml:"args"`
+	// Env はサーバーに渡す環境変数（${VAR} はホスト環境から展開される）
+	Env map[string]string `yaml:"env,omitempty"`
+	// ProposalRequired が true の場合、Brain はツール呼び出し前にユーザー承認を求める
+	ProposalRequired *bool `yaml:"proposal_required,omitempty"`
+}
+
+// MCPConfig は MCP 設定ファイルのトップレベル構造体
+type MCPConfig struct {
+	// Servers は設定された MCP サーバーの一覧
+	Servers []ServerConfig `yaml:"servers"`
+}

--- a/pkg/schema/action.go
+++ b/pkg/schema/action.go
@@ -25,6 +25,10 @@ const (
 	// ActionAddTarget は横展開時に新ターゲットを追加する。
 	// Brain がネットワーク内の別ホストを発見した際に使用する。
 	ActionAddTarget ActionType = "add_target"
+
+	// ActionCallMCP は MCP サーバーのツールを呼び出す。
+	// Brain が MCP ツール（Playwright ブラウザ操作等）を使用する際に使用する。
+	ActionCallMCP ActionType = "call_mcp"
 )
 
 // Action is the JSON payload emitted by the Brain (LLM).
@@ -42,6 +46,13 @@ type Action struct {
 	Command string     `json:"command,omitempty"` // ActionRun / ActionPropose
 	Memory  *Memory    `json:"memory,omitempty"`  // ActionMemory
 	Target  string     `json:"target,omitempty"`  // ActionAddTarget: 追加するホスト
+
+	// MCPServer は呼び出す MCP サーバーの名前（ActionCallMCP 時に使用）。
+	MCPServer string         `json:"mcp_server,omitempty"`
+	// MCPTool は呼び出す MCP ツールの名前（ActionCallMCP 時に使用）。
+	MCPTool   string         `json:"mcp_tool,omitempty"`
+	// MCPArgs は MCP ツールに渡す引数（ActionCallMCP 時に使用）。
+	MCPArgs   map[string]any `json:"mcp_args,omitempty"`
 }
 
 // Memory は Brain がナレッジグラフに記録する発見物。


### PR DESCRIPTION
## Summary
- Brain が MCP サーバーのツールを `call_mcp` アクションで呼び出せるようにする
- JSON-RPC 2.0 over stdio による MCP 通信を自前実装（外部依存なし）
- `@playwright/mcp` 等のブラウザ自動操作ツールを統合可能に

## Changes

### 新規パッケージ: `internal/mcp/`
- `types.go` — ToolSchema, CallResult, ServerConfig 等の型定義
- `config.go` — YAML 設定読み込み + `${ENV}` 環境変数展開
- `client.go` — MCPClient (JSON-RPC 2.0 stdio, sync.Mutex でスレッドセーフ)
- `manager.go` — MCPManager (複数サーバーのライフサイクル管理)

### 既存ファイルの変更
- `pkg/schema/action.go` — `ActionCallMCP` + MCPServer/MCPTool/MCPArgs フィールド
- `internal/brain/` — MCPTools スキーマのシステムプロンプト注入
- `internal/agent/loop.go` — `callMCP()` ディスパッチ + 承認ゲート
- `internal/agent/team.go` — MCPManager 配線
- `cmd/pentecter/main.go` — MCP 初期化フロー（config/mcp.yaml から読み込み）

### ドキュメント
- `docs/architecture_design/mcp-integration.md` — 設計ドキュメント
- `config/mcp.yaml` — デフォルト設定ファイル（コメント付き例）

## Test plan
- [x] `go test ./internal/mcp/...` — 24テスト PASS
- [x] `go test ./internal/brain/...` — MCP プロンプト注入テスト含む PASS
- [x] `go test ./internal/agent/...` — CallMCP_NoManager テスト含む PASS
- [x] `go build ./...` — ビルド成功
- [x] `golangci-lint run` — 0 issues

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)