### PR TITLE
feat: SubAgent architecture — parallel task execution

### DIFF
--- a/docs/architecture_design/subagent-architecture.md
+++ b/docs/architecture_design/subagent-architecture.md
@@ -1,0 +1,687 @@
+# SubAgent アーキテクチャ設計
+
+## 概要
+
+pentecter の Brain（メインエージェント）が、独立したサブタスクを並列に生成・管理する仕組みの設計。
+現在の逐次実行モデル（1コマンドずつ実行 → 結果待ち → 次コマンド）を拡張し、
+複数の偵察・攻撃タスクを同時に進行させることで、ペネトレーションテストの効率を大幅に向上させる。
+
+---
+
+## 背景と課題
+
+### 現状のモデル（逐次ブロッキング）
+
+```
+Brain → run(nmap -sV 10.0.0.5) → 待機 → 結果 → Brain → run(nikto ...) → 待機 → 結果 → ...
+```
+
+**問題点:**
+- nmap のフルスキャン（数分〜数十分）中、Brain は何もできない
+- 独立した偵察タスク（ポートスキャン、DNS偵察、Web脆弱性スキャン）を同時実行できない
+- ターゲット内の複数サービスに対する攻撃が直列になり、全体の所要時間が長い
+- Brain のコンテキストが単一タスクの詳細で圧迫される
+
+### 目標のモデル（並列実行）
+
+```
+Brain → spawn_task("port_scan", "nmap -sV -p- 10.0.0.5")
+      → spawn_task("web_recon", "nikto -h http://10.0.0.5/")
+      → spawn_task("dns_recon", "dig @10.0.0.5 AXFR example.com")
+      → ... 他の思考を継続 ...
+      → check_task("port_scan") → 完了済み → 結果を取得
+      → check_task("web_recon") → まだ実行中
+      → wait(["port_scan", "web_recon"]) → 両方完了を待機
+```
+
+---
+
+## アーキテクチャ概要
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Agent Loop (メインスレッド)                              │
+│                                                         │
+│  Brain.Think() → Action{spawn_task} ─┐                  │
+│                                      │                  │
+│  ┌───────────────────────────────────▼────────────────┐ │
+│  │           TaskManager                              │ │
+│  │                                                    │ │
+│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐           │ │
+│  │  │TaskRunner│ │TaskRunner│ │TaskRunner│  ...       │ │
+│  │  │ goroutine│ │ goroutine│ │ goroutine│           │ │
+│  │  └────┬─────┘ └────┬─────┘ └────┬─────┘           │ │
+│  │       │             │             │                │ │
+│  │       ▼             ▼             ▼                │ │
+│  │  ┌─────────┐  ┌─────────┐  ┌─────────┐           │ │
+│  │  │SubTask  │  │SubTask  │  │SubTask  │           │ │
+│  │  │ result  │  │ result  │  │ result  │           │ │
+│  │  │ channel │  │ channel │  │ channel │           │ │
+│  │  └─────────┘  └─────────┘  └─────────┘           │ │
+│  │                                                    │ │
+│  │  TaskTree (親子関係の追跡)                           │ │
+│  └────────────────────────────────────────────────────┘ │
+│                                                         │
+│  Brain.Think() ← check_task / wait → 結果取得           │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+         │                    │
+         ▼                    ▼
+   ┌──────────┐        ┌──────────┐
+   │ TUI      │        │ ToolExec │
+   │ (イベント │        │ (コマンド │
+   │  表示)    │        │  実行)    │
+   └──────────┘        └──────────┘
+```
+
+---
+
+## 新しい Action タイプ
+
+### spawn_task — サブタスクの生成
+
+Brain がサブタスクを生成する。タスクは独立した goroutine で非同期実行される。
+
+```json
+{
+  "thought": "nmap フルスキャンは時間がかかるので、並行して nikto も実行する",
+  "action": "spawn_task",
+  "task_id": "port_scan",
+  "task_description": "Full port scan on target",
+  "command": "nmap -sV -p- 10.0.0.5"
+}
+```
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| task_id | string | タスクの一意識別子（Brain が命名） |
+| task_description | string | タスクの目的（ログ・デバッグ用） |
+| command | string | 実行するコマンド |
+
+**制約:**
+- 同一 `task_id` のタスクが実行中の場合はエラーを返す
+- 承認ゲートは通常の `run` アクションと同じルールに従う（Docker / ホスト実行の判定）
+- 同時実行タスク数に上限を設ける（デフォルト: 8）
+
+### wait — タスク完了の待機
+
+指定したタスクの完了を待機する。タイムアウトを指定可能。
+
+```json
+{
+  "thought": "ポートスキャンと Web 偵察の結果を待つ",
+  "action": "wait",
+  "task_ids": ["port_scan", "web_recon"],
+  "timeout_seconds": 300
+}
+```
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| task_ids | []string | 待機対象のタスク ID リスト |
+| timeout_seconds | int | タイムアウト秒数（省略時: 600） |
+
+**動作:**
+- 指定したすべてのタスクが完了するまでブロック
+- タイムアウトした場合、完了済みのタスク結果 + 未完了タスクのステータスを返す
+- 待機中も TUI にはリアルタイムでタスク進捗が表示される
+
+### check_task — タスク状態の確認
+
+タスクの状態をノンブロッキングで確認する。完了していれば結果も取得する。
+
+```json
+{
+  "thought": "ポートスキャンが終わったか確認する",
+  "action": "check_task",
+  "task_id": "port_scan"
+}
+```
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| task_id | string | 確認対象のタスク ID |
+
+**レスポンス形式（Brain への入力として返す）:**
+
+実行中の場合:
+```
+Task "port_scan" is still running (elapsed: 45s)
+```
+
+完了の場合:
+```
+Task "port_scan" completed (exit code: 0, 128 lines)
+--- Output ---
+{truncated output}
+```
+
+失敗の場合:
+```
+Task "port_scan" failed (exit code: 1)
+Error: Connection refused
+```
+
+### kill_task — タスクの強制終了
+
+実行中のタスクをキャンセルする。
+
+```json
+{
+  "thought": "nmap が長すぎるのでキャンセルして別のアプローチを試す",
+  "action": "kill_task",
+  "task_id": "port_scan"
+}
+```
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| task_id | string | 終了対象のタスク ID |
+
+**動作:**
+- タスクの context をキャンセルし、プロセスに SIGTERM を送信
+- 5秒以内に終了しない場合は SIGKILL
+- キャンセル時点までの出力は保持される
+
+---
+
+## コンポーネント詳細
+
+### SubTask
+
+サブタスクの状態を表現する構造体。
+
+```go
+type SubTaskStatus string
+
+const (
+    SubTaskPending  SubTaskStatus = "pending"
+    SubTaskRunning  SubTaskStatus = "running"
+    SubTaskDone     SubTaskStatus = "done"
+    SubTaskFailed   SubTaskStatus = "failed"
+    SubTaskKilled   SubTaskStatus = "killed"
+)
+
+type SubTask struct {
+    ID          string
+    Description string
+    Command     string
+    Status      SubTaskStatus
+    ExitCode    int
+    Output      string         // 切り捨て済み出力
+    RawOutput   string         // 全出力（Log Store 用）
+    StartedAt   time.Time
+    FinishedAt  time.Time
+    ParentID    string         // 親タスク ID（ネスト時）
+    Error       error          // 実行エラー
+}
+```
+
+### TaskRunner
+
+1 つのサブタスクを goroutine 内で実行するワーカー。
+
+```go
+type TaskRunner struct {
+    task     *SubTask
+    ctx      context.Context
+    cancel   context.CancelFunc
+    done     chan struct{}
+    executor ToolExecutor     // コマンド実行インターフェース
+}
+
+func NewTaskRunner(task *SubTask, executor ToolExecutor) *TaskRunner
+func (r *TaskRunner) Run(ctx context.Context)   // goroutine で実行
+func (r *TaskRunner) Wait() <-chan struct{}      // 完了チャネル
+func (r *TaskRunner) Kill()                      // 強制終了
+```
+
+**実行フロー:**
+
+1. `task.Status` を `SubTaskRunning` に変更
+2. `executor.Execute()` でコマンドを実行
+3. 完了時に `task.Status` を `SubTaskDone` / `SubTaskFailed` に変更
+4. `done` チャネルをクローズして完了を通知
+5. context がキャンセルされた場合は `SubTaskKilled` に変更
+
+### SmartSubAgent
+
+SubAgent に独自の Brain（LLM）を持たせ、単一コマンド実行ではなく
+複数ステップの自律タスクを実行できるようにする拡張コンポーネント。
+
+```go
+type SmartSubAgent struct {
+    TaskRunner                    // 埋め込み
+    brain      brain.Brain        // サブエージェント用 Brain
+    maxTurns   int                // 最大ターン数（デフォルト: 10）
+    model      string             // 使用モデル（SUBAGENT_MODEL）
+    provider   string             // 使用プロバイダ（SUBAGENT_PROVIDER）
+}
+
+func NewSmartSubAgent(task *SubTask, brainCfg brain.Config) *SmartSubAgent
+func (s *SmartSubAgent) Run(ctx context.Context)
+```
+
+**SmartSubAgent のループ:**
+
+```
+SmartSubAgent.Run():
+  for turn := 0; turn < maxTurns; turn++ {
+      action := brain.Think(taskContext)
+      switch action.Action {
+      case "run":
+          result := executor.Execute(action.Command)
+          taskContext.Update(result)
+      case "complete":
+          task.Output = action.Summary
+          return
+      case "fail":
+          task.Error = errors.New(action.Reason)
+          return
+      }
+  }
+  // maxTurns 到達 → 自動完了
+```
+
+**使用例:**
+
+```json
+{
+  "thought": "Web アプリの認証バイパスを網羅的に調査するサブエージェントを起動",
+  "action": "spawn_task",
+  "task_id": "auth_bypass",
+  "task_description": "Web authentication bypass testing",
+  "smart": true,
+  "task_prompt": "Perform authentication bypass testing on http://10.0.0.5/login."
+}
+```
+
+`smart: true` が指定された場合、TaskManager は TaskRunner の代わりに SmartSubAgent を生成する。
+
+### TaskManager
+
+全サブタスクのライフサイクルを管理するオーケストレータ。
+
+```go
+type TaskManager struct {
+    mu       sync.RWMutex
+    tasks    map[string]*TaskRunner       // task_id → runner
+    tree     *TaskTree                    // 親子関係
+    maxTasks int                          // 同時実行上限
+    events   chan<- agent.Event           // TUI へのイベント送信
+    executor ToolExecutor                 // コマンド実行
+}
+
+func NewTaskManager(maxTasks int, events chan<- agent.Event, executor ToolExecutor) *TaskManager
+func (m *TaskManager) Spawn(task *SubTask) error
+func (m *TaskManager) Check(taskID string) *SubTask
+func (m *TaskManager) Wait(ctx context.Context, taskIDs []string, timeout time.Duration) map[string]*SubTask
+func (m *TaskManager) Kill(taskID string) error
+func (m *TaskManager) ListActive() []*SubTask
+func (m *TaskManager) Cleanup()                     // 完了済みタスクの掃除
+```
+
+### TaskTree
+
+サブタスクの親子関係を追跡する。SmartSubAgent が子タスクをスポーンした場合に使用。
+
+```go
+type TaskTree struct {
+    mu       sync.RWMutex
+    children map[string][]string    // parent_id → []child_id
+    parent   map[string]string      // child_id → parent_id
+}
+
+func (t *TaskTree) AddChild(parentID, childID string)
+func (t *TaskTree) GetChildren(parentID string) []string
+func (t *TaskTree) GetParent(childID string) string
+func (t *TaskTree) RemoveTask(taskID string)
+```
+
+**ツリー構造の例:**
+
+```
+root (メインエージェント)
+  ├── port_scan (TaskRunner — 単純コマンド実行)
+  ├── web_recon (SmartSubAgent — 自律ループ)
+  │     ├── web_recon/nikto (子タスク)
+  │     └── web_recon/dirb (子タスク)
+  └── dns_recon (TaskRunner — 単純コマンド実行)
+```
+
+---
+
+## 並行処理モデル
+
+### goroutine 設計
+
+各 TaskRunner / SmartSubAgent は独立した goroutine で動作する。
+メインの Agent Loop スレッドとは channel で通信する。
+
+```
+Agent Loop goroutine
+  │
+  ├── TaskRunner goroutine (port_scan)
+  │     └── os/exec プロセス
+  │
+  ├── SmartSubAgent goroutine (web_recon)
+  │     ├── Brain.Think() (HTTP 呼び出し)
+  │     └── os/exec プロセス
+  │
+  └── TaskRunner goroutine (dns_recon)
+        └── os/exec プロセス
+```
+
+### channel ベースの完了通知
+
+```go
+// TaskRunner.Run() 内
+func (r *TaskRunner) Run(ctx context.Context) {
+    defer close(r.done)
+
+    r.task.Status = SubTaskRunning
+    r.task.StartedAt = time.Now()
+    r.emitEvent(EventSubTaskStarted)
+
+    result, err := r.executor.Execute(ctx, r.task.Command)
+
+    r.task.FinishedAt = time.Now()
+    if err != nil {
+        r.task.Status = SubTaskFailed
+        r.task.Error = err
+    } else {
+        r.task.Status = SubTaskDone
+        r.task.ExitCode = result.ExitCode
+        r.task.Output = truncateOutput(result.Output)
+        r.task.RawOutput = result.Output
+    }
+    r.emitEvent(EventSubTaskCompleted)
+}
+```
+
+### Pull ベースの出力取得
+
+サブタスクの出力はメインの Agent Loop が明示的にリクエスト（`check_task` / `wait`）したときのみ Brain に渡す。
+Push 方式（完了時に即座に Brain のコンテキストに注入）ではない。
+
+**理由:**
+- Brain のコンテキストウィンドウを節約する
+- Brain が「いつ結果を確認するか」を自律的に判断できる
+- 複数タスクが同時に完了しても、Brain は1つずつ順序立てて処理できる
+
+**例外:** `wait` アクションでは、指定した全タスクの結果をまとめて返す。
+
+---
+
+## イベントフロー（SubTask ライフサイクル）
+
+### 新規イベントタイプ
+
+```go
+const (
+    EventSubTaskSpawned   EventType = "subtask_spawned"
+    EventSubTaskStarted   EventType = "subtask_started"
+    EventSubTaskOutput    EventType = "subtask_output"
+    EventSubTaskCompleted EventType = "subtask_completed"
+    EventSubTaskKilled    EventType = "subtask_killed"
+    EventSubTaskError     EventType = "subtask_error"
+)
+```
+
+### イベントシーケンス
+
+```
+Brain: spawn_task("port_scan", "nmap -sV -p- 10.0.0.5")
+  │
+  ├── EventSubTaskSpawned   → TUI: "Spawned task: port_scan (nmap -sV -p- 10.0.0.5)"
+  ├── EventSubTaskStarted   → TUI: "Task port_scan started"
+  │
+  │   (... 数分後 ...)
+  │
+  ├── EventSubTaskOutput    → TUI: ストリーミング出力（オプション）
+  ├── EventSubTaskCompleted → TUI: "Task port_scan completed (exit 0, 128 lines)"
+  │
+  └── Brain: check_task("port_scan")
+        └── 結果を Brain の次ターン入力に含める
+```
+
+### TUI 表示
+
+TUI のログパネルにサブタスク関連のイベントが表示される。
+タスク ID がプレフィックスとして付与され、どのタスクのログかが識別可能。
+
+```
+[14:23:01] [SUBTASK] Spawned: port_scan — nmap -sV -p- 10.0.0.5
+[14:23:01] [SUBTASK] Spawned: web_recon — nikto -h http://10.0.0.5/
+[14:23:02] [SUBTASK] Started: port_scan
+[14:23:02] [SUBTASK] Started: web_recon
+[14:25:30] [SUBTASK] Completed: web_recon (exit 0, 42 lines)
+[14:28:15] [SUBTASK] Completed: port_scan (exit 0, 128 lines)
+```
+
+---
+
+## Brain プロンプトへの追加
+
+### システムプロンプトへの追加セクション
+
+```
+PARALLEL EXECUTION:
+You can run multiple commands in parallel using sub-tasks.
+
+Available actions for parallel execution:
+- "spawn_task": Start a command as a background task
+  Required fields: task_id, task_description, command
+  Optional fields: smart (bool), task_prompt (string, for smart sub-agents)
+- "check_task": Check if a background task has completed (non-blocking)
+  Required fields: task_id
+- "wait": Block until specified tasks complete
+  Required fields: task_ids (array)
+  Optional fields: timeout_seconds (default: 600)
+- "kill_task": Cancel a running background task
+  Required fields: task_id
+
+Guidelines:
+- Use spawn_task when a command will take a long time (nmap full scan, brute force, etc.)
+- Use spawn_task for independent reconnaissance tasks that can run simultaneously
+- Use check_task to poll task status without blocking
+- Use wait when you need results from multiple tasks before proceeding
+- Each task_id must be unique and descriptive (e.g., "full_port_scan", "web_nikto", "dns_axfr")
+- Maximum concurrent tasks: {maxTasks}
+- Smart sub-agents (smart: true) run their own autonomous loop with a separate LLM
+  Use them for complex multi-step investigations
+
+ACTIVE TASKS:
+{dynamically generated list of running/completed tasks}
+```
+
+### ユーザープロンプトへのタスクステータス追加
+
+Brain の各ターンのプロンプトに、アクティブなサブタスクの状態を含める:
+
+```
+## Active Sub-Tasks
+| Task ID     | Status   | Elapsed | Command                        |
+|-------------|----------|---------|--------------------------------|
+| port_scan   | running  | 2m 15s  | nmap -sV -p- 10.0.0.5         |
+| web_recon   | done     | 1m 42s  | nikto -h http://10.0.0.5/      |
+| dns_recon   | failed   | 0m 03s  | dig @10.0.0.5 AXFR example.com |
+```
+
+---
+
+## 設定: 環境変数
+
+### SUBAGENT_MODEL
+
+SmartSubAgent が使用する LLM モデルを指定する。
+メインの Brain と異なるモデル（軽量・高速なモデル）を使い分けることができる。
+
+```bash
+# 例: メインは Claude Opus、サブエージェントは Claude Sonnet
+ANTHROPIC_MODEL=claude-opus-4-0-20250514
+SUBAGENT_MODEL=claude-sonnet-4-20250514
+```
+
+| 値 | 説明 |
+|---|------|
+| 未設定 | メインの Brain と同じモデルを使用 |
+| モデル名 | 指定したモデルを SmartSubAgent に使用 |
+
+### SUBAGENT_PROVIDER
+
+SmartSubAgent が使用する LLM プロバイダを指定する。
+メインと異なるプロバイダを使うことで、レート制限の分散やコスト最適化が可能。
+
+```bash
+# 例: メインは Anthropic 直接、サブエージェントは OpenRouter 経由
+ANTHROPIC_API_KEY=sk-ant-...
+SUBAGENT_PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-or-...
+```
+
+| 値 | 説明 |
+|---|------|
+| 未設定 | メインの Brain と同じプロバイダを使用 |
+| anthropic | Anthropic API 直接 |
+| openai | OpenAI 互換 API |
+| openrouter | OpenRouter 経由 |
+| ollama | Ollama ローカル推論 |
+
+### SUBAGENT_MAX_TASKS
+
+同時実行可能なサブタスク数の上限。
+
+```bash
+SUBAGENT_MAX_TASKS=8   # デフォルト: 8
+```
+
+### SUBAGENT_MAX_TURNS
+
+SmartSubAgent の最大ターン数。
+
+```bash
+SUBAGENT_MAX_TURNS=10   # デフォルト: 10
+```
+
+---
+
+## schema.Action の拡張
+
+```go
+const (
+    ActionSpawnTask ActionType = "spawn_task"
+    ActionCheckTask ActionType = "check_task"
+    ActionWait      ActionType = "wait"
+    ActionKillTask  ActionType = "kill_task"
+)
+
+type Action struct {
+    // 既存フィールド
+    Thought   string         `json:"thought"`
+    Action    ActionType     `json:"action"`
+    Command   string         `json:"command,omitempty"`
+    Memory    *Memory        `json:"memory,omitempty"`
+    Target    string         `json:"target,omitempty"`
+    MCPServer string         `json:"mcp_server,omitempty"`
+    MCPTool   string         `json:"mcp_tool,omitempty"`
+    MCPArgs   map[string]any `json:"mcp_args,omitempty"`
+
+    // SubAgent 関連フィールド
+    TaskID          string   `json:"task_id,omitempty"`
+    TaskDescription string   `json:"task_description,omitempty"`
+    TaskIDs         []string `json:"task_ids,omitempty"`
+    TimeoutSeconds  int      `json:"timeout_seconds,omitempty"`
+    Smart           bool     `json:"smart,omitempty"`
+    TaskPrompt      string   `json:"task_prompt,omitempty"`
+}
+```
+
+---
+
+## Agent Loop のディスパッチ拡張
+
+```go
+case schema.ActionSpawnTask:
+    l.spawnTask(ctx, action)
+
+case schema.ActionCheckTask:
+    result := l.taskManager.Check(action.TaskID)
+    l.feedTaskResultToBrain(result)
+
+case schema.ActionWait:
+    timeout := time.Duration(action.TimeoutSeconds) * time.Second
+    if timeout == 0 {
+        timeout = 600 * time.Second
+    }
+    results := l.taskManager.Wait(ctx, action.TaskIDs, timeout)
+    l.feedTaskResultsToBrain(results)
+
+case schema.ActionKillTask:
+    l.taskManager.Kill(action.TaskID)
+```
+
+### spawnTask の処理フロー
+
+```go
+func (l *Loop) spawnTask(ctx context.Context, action schema.Action) {
+    task := &SubTask{
+        ID:          action.TaskID,
+        Description: action.TaskDescription,
+        Command:     action.Command,
+        Status:      SubTaskPending,
+        ParentID:    "root",
+    }
+
+    // 承認ゲートチェック（通常の run と同じロジック）
+    if needsProposal(action.Command) {
+        l.emit(EventProposal, action)
+        approved := l.waitForApproval()
+        if !approved {
+            return
+        }
+    }
+
+    if action.Smart {
+        // SmartSubAgent を生成
+        brainCfg := l.buildSubAgentBrainConfig()
+        err := l.taskManager.SpawnSmart(task, brainCfg, action.TaskPrompt)
+    } else {
+        // 通常の TaskRunner を生成
+        err := l.taskManager.Spawn(task)
+    }
+}
+```
+
+---
+
+## 承認ゲートとの統合
+
+サブタスクの承認は通常のコマンド実行と同じルールに従う:
+
+| 実行方式 | 承認 |
+|----------|------|
+| Docker 実行ツール | 自動実行 |
+| ホスト実行ツール | 要承認（Proposal） |
+| `proposal_required: false` 明示 | 自動実行 |
+| グローバル Auto-Approve 有効 | 自動実行 |
+
+SmartSubAgent 内で実行されるコマンドも同じルールが適用される。
+SmartSubAgent が承認待ちになった場合、TUI にその旨が表示され、ユーザーが承認するまでサブエージェントのループは一時停止する。
+
+---
+
+## 関連ファイル
+
+| ファイル | 関連 |
+|---------|------|
+| `pkg/schema/action.go` | Action 型定義の拡張 |
+| `internal/agent/loop.go` | Agent Loop ディスパッチの拡張 |
+| `internal/agent/subtask.go` | SubTask, TaskRunner, SmartSubAgent 実装 |
+| `internal/agent/taskmanager.go` | TaskManager 実装 |
+| `internal/agent/tasktree.go` | TaskTree 実装 |
+| `internal/agent/event.go` | SubTask 関連イベントタイプ追加 |
+| `internal/brain/prompt.go` | システムプロンプトの PARALLEL EXECUTION セクション |
+| `internal/brain/brain.go` | SmartSubAgent 用 Brain 設定 |
+| `docs/architecture_design/execution-model.md` | コマンド実行モデル（参照） |
+| `docs/architecture_design/design-philosophy.md` | Agent Team 設計（参照） |

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -20,6 +20,10 @@ const (
 	EventTurnStart EventType = "turn_start"
 	// EventCommandResult はコマンド実行結果のサマリー。
 	EventCommandResult EventType = "command_result"
+	// EventSubTaskLog はサブタスクの出力ログ。
+	EventSubTaskLog EventType = "subtask_log"
+	// EventSubTaskComplete はサブタスクの完了通知。
+	EventSubTaskComplete EventType = "subtask_complete"
 )
 
 // Event は Agent ループから TUI へ送るメッセージ。
@@ -32,4 +36,5 @@ type Event struct {
 	NewHost    string    // EventAddTarget 時に使用
 	TurnNumber int       // EventTurnStart 時のターン番号
 	ExitCode   int       // EventCommandResult 時の exit code
+	TaskID     string    // SubTask 関連イベント時の taskID
 }

--- a/internal/agent/loop_tasks.go
+++ b/internal/agent/loop_tasks.go
@@ -1,0 +1,176 @@
+// Package agent - loop_tasks.go は Loop の SubTask 関連ハンドラを定義する。
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// handleSpawnTask は spawn_task アクションを処理する。
+func (l *Loop) handleSpawnTask(ctx context.Context, action *schema.Action) {
+	if l.taskMgr == nil {
+		l.emit(Event{Type: EventLog, Source: SourceSystem,
+			Message: "TaskManager not configured — cannot spawn tasks"})
+		l.lastToolOutput = "Error: TaskManager not configured"
+		return
+	}
+
+	kind := TaskKind(action.TaskKind)
+	if kind == "" {
+		kind = TaskKindRunner
+	}
+
+	req := SpawnTaskRequest{
+		Kind:       kind,
+		Goal:       action.TaskGoal,
+		Command:    action.Command,
+		TargetHost: l.target.Host,
+		TargetID:   l.target.ID,
+		MaxTurns:   action.TaskMaxTurns,
+		Metadata: TaskMetadata{
+			Port:    action.TaskPort,
+			Service: action.TaskService,
+			Phase:   action.TaskPhase,
+		},
+	}
+
+	taskID, err := l.taskMgr.SpawnTask(ctx, req)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to spawn task: %v", err)
+		l.emit(Event{Type: EventLog, Source: SourceSystem, Message: errMsg})
+		l.lastToolOutput = "Error: " + err.Error()
+		return
+	}
+
+	msg := fmt.Sprintf("Task spawned: %s (kind=%s, goal=%s)", taskID, req.Kind, req.Goal)
+	l.emit(Event{Type: EventLog, Source: SourceSystem, Message: msg})
+	l.lastToolOutput = msg
+}
+
+// handleWait は wait アクションを処理する。指定タスクの完了を待つ。
+func (l *Loop) handleWait(ctx context.Context, action *schema.Action) {
+	if l.taskMgr == nil {
+		l.lastToolOutput = "Error: TaskManager not configured"
+		return
+	}
+
+	var doneID string
+	if action.TaskID != "" {
+		ok := l.taskMgr.WaitTask(ctx, action.TaskID)
+		if !ok {
+			l.lastToolOutput = fmt.Sprintf("Error: wait for task %s cancelled or not found", action.TaskID)
+			return
+		}
+		doneID = action.TaskID
+	} else {
+		doneID = l.taskMgr.WaitAny(ctx)
+		if doneID == "" {
+			l.lastToolOutput = "Error: wait cancelled (context done)"
+			return
+		}
+	}
+
+	task, ok := l.taskMgr.GetTask(doneID)
+	if !ok {
+		l.lastToolOutput = fmt.Sprintf("Error: task %s not found after wait", doneID)
+		return
+	}
+
+	l.lastToolOutput = l.buildTaskResult(task)
+
+	// Post-wait drain: 待機中に届いたユーザーメッセージを回収
+	if msg := l.drainUserMsg(); msg != "" {
+		l.pendingUserMsg = msg
+	}
+}
+
+// handleCheckTask は check_task アクションを処理する。タスクの部分出力を取得する。
+func (l *Loop) handleCheckTask(action *schema.Action) {
+	if l.taskMgr == nil {
+		l.lastToolOutput = "Error: TaskManager not configured"
+		return
+	}
+
+	task, ok := l.taskMgr.GetTask(action.TaskID)
+	if !ok {
+		l.lastToolOutput = fmt.Sprintf("Error: task %s not found", action.TaskID)
+		return
+	}
+
+	// 新しい出力を取得してカーソルを進める
+	newLines := task.ReadNewOutput()
+	task.AdvanceReadCursor()
+
+	var sb strings.Builder
+	sb.WriteString(task.Summary())
+	sb.WriteString("\n")
+	if len(newLines) > 0 {
+		sb.WriteString("--- new output ---\n")
+		for _, line := range newLines {
+			sb.WriteString(line)
+			sb.WriteString("\n")
+		}
+	} else {
+		sb.WriteString("(no new output)\n")
+	}
+
+	l.lastToolOutput = sb.String()
+}
+
+// handleKillTask は kill_task アクションを処理する。
+func (l *Loop) handleKillTask(action *schema.Action) {
+	if l.taskMgr == nil {
+		l.lastToolOutput = "Error: TaskManager not configured"
+		return
+	}
+
+	err := l.taskMgr.KillTask(action.TaskID)
+	if err != nil {
+		l.lastToolOutput = fmt.Sprintf("Error: %v", err)
+		return
+	}
+
+	l.lastToolOutput = fmt.Sprintf("Task %s cancelled", action.TaskID)
+	l.emit(Event{Type: EventLog, Source: SourceSystem,
+		Message: fmt.Sprintf("Task %s cancelled", action.TaskID)})
+}
+
+// buildTaskResult はサブタスクの完了結果テキストを組み立てる。
+func (l *Loop) buildTaskResult(task *SubTask) string {
+	var sb strings.Builder
+	sb.WriteString(task.Summary())
+	sb.WriteString("\n")
+
+	// Findings を追加
+	if len(task.Findings) > 0 {
+		sb.WriteString("--- findings ---\n")
+		for _, f := range task.Findings {
+			sb.WriteString("- ")
+			sb.WriteString(f)
+			sb.WriteString("\n")
+		}
+	}
+
+	// 出力（2000文字に制限）
+	output := task.FullOutput()
+	if output != "" {
+		sb.WriteString("--- output ---\n")
+		if len(output) > 2000 {
+			sb.WriteString(output[:2000])
+			sb.WriteString("\n... (truncated)\n")
+		} else {
+			sb.WriteString(output)
+			sb.WriteString("\n")
+		}
+	}
+
+	// Entity をターゲットに追加
+	if len(task.Entities) > 0 {
+		l.target.AddEntities(task.Entities)
+	}
+
+	return sb.String()
+}

--- a/internal/agent/smart_subagent.go
+++ b/internal/agent/smart_subagent.go
@@ -1,0 +1,175 @@
+// Package agent - smart_subagent.go は小型 LLM を使って多段タスクを自律実行するサブエージェント。
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/brain"
+	"github.com/0x6d61/pentecter/internal/mcp"
+	"github.com/0x6d61/pentecter/internal/tools"
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// SmartSubAgent は小型 LLM を使って多段タスクを自律実行するサブエージェント。
+type SmartSubAgent struct {
+	br     brain.Brain
+	runner *tools.CommandRunner
+	mcpMgr *mcp.MCPManager
+	events chan<- Event
+}
+
+// NewSmartSubAgent は SmartSubAgent を構築する。
+func NewSmartSubAgent(br brain.Brain, runner *tools.CommandRunner, mcpMgr *mcp.MCPManager, events chan<- Event) *SmartSubAgent {
+	return &SmartSubAgent{
+		br:     br,
+		runner: runner,
+		mcpMgr: mcpMgr,
+		events: events,
+	}
+}
+
+// Run はサブタスクを自律ループで実行する。完了まで blocking する。
+func (sa *SmartSubAgent) Run(ctx context.Context, task *SubTask, targetHost string) {
+	task.Status = TaskStatusRunning
+	task.StartedAt = time.Now()
+
+	// デフォルトの MaxTurns
+	if task.MaxTurns == 0 {
+		task.MaxTurns = 10
+	}
+
+	sa.emitLog(task, SourceSystem, fmt.Sprintf("SmartSubAgent %s started: %s", task.ID, task.Goal))
+
+	var lastCommand string
+	var lastOutput string
+	var lastExitCode int
+
+	for turn := 1; turn <= task.MaxTurns; turn++ {
+		// コンテキストキャンセルチェック
+		select {
+		case <-ctx.Done():
+			task.Status = TaskStatusCancelled
+			task.Error = "cancelled"
+			task.CompletedAt = time.Now()
+			task.Complete()
+			sa.emitLog(task, SourceSystem, fmt.Sprintf("SmartSubAgent %s cancelled", task.ID))
+			sa.emitTaskComplete(task)
+			return
+		default:
+		}
+
+		task.TurnCount = turn
+
+		// Brain に渡す Input を構築
+		input := brain.Input{
+			TargetSnapshot: fmt.Sprintf(`{"host":%q,"task_goal":%q}`, targetHost, task.Goal),
+			ToolOutput:     lastOutput,
+			LastCommand:    lastCommand,
+			LastExitCode:   lastExitCode,
+			TurnCount:      turn,
+			UserMessage:    "", // SubAgent はユーザーメッセージを受け取らない
+		}
+
+		// Brain に思考を依頼
+		action, err := sa.br.Think(ctx, input)
+		if err != nil {
+			task.Status = TaskStatusFailed
+			task.Error = fmt.Sprintf("brain error: %v", err)
+			task.AppendOutput(fmt.Sprintf("[error] %s", err))
+			task.CompletedAt = time.Now()
+			task.Complete()
+			sa.emitLog(task, SourceSystem, fmt.Sprintf("SmartSubAgent %s failed: %v", task.ID, err))
+			sa.emitTaskComplete(task)
+			return
+		}
+
+		// Thought をログに追加
+		if action.Thought != "" {
+			task.AppendOutput("[think] " + action.Thought)
+			sa.emitLog(task, SourceAI, action.Thought)
+		}
+
+		switch action.Action {
+		case schema.ActionRun:
+			lastCommand = action.Command
+			linesCh, resultCh := sa.runner.ForceRun(ctx, action.Command)
+
+			// ストリーム出力を収集
+			for line := range linesCh {
+				if line.Content != "" {
+					task.AppendOutput(line.Content)
+				}
+			}
+
+			// 結果を取得
+			result := <-resultCh
+			lastExitCode = result.ExitCode
+			lastOutput = result.Truncated
+
+			// Entity 抽出結果をタスクに追加
+			if result.Entities != nil {
+				task.Entities = append(task.Entities, result.Entities...)
+			}
+
+		case schema.ActionMemory:
+			if action.Memory != nil {
+				finding := fmt.Sprintf("[%s] %s: %s",
+					action.Memory.Type, action.Memory.Title, action.Memory.Description)
+				task.Findings = append(task.Findings, finding)
+				task.AppendOutput("[memory] " + action.Memory.Title)
+				sa.emitLog(task, SourceAI, fmt.Sprintf("Memory: %s", action.Memory.Title))
+			}
+
+		case schema.ActionComplete:
+			task.Status = TaskStatusCompleted
+			task.CompletedAt = time.Now()
+			task.Complete()
+			sa.emitLog(task, SourceSystem, fmt.Sprintf("SmartSubAgent %s completed", task.ID))
+			sa.emitTaskComplete(task)
+			return
+
+		case schema.ActionThink:
+			// Thought は既にログ済み。ループ継続。
+
+		default:
+			task.AppendOutput("Unsupported action in SubAgent: " + string(action.Action))
+			sa.emitLog(task, SourceSystem,
+				fmt.Sprintf("SmartSubAgent %s: unsupported action %q", task.ID, action.Action))
+		}
+	}
+
+	// MaxTurns に到達
+	task.Status = TaskStatusCompleted
+	task.CompletedAt = time.Now()
+	task.Complete()
+	sa.emitLog(task, SourceSystem,
+		fmt.Sprintf("SmartSubAgent %s completed (max turns %d reached)", task.ID, task.MaxTurns))
+	sa.emitTaskComplete(task)
+}
+
+// emitLog はサブタスクのログイベントを送信する（ブロックしない）。
+func (sa *SmartSubAgent) emitLog(task *SubTask, source LogSource, msg string) {
+	select {
+	case sa.events <- Event{
+		Type:    EventSubTaskLog,
+		TaskID:  task.ID,
+		Source:  source,
+		Message: msg,
+	}:
+	default:
+	}
+}
+
+// emitTaskComplete はサブタスクの完了イベントを送信する。
+func (sa *SmartSubAgent) emitTaskComplete(task *SubTask) {
+	select {
+	case sa.events <- Event{
+		Type:    EventSubTaskComplete,
+		TaskID:  task.ID,
+		Message: task.Summary(),
+	}:
+	default:
+	}
+}

--- a/internal/agent/smart_subagent_test.go
+++ b/internal/agent/smart_subagent_test.go
@@ -1,0 +1,263 @@
+package agent_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/agent"
+	"github.com/0x6d61/pentecter/internal/brain"
+	"github.com/0x6d61/pentecter/internal/tools"
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// newSmartTestRunner は SmartSubAgent テスト用の CommandRunner を構築する。
+func newSmartTestRunner() *tools.CommandRunner {
+	falseVal := false
+	reg := tools.NewRegistry()
+	reg.Register(&tools.ToolDef{
+		Name:             "echo",
+		ProposalRequired: &falseVal,
+		Output: tools.OutputConfig{
+			Strategy:  tools.StrategyHeadTail,
+			HeadLines: 5,
+			TailLines: 5,
+		},
+	})
+	return tools.NewCommandRunner(reg, tools.NewBlacklist(nil), tools.NewLogStore())
+}
+
+// slowMockBrain は Think() の度に少し待つ mockBrain。キャンセルテスト用。
+type slowMockBrain struct {
+	actions []*schema.Action
+	idx     int64
+	delay   time.Duration
+}
+
+func (m *slowMockBrain) Think(ctx context.Context, _ brain.Input) (*schema.Action, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(m.delay):
+	}
+
+	i := int(atomic.AddInt64(&m.idx, 1) - 1)
+	if i >= len(m.actions) {
+		return &schema.Action{Thought: "done", Action: schema.ActionComplete}, nil
+	}
+	return m.actions[i], nil
+}
+
+func (m *slowMockBrain) Provider() string { return "slow-mock" }
+
+func TestSmartSubAgent_Run_MultiTurn(t *testing.T) {
+	// mockBrain: run "echo step1" → memory (vulnerability) → complete
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{
+				Thought: "scanning services",
+				Action:  schema.ActionRun,
+				Command: "echo step1",
+			},
+			{
+				Thought: "found vulnerability",
+				Action:  schema.ActionMemory,
+				Memory: &schema.Memory{
+					Type:        schema.MemoryVulnerability,
+					Title:       "Open SSH",
+					Description: "SSH on port 22 allows password auth",
+					Severity:    "high",
+				},
+			},
+			{
+				Thought: "assessment done",
+				Action:  schema.ActionComplete,
+			},
+		},
+	}
+
+	runner := newSmartTestRunner()
+	events := make(chan agent.Event, 64)
+
+	task := agent.NewSubTask("smart-1", agent.TaskKindSmart, "enumerate services")
+	task.MaxTurns = 10
+
+	sa := agent.NewSmartSubAgent(mb, runner, nil, events)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go sa.Run(ctx, task, "10.0.0.5")
+
+	// タスク完了を待つ
+	select {
+	case <-task.Done():
+		// OK
+	case <-time.After(8 * time.Second):
+		t.Fatal("timeout waiting for SmartSubAgent to complete")
+	}
+
+	// ステータス検証
+	if task.Status != agent.TaskStatusCompleted {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusCompleted)
+	}
+
+	// ターン数検証: run + memory + complete = 3 turns
+	if task.TurnCount != 3 {
+		t.Errorf("TurnCount: got %d, want 3", task.TurnCount)
+	}
+
+	// Findings 検証: memory アクションで記録された内容が含まれること
+	findingsJoined := strings.Join(task.Findings, " ")
+	if !strings.Contains(findingsJoined, "Open SSH") {
+		t.Errorf("Findings should contain 'Open SSH', got: %v", task.Findings)
+	}
+
+	// FullOutput 検証
+	output := task.FullOutput()
+	if !strings.Contains(output, "step1") {
+		t.Errorf("FullOutput should contain 'step1', got: %q", output)
+	}
+	if !strings.Contains(output, "scanning services") {
+		t.Errorf("FullOutput should contain thought text 'scanning services', got: %q", output)
+	}
+
+	// done チャネルが閉じていることを確認（select が即時通過する）
+	select {
+	case <-task.Done():
+		// OK: channel is closed
+	default:
+		t.Error("done channel should be closed after completion")
+	}
+}
+
+func TestSmartSubAgent_Run_MaxTurnsReached(t *testing.T) {
+	// mockBrain が常に ActionThink を返す（complete しない）
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "thinking 1", Action: schema.ActionThink},
+			{Thought: "thinking 2", Action: schema.ActionThink},
+			{Thought: "thinking 3", Action: schema.ActionThink},
+			{Thought: "thinking 4", Action: schema.ActionThink},
+			{Thought: "thinking 5", Action: schema.ActionThink},
+		},
+	}
+
+	runner := newSmartTestRunner()
+	events := make(chan agent.Event, 64)
+
+	task := agent.NewSubTask("smart-2", agent.TaskKindSmart, "infinite thinker")
+	task.MaxTurns = 3
+
+	sa := agent.NewSmartSubAgent(mb, runner, nil, events)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go sa.Run(ctx, task, "10.0.0.5")
+
+	select {
+	case <-task.Done():
+		// OK
+	case <-time.After(8 * time.Second):
+		t.Fatal("timeout waiting for SmartSubAgent to complete on MaxTurns")
+	}
+
+	// MaxTurns に到達して完了
+	if task.Status != agent.TaskStatusCompleted {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusCompleted)
+	}
+
+	if task.TurnCount != 3 {
+		t.Errorf("TurnCount: got %d, want 3", task.TurnCount)
+	}
+}
+
+func TestSmartSubAgent_Run_BrainError(t *testing.T) {
+	// mockBrain がエラーを返す
+	mb := &mockBrain{
+		errors: []error{
+			fmt.Errorf("brain connection failed"),
+		},
+	}
+
+	runner := newSmartTestRunner()
+	events := make(chan agent.Event, 64)
+
+	task := agent.NewSubTask("smart-3", agent.TaskKindSmart, "error test")
+	task.MaxTurns = 5
+
+	sa := agent.NewSmartSubAgent(mb, runner, nil, events)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go sa.Run(ctx, task, "10.0.0.5")
+
+	select {
+	case <-task.Done():
+		// OK
+	case <-time.After(8 * time.Second):
+		t.Fatal("timeout waiting for SmartSubAgent to complete on error")
+	}
+
+	if task.Status != agent.TaskStatusFailed {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusFailed)
+	}
+
+	if !strings.Contains(task.Error, "brain connection failed") {
+		t.Errorf("Error should contain 'brain connection failed', got: %q", task.Error)
+	}
+}
+
+func TestSmartSubAgent_Run_ContextCancel(t *testing.T) {
+	// slowMockBrain を使って各 Think() で 50ms 待つ
+	// 20 ターン × 50ms = 1秒 なので、200ms 後にキャンセルすれば途中で止まる
+	actions := make([]*schema.Action, 20)
+	for i := range actions {
+		actions[i] = &schema.Action{
+			Thought: fmt.Sprintf("thinking %d", i+1),
+			Action:  schema.ActionThink,
+		}
+	}
+	mb := &slowMockBrain{
+		actions: actions,
+		delay:   50 * time.Millisecond,
+	}
+
+	runner := newSmartTestRunner()
+	events := make(chan agent.Event, 64)
+
+	task := agent.NewSubTask("smart-4", agent.TaskKindSmart, "cancel test")
+	task.MaxTurns = 20
+
+	sa := agent.NewSmartSubAgent(mb, runner, nil, events)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go sa.Run(ctx, task, "10.0.0.5")
+
+	// 200ms 後にキャンセル（3-4 ターン程度実行されるはず）
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-task.Done():
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for SmartSubAgent to complete on cancel")
+	}
+
+	// キャンセルまたは失敗（Brain がコンテキストエラーを返す場合）
+	if task.Status != agent.TaskStatusCancelled && task.Status != agent.TaskStatusFailed {
+		t.Errorf("Status: got %q, want cancelled or failed", task.Status)
+	}
+
+	// MaxTurns には到達していないはず
+	if task.TurnCount >= 20 {
+		t.Errorf("TurnCount should be less than 20 (cancelled early), got %d", task.TurnCount)
+	}
+}

--- a/internal/agent/subtask.go
+++ b/internal/agent/subtask.go
@@ -1,0 +1,160 @@
+// Package agent - subtask.go はバックグラウンドで実行されるサブタスクを定義する。
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/tools"
+)
+
+// TaskKind はサブタスクの種別を表す。
+type TaskKind string
+
+const (
+	// TaskKindRunner は単一コマンドを実行するタスク。
+	TaskKindRunner TaskKind = "runner"
+	// TaskKindSmart は Brain を使った自律型サブエージェントタスク。
+	TaskKindSmart TaskKind = "smart"
+)
+
+// TaskStatus はサブタスクの実行状態。
+type TaskStatus string
+
+const (
+	TaskStatusPending   TaskStatus = "pending"
+	TaskStatusRunning   TaskStatus = "running"
+	TaskStatusCompleted TaskStatus = "completed"
+	TaskStatusFailed    TaskStatus = "failed"
+	TaskStatusCancelled TaskStatus = "cancelled"
+)
+
+// TaskMetadata はサブタスクに付与されるメタ情報。
+type TaskMetadata struct {
+	Port    int    `json:"port,omitempty"`
+	Service string `json:"service,omitempty"`
+	Phase   string `json:"phase,omitempty"`
+}
+
+// SubTask はバックグラウンドで実行されるタスクを表す。
+type SubTask struct {
+	ID          string
+	Kind        TaskKind
+	Goal        string
+	Command     string
+	Status      TaskStatus
+	Metadata    TaskMetadata
+	TargetID    int
+	StartedAt   time.Time
+	CompletedAt time.Time
+	ExitCode    int
+	Error       string
+	MaxTurns    int
+	TurnCount   int
+	Findings    []string
+	Entities    []tools.Entity
+
+	// 非公開フィールド
+	mu          sync.RWMutex
+	outputLines []string
+	lastReadIdx int
+	done        chan struct{}
+	cancel      context.CancelFunc
+}
+
+// NewSubTask はサブタスクを作成する。done チャネルを初期化する。
+func NewSubTask(id string, kind TaskKind, goal string) *SubTask {
+	return &SubTask{
+		ID:     id,
+		Kind:   kind,
+		Goal:   goal,
+		Status: TaskStatusPending,
+		done:   make(chan struct{}),
+	}
+}
+
+// AppendOutput は出力バッファに1行追加する。goroutine-safe。
+func (st *SubTask) AppendOutput(line string) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.outputLines = append(st.outputLines, line)
+}
+
+// ReadNewOutput は lastReadIdx 以降の新しい出力行を返す。
+// カーソルは進めない（AdvanceReadCursor で明示的に進める）。
+func (st *SubTask) ReadNewOutput() []string {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+
+	if st.lastReadIdx >= len(st.outputLines) {
+		return nil
+	}
+	// コピーを返す
+	newLines := make([]string, len(st.outputLines)-st.lastReadIdx)
+	copy(newLines, st.outputLines[st.lastReadIdx:])
+	return newLines
+}
+
+// AdvanceReadCursor はリードカーソルを現在の出力末尾まで進める。
+func (st *SubTask) AdvanceReadCursor() {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.lastReadIdx = len(st.outputLines)
+}
+
+// FullOutput は全出力行を改行で結合して返す。
+func (st *SubTask) FullOutput() string {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	return strings.Join(st.outputLines, "\n")
+}
+
+// Summary はタスクのサマリーテキストを返す。
+// Runner: "[task-1] running (5 output lines): scan target"
+// Smart:  "[task-1] running (turn 3/10, 5 output lines): enumerate services"
+func (st *SubTask) Summary() string {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+
+	lineCount := len(st.outputLines)
+
+	if st.Kind == TaskKindSmart && st.MaxTurns > 0 {
+		return fmt.Sprintf("[%s] %s (turn %d/%d, %d output lines): %s",
+			st.ID, st.Status, st.TurnCount, st.MaxTurns, lineCount, st.Goal)
+	}
+	return fmt.Sprintf("[%s] %s (%d output lines): %s",
+		st.ID, st.Status, lineCount, st.Goal)
+}
+
+// GetMetadata はメタデータのコピーを返す（goroutine-safe）。
+func (st *SubTask) GetMetadata() TaskMetadata {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	return st.Metadata
+}
+
+// Done は完了通知チャネルを返す。Complete() 時にクローズされる。
+func (st *SubTask) Done() <-chan struct{} {
+	return st.done
+}
+
+// Complete はタスクを完了としてマークし、done チャネルを閉じる。
+// 1回だけ呼ぶこと。
+func (st *SubTask) Complete() {
+	close(st.done)
+}
+
+// Cancel はキャンセル関数を呼び出す（設定されている場合）。
+func (st *SubTask) Cancel() {
+	if st.cancel != nil {
+		st.cancel()
+	}
+}
+
+// SetCancel はキャンセル関数をセットする。
+func (st *SubTask) SetCancel(fn context.CancelFunc) {
+	st.cancel = fn
+}

--- a/internal/agent/subtask_test.go
+++ b/internal/agent/subtask_test.go
@@ -1,0 +1,185 @@
+package agent_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/0x6d61/pentecter/internal/agent"
+)
+
+func TestSubTask_AppendOutput_ReadNewOutput(t *testing.T) {
+	st := agent.NewSubTask("task-1", agent.TaskKindRunner, "scan target")
+
+	st.AppendOutput("line1")
+	st.AppendOutput("line2")
+	st.AppendOutput("line3")
+
+	lines := st.ReadNewOutput()
+	if len(lines) != 3 {
+		t.Fatalf("ReadNewOutput: got %d lines, want 3", len(lines))
+	}
+	if lines[0] != "line1" || lines[1] != "line2" || lines[2] != "line3" {
+		t.Errorf("ReadNewOutput: got %v, want [line1 line2 line3]", lines)
+	}
+
+	// ReadNewOutput does NOT advance cursor, so calling again returns same lines
+	lines2 := st.ReadNewOutput()
+	if len(lines2) != 3 {
+		t.Errorf("second ReadNewOutput without advance: got %d lines, want 3", len(lines2))
+	}
+}
+
+func TestSubTask_AdvanceReadCursor(t *testing.T) {
+	st := agent.NewSubTask("task-1", agent.TaskKindRunner, "scan target")
+
+	st.AppendOutput("line1")
+	st.AppendOutput("line2")
+
+	// Read and advance
+	lines := st.ReadNewOutput()
+	if len(lines) != 2 {
+		t.Fatalf("ReadNewOutput: got %d lines, want 2", len(lines))
+	}
+	st.AdvanceReadCursor()
+
+	// Append more
+	st.AppendOutput("line3")
+	st.AppendOutput("line4")
+
+	// Should only get new lines
+	lines = st.ReadNewOutput()
+	if len(lines) != 2 {
+		t.Fatalf("ReadNewOutput after advance: got %d lines, want 2", len(lines))
+	}
+	if lines[0] != "line3" || lines[1] != "line4" {
+		t.Errorf("ReadNewOutput after advance: got %v, want [line3 line4]", lines)
+	}
+}
+
+func TestSubTask_FullOutput(t *testing.T) {
+	st := agent.NewSubTask("task-1", agent.TaskKindRunner, "scan target")
+
+	st.AppendOutput("line1")
+	st.AppendOutput("line2")
+	st.AppendOutput("line3")
+
+	full := st.FullOutput()
+	expected := "line1\nline2\nline3"
+	if full != expected {
+		t.Errorf("FullOutput: got %q, want %q", full, expected)
+	}
+}
+
+func TestSubTask_Summary_Runner(t *testing.T) {
+	st := agent.NewSubTask("task-1", agent.TaskKindRunner, "scan target")
+	st.Status = agent.TaskStatusRunning
+
+	st.AppendOutput("line1")
+	st.AppendOutput("line2")
+	st.AppendOutput("line3")
+	st.AppendOutput("line4")
+	st.AppendOutput("line5")
+
+	summary := st.Summary()
+	// Format: "[task-1] running (5 output lines): scan target"
+	if !strings.Contains(summary, "task-1") {
+		t.Errorf("Summary should contain task ID, got: %s", summary)
+	}
+	if !strings.Contains(summary, "running") {
+		t.Errorf("Summary should contain status, got: %s", summary)
+	}
+	if !strings.Contains(summary, "5 output lines") {
+		t.Errorf("Summary should contain output line count, got: %s", summary)
+	}
+	if !strings.Contains(summary, "scan target") {
+		t.Errorf("Summary should contain goal, got: %s", summary)
+	}
+}
+
+func TestSubTask_Summary_Smart(t *testing.T) {
+	st := agent.NewSubTask("task-2", agent.TaskKindSmart, "enumerate services")
+	st.Status = agent.TaskStatusRunning
+	st.MaxTurns = 10
+	st.TurnCount = 3
+
+	st.AppendOutput("line1")
+	st.AppendOutput("line2")
+	st.AppendOutput("line3")
+	st.AppendOutput("line4")
+	st.AppendOutput("line5")
+
+	summary := st.Summary()
+	// Format: "[task-2] running (turn 3/10, 5 output lines): enumerate services"
+	if !strings.Contains(summary, "task-2") {
+		t.Errorf("Summary should contain task ID, got: %s", summary)
+	}
+	if !strings.Contains(summary, "turn 3/10") {
+		t.Errorf("Summary should contain turn info, got: %s", summary)
+	}
+	if !strings.Contains(summary, "5 output lines") {
+		t.Errorf("Summary should contain output line count, got: %s", summary)
+	}
+	if !strings.Contains(summary, "enumerate services") {
+		t.Errorf("Summary should contain goal, got: %s", summary)
+	}
+}
+
+func TestSubTask_ConcurrentAccess(t *testing.T) {
+	st := agent.NewSubTask("task-1", agent.TaskKindRunner, "concurrent test")
+
+	var wg sync.WaitGroup
+	// Multiple writers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				st.AppendOutput("line")
+			}
+		}(i)
+	}
+
+	// One reader
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = st.ReadNewOutput()
+			st.AdvanceReadCursor()
+			_ = st.FullOutput()
+			_ = st.Summary()
+		}
+	}()
+
+	wg.Wait()
+
+	// After all goroutines finish, verify total output lines = 10 * 100 = 1000
+	full := st.FullOutput()
+	lineCount := strings.Count(full, "line")
+	if lineCount != 1000 {
+		t.Errorf("ConcurrentAccess: got %d lines, want 1000", lineCount)
+	}
+}
+
+func TestSubTask_Done_Channel(t *testing.T) {
+	st := agent.NewSubTask("task-1", agent.TaskKindRunner, "test done")
+
+	// done channel should not be closed initially
+	select {
+	case <-st.Done():
+		t.Fatal("Done() should not be closed before Complete()")
+	default:
+		// OK - not closed
+	}
+
+	st.Complete()
+
+	// done channel should be closed now
+	select {
+	case <-st.Done():
+		// OK - closed
+	default:
+		t.Fatal("Done() should be closed after Complete()")
+	}
+}

--- a/internal/agent/task_manager.go
+++ b/internal/agent/task_manager.go
@@ -1,0 +1,187 @@
+// Package agent - task_manager.go はサブタスクのライフサイクルを管理する TaskManager を定義する。
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/0x6d61/pentecter/internal/brain"
+	"github.com/0x6d61/pentecter/internal/mcp"
+	"github.com/0x6d61/pentecter/internal/tools"
+)
+
+// TaskManager はサブタスクの生成・追跡・終了を管理する。
+type TaskManager struct {
+	mu       sync.RWMutex
+	tasks    map[string]*SubTask
+	nextID   atomic.Int64
+	runner   *tools.CommandRunner
+	mcpMgr   *mcp.MCPManager
+	events   chan<- Event
+	subBrain brain.Brain
+	doneCh   chan string // バッファ: 64
+}
+
+// SpawnTaskRequest はサブタスクの生成リクエスト。
+type SpawnTaskRequest struct {
+	Kind       TaskKind
+	Goal       string
+	Command    string
+	Metadata   TaskMetadata
+	TargetID   int
+	TargetHost string
+	MaxTurns   int
+}
+
+// NewTaskManager は TaskManager を構築する。
+func NewTaskManager(runner *tools.CommandRunner, mcpMgr *mcp.MCPManager, events chan<- Event, subBrain brain.Brain) *TaskManager {
+	return &TaskManager{
+		tasks:    make(map[string]*SubTask),
+		runner:   runner,
+		mcpMgr:   mcpMgr,
+		events:   events,
+		subBrain: subBrain,
+		doneCh:   make(chan string, 64),
+	}
+}
+
+// SpawnTask は新しいサブタスクを生成し、バックグラウンドで実行する。
+func (tm *TaskManager) SpawnTask(ctx context.Context, req SpawnTaskRequest) (string, error) {
+	id := fmt.Sprintf("task-%d", tm.nextID.Add(1))
+
+	task := NewSubTask(id, req.Kind, req.Goal)
+	task.Command = req.Command
+	task.Metadata = req.Metadata
+	task.TargetID = req.TargetID
+	task.MaxTurns = req.MaxTurns
+
+	// キャンセル用コンテキスト
+	taskCtx, cancel := context.WithCancel(ctx)
+	task.SetCancel(cancel)
+
+	tm.mu.Lock()
+	tm.tasks[id] = task
+	tm.mu.Unlock()
+
+	switch req.Kind {
+	case TaskKindRunner:
+		tr := NewTaskRunner(tm.runner, tm.mcpMgr, tm.events)
+		go func() {
+			tr.Run(taskCtx, task)
+			select {
+			case tm.doneCh <- id:
+			default:
+			}
+		}()
+	case TaskKindSmart:
+		if tm.subBrain == nil {
+			task.Status = TaskStatusFailed
+			task.Error = "sub-brain is not configured"
+			task.Complete()
+			cancel()
+			return id, fmt.Errorf("sub-brain is not configured for smart tasks")
+		}
+		sa := NewSmartSubAgent(tm.subBrain, tm.runner, tm.mcpMgr, tm.events)
+		go func() {
+			sa.Run(taskCtx, task, req.TargetHost)
+			select {
+			case tm.doneCh <- id:
+			default:
+			}
+		}()
+	default:
+		task.Status = TaskStatusFailed
+		task.Error = fmt.Sprintf("unknown task kind: %s", req.Kind)
+		task.Complete()
+		cancel()
+		return id, fmt.Errorf("unknown task kind: %s", req.Kind)
+	}
+
+	return id, nil
+}
+
+// GetTask は指定 ID のサブタスクを返す。
+func (tm *TaskManager) GetTask(id string) (*SubTask, bool) {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	task, ok := tm.tasks[id]
+	return task, ok
+}
+
+// WaitAny は完了したサブタスクの ID を1つ返す。
+// コンテキストがキャンセルされた場合は空文字を返す。
+func (tm *TaskManager) WaitAny(ctx context.Context) string {
+	select {
+	case id := <-tm.doneCh:
+		return id
+	case <-ctx.Done():
+		return ""
+	}
+}
+
+// WaitTask は指定 ID のサブタスクの完了を待つ。
+// 完了した場合は true、コンテキストキャンセルの場合は false を返す。
+func (tm *TaskManager) WaitTask(ctx context.Context, id string) bool {
+	tm.mu.RLock()
+	task, ok := tm.tasks[id]
+	tm.mu.RUnlock()
+	if !ok {
+		return false
+	}
+
+	select {
+	case <-task.Done():
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// KillTask は指定 ID のサブタスクをキャンセルする。
+func (tm *TaskManager) KillTask(id string) error {
+	tm.mu.RLock()
+	task, ok := tm.tasks[id]
+	tm.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("task not found: %s", id)
+	}
+
+	task.Cancel()
+	return nil
+}
+
+// ActiveTasks は指定ターゲットの実行中（pending/running）サブタスクを返す。
+func (tm *TaskManager) ActiveTasks(targetID int) []*SubTask {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	var active []*SubTask
+	for _, task := range tm.tasks {
+		if task.TargetID == targetID &&
+			(task.Status == TaskStatusPending || task.Status == TaskStatusRunning) {
+			active = append(active, task)
+		}
+	}
+	return active
+}
+
+// AllTasks は指定ターゲットの全サブタスクを返す。
+func (tm *TaskManager) AllTasks(targetID int) []*SubTask {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	var all []*SubTask
+	for _, task := range tm.tasks {
+		if task.TargetID == targetID {
+			all = append(all, task)
+		}
+	}
+	return all
+}
+
+// DoneCh は完了通知チャネルを返す（外部の select 用）。
+func (tm *TaskManager) DoneCh() <-chan string {
+	return tm.doneCh
+}

--- a/internal/agent/task_manager_test.go
+++ b/internal/agent/task_manager_test.go
@@ -1,0 +1,315 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/agent"
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+func TestTaskManager_SpawnTask_Runner(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tm := agent.NewTaskManager(runner, nil, events, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	taskID, err := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:    agent.TaskKindRunner,
+		Goal:    "echo test",
+		Command: "echo hello-manager",
+	})
+	if err != nil {
+		t.Fatalf("SpawnTask: %v", err)
+	}
+	if taskID == "" {
+		t.Fatal("SpawnTask returned empty taskID")
+	}
+
+	// WaitAny should return this taskID when it completes
+	completedID := tm.WaitAny(ctx)
+	if completedID != taskID {
+		t.Errorf("WaitAny: got %q, want %q", completedID, taskID)
+	}
+
+	// Verify the task is completed
+	task, ok := tm.GetTask(taskID)
+	if !ok {
+		t.Fatal("GetTask: task not found")
+	}
+	if task.Status != agent.TaskStatusCompleted {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusCompleted)
+	}
+}
+
+func TestTaskManager_WaitTask(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tm := agent.NewTaskManager(runner, nil, events, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	taskID, err := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:    agent.TaskKindRunner,
+		Goal:    "wait test",
+		Command: "echo wait-test",
+	})
+	if err != nil {
+		t.Fatalf("SpawnTask: %v", err)
+	}
+
+	done := tm.WaitTask(ctx, taskID)
+	if !done {
+		t.Error("WaitTask should return true when task completes")
+	}
+
+	task, _ := tm.GetTask(taskID)
+	if task.Status != agent.TaskStatusCompleted {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusCompleted)
+	}
+}
+
+func TestTaskManager_GetTask(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tm := agent.NewTaskManager(runner, nil, events, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	taskID, err := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:    agent.TaskKindRunner,
+		Goal:    "get test",
+		Command: "echo get-test",
+	})
+	if err != nil {
+		t.Fatalf("SpawnTask: %v", err)
+	}
+
+	task, ok := tm.GetTask(taskID)
+	if !ok {
+		t.Fatal("GetTask: task not found")
+	}
+	if task.ID != taskID {
+		t.Errorf("ID: got %q, want %q", task.ID, taskID)
+	}
+	if task.Goal != "get test" {
+		t.Errorf("Goal: got %q, want %q", task.Goal, "get test")
+	}
+
+	// Non-existent task
+	_, ok = tm.GetTask("nonexistent")
+	if ok {
+		t.Error("GetTask should return false for nonexistent task")
+	}
+}
+
+func TestTaskManager_KillTask(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tm := agent.NewTaskManager(runner, nil, events, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Spawn a slow task — use a pre-cancelled context approach
+	// We spawn with a valid context, then kill it
+	taskID, err := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:    agent.TaskKindRunner,
+		Goal:    "kill test",
+		Command: "echo killed",
+	})
+	if err != nil {
+		t.Fatalf("SpawnTask: %v", err)
+	}
+
+	// Wait for task to finish (it's a fast echo)
+	tm.WaitTask(ctx, taskID)
+
+	// KillTask on an already-completed task should not return error
+	err = tm.KillTask(taskID)
+	if err != nil {
+		t.Errorf("KillTask on completed task: %v", err)
+	}
+
+	// KillTask on nonexistent task
+	err = tm.KillTask("nonexistent")
+	if err == nil {
+		t.Error("KillTask should return error for nonexistent task")
+	}
+}
+
+func TestTaskManager_ActiveTasks(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tm := agent.NewTaskManager(runner, nil, events, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Spawn 2 tasks for target 1
+	id1, _ := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:     agent.TaskKindRunner,
+		Goal:     "task 1",
+		Command:  "echo task1",
+		TargetID: 1,
+	})
+	id2, _ := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:     agent.TaskKindRunner,
+		Goal:     "task 2",
+		Command:  "echo task2",
+		TargetID: 1,
+	})
+
+	// Spawn 1 task for target 2
+	_, _ = tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:     agent.TaskKindRunner,
+		Goal:     "task 3",
+		Command:  "echo task3",
+		TargetID: 2,
+	})
+
+	// Wait for all tasks to complete
+	tm.WaitTask(ctx, id1)
+	tm.WaitTask(ctx, id2)
+
+	// AllTasks for target 1 should have 2
+	allTarget1 := tm.AllTasks(1)
+	if len(allTarget1) != 2 {
+		t.Errorf("AllTasks(1): got %d, want 2", len(allTarget1))
+	}
+
+	// AllTasks for target 2 should have 1
+	allTarget2 := tm.AllTasks(2)
+	if len(allTarget2) != 1 {
+		t.Errorf("AllTasks(2): got %d, want 1", len(allTarget2))
+	}
+}
+
+func TestTaskManager_WaitAny_MultipleCompleted(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tm := agent.NewTaskManager(runner, nil, events, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	id1, _ := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:    agent.TaskKindRunner,
+		Goal:    "multi 1",
+		Command: "echo multi1",
+	})
+	id2, _ := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:    agent.TaskKindRunner,
+		Goal:    "multi 2",
+		Command: "echo multi2",
+	})
+
+	// Collect both completed IDs via WaitAny
+	completed := make(map[string]bool)
+	first := tm.WaitAny(ctx)
+	completed[first] = true
+
+	second := tm.WaitAny(ctx)
+	completed[second] = true
+
+	if !completed[id1] {
+		t.Errorf("WaitAny should eventually return %q", id1)
+	}
+	if !completed[id2] {
+		t.Errorf("WaitAny should eventually return %q", id2)
+	}
+}
+
+func TestTaskManager_SpawnTask_Smart(t *testing.T) {
+	// mockBrain: run "echo smart-task" → complete
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{
+				Thought: "executing smart task",
+				Action:  schema.ActionRun,
+				Command: "echo smart-task",
+			},
+			{
+				Thought: "task done",
+				Action:  schema.ActionComplete,
+			},
+		},
+	}
+
+	runner := newSmartTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tm := agent.NewTaskManager(runner, nil, events, mb)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	taskID, err := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:       agent.TaskKindSmart,
+		Goal:       "test smart",
+		TargetHost: "10.0.0.5",
+		MaxTurns:   10,
+	})
+	if err != nil {
+		t.Fatalf("SpawnTask (smart): %v", err)
+	}
+	if taskID == "" {
+		t.Fatal("SpawnTask returned empty taskID")
+	}
+
+	// WaitTask で完了を待つ
+	done := tm.WaitTask(ctx, taskID)
+	if !done {
+		t.Fatal("WaitTask should return true when smart task completes")
+	}
+
+	// タスクの状態を検証
+	task, ok := tm.GetTask(taskID)
+	if !ok {
+		t.Fatal("GetTask: task not found")
+	}
+	if task.Status != agent.TaskStatusCompleted {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusCompleted)
+	}
+
+	// 出力に "smart-task" が含まれること
+	output := task.FullOutput()
+	if !strings.Contains(output, "smart-task") {
+		t.Errorf("FullOutput should contain 'smart-task', got: %q", output)
+	}
+}
+
+func TestTaskManager_SpawnTask_Smart_NoBrain(t *testing.T) {
+	runner := newSmartTestRunner()
+	events := make(chan agent.Event, 64)
+
+	// subBrain を nil にして作成
+	tm := agent.NewTaskManager(runner, nil, events, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := tm.SpawnTask(ctx, agent.SpawnTaskRequest{
+		Kind:       agent.TaskKindSmart,
+		Goal:       "should fail",
+		TargetHost: "10.0.0.5",
+	})
+	if err == nil {
+		t.Fatal("SpawnTask (smart) should return error when subBrain is nil")
+	}
+	if !strings.Contains(err.Error(), "sub-brain") {
+		t.Errorf("Error should mention sub-brain, got: %q", err.Error())
+	}
+}

--- a/internal/agent/task_runner.go
+++ b/internal/agent/task_runner.go
@@ -1,0 +1,105 @@
+// Package agent - task_runner.go は単一コマンドをバックグラウンドで実行する TaskRunner を定義する。
+package agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/mcp"
+	"github.com/0x6d61/pentecter/internal/tools"
+)
+
+// TaskRunner は SubTask（runner kind）のコマンドを実行する。
+type TaskRunner struct {
+	runner *tools.CommandRunner
+	mcpMgr *mcp.MCPManager
+	events chan<- Event
+}
+
+// NewTaskRunner は TaskRunner を構築する。
+func NewTaskRunner(runner *tools.CommandRunner, mcpMgr *mcp.MCPManager, events chan<- Event) *TaskRunner {
+	return &TaskRunner{
+		runner: runner,
+		mcpMgr: mcpMgr,
+		events: events,
+	}
+}
+
+// Run はサブタスクのコマンドを実行する。完了まで blocking する。
+func (tr *TaskRunner) Run(ctx context.Context, task *SubTask) {
+	task.Status = TaskStatusRunning
+	task.StartedAt = time.Now()
+
+	// コマンドが空の場合はエラー
+	if task.Command == "" {
+		task.Status = TaskStatusFailed
+		task.Error = "command is empty"
+		task.CompletedAt = time.Now()
+		task.Complete()
+		tr.emitComplete(task)
+		return
+	}
+
+	// ForceRun で実行（承認チェックなし）
+	linesCh, resultCh := tr.runner.ForceRun(ctx, task.Command)
+
+	// ストリーム出力を収集
+	for line := range linesCh {
+		if line.Content == "" {
+			continue
+		}
+		task.AppendOutput(line.Content)
+		tr.emit(Event{
+			Type:    EventSubTaskLog,
+			TaskID:  task.ID,
+			Source:  SourceTool,
+			Message: line.Content,
+		})
+	}
+
+	// 結果を取得
+	result := <-resultCh
+	task.ExitCode = result.ExitCode
+	task.CompletedAt = time.Now()
+
+	if result.Err != nil {
+		task.Status = TaskStatusFailed
+		task.Error = result.Err.Error()
+	} else if result.ExitCode != 0 {
+		// exit code が非ゼロでもコンテキストキャンセルの可能性をチェック
+		if ctx.Err() != nil {
+			task.Status = TaskStatusCancelled
+			task.Error = "cancelled"
+		} else {
+			task.Status = TaskStatusFailed
+			task.Error = "non-zero exit code"
+		}
+	} else {
+		task.Status = TaskStatusCompleted
+	}
+
+	// Entity 抽出結果をタスクに保存
+	if result.Entities != nil {
+		task.Entities = result.Entities
+	}
+
+	task.Complete()
+	tr.emitComplete(task)
+}
+
+// emit はイベントを送信する（ブロックしない）。
+func (tr *TaskRunner) emit(e Event) {
+	select {
+	case tr.events <- e:
+	default:
+	}
+}
+
+// emitComplete は完了イベントを送信する。
+func (tr *TaskRunner) emitComplete(task *SubTask) {
+	tr.emit(Event{
+		Type:    EventSubTaskComplete,
+		TaskID:  task.ID,
+		Message: task.Summary(),
+	})
+}

--- a/internal/agent/task_runner_test.go
+++ b/internal/agent/task_runner_test.go
@@ -1,0 +1,120 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/agent"
+)
+
+func TestTaskRunner_Run_EchoCommand(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tr := agent.NewTaskRunner(runner, nil, events)
+
+	task := agent.NewSubTask("task-1", agent.TaskKindRunner, "echo test")
+	task.Command = "echo hello-runner"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Run in goroutine (it blocks until done)
+	go tr.Run(ctx, task)
+
+	// Wait for task to complete
+	select {
+	case <-task.Done():
+		// OK
+	case <-time.After(4 * time.Second):
+		t.Fatal("timeout waiting for task to complete")
+	}
+
+	// Verify status
+	if task.Status != agent.TaskStatusCompleted {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusCompleted)
+	}
+
+	// Verify output contains the echo content
+	output := task.FullOutput()
+	if !strings.Contains(output, "hello-runner") {
+		t.Errorf("FullOutput should contain 'hello-runner', got: %q", output)
+	}
+
+	// Verify EventSubTaskComplete was emitted
+	gotComplete := false
+	deadline := time.After(1 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventSubTaskComplete && e.TaskID == "task-1" {
+				gotComplete = true
+			}
+		case <-deadline:
+			goto done
+		}
+	}
+done:
+	if !gotComplete {
+		t.Error("expected EventSubTaskComplete to be emitted")
+	}
+}
+
+func TestTaskRunner_Run_EmptyCommand(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tr := agent.NewTaskRunner(runner, nil, events)
+
+	task := agent.NewSubTask("task-2", agent.TaskKindRunner, "empty test")
+	task.Command = ""
+
+	ctx := context.Background()
+	go tr.Run(ctx, task)
+
+	// Wait for task to complete
+	select {
+	case <-task.Done():
+		// OK
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for task to complete")
+	}
+
+	if task.Status != agent.TaskStatusFailed {
+		t.Errorf("Status: got %q, want %q", task.Status, agent.TaskStatusFailed)
+	}
+	if task.Error == "" {
+		t.Error("Error should be set for empty command")
+	}
+}
+
+func TestTaskRunner_Run_ContextCancel(t *testing.T) {
+	runner := newTestRunner()
+	events := make(chan agent.Event, 64)
+
+	tr := agent.NewTaskRunner(runner, nil, events)
+
+	// Cancel the context before running — should cause immediate failure
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	task := agent.NewSubTask("task-3", agent.TaskKindRunner, "cancel test")
+	task.Command = "echo should-not-run"
+
+	go tr.Run(ctx, task)
+
+	// Wait for task to complete
+	select {
+	case <-task.Done():
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for cancelled task to complete")
+	}
+
+	// Status should be failed or cancelled (pre-cancelled context → command start fails)
+	if task.Status != agent.TaskStatusFailed && task.Status != agent.TaskStatusCancelled {
+		t.Errorf("Status: got %q, want failed or cancelled", task.Status)
+	}
+}

--- a/internal/agent/task_tree.go
+++ b/internal/agent/task_tree.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"fmt"
+	"sort"
+)
+
+// TaskTreeNode はタスクツリーの1ノード。
+type TaskTreeNode struct {
+	Label    string          // 表示ラベル
+	Tasks    []*SubTask      // このノードに属するタスク
+	Children []*TaskTreeNode // 子ノード
+}
+
+// BuildTaskTree はターゲットの全 SubTask からツリー構造を自動生成する。
+// ポート番号ごとにグループ化し、ポート未指定（0）のタスクは "General" にまとめる。
+func BuildTaskTree(targetHost string, tasks []*SubTask) *TaskTreeNode {
+	root := &TaskTreeNode{Label: targetHost}
+
+	type portKey struct {
+		Port    int
+		Service string
+	}
+	portGroups := map[portKey]*TaskTreeNode{}
+	var general []*SubTask
+	var portKeys []portKey // 順序保持用
+
+	for _, task := range tasks {
+		meta := task.GetMetadata()
+
+		if meta.Port > 0 {
+			key := portKey{Port: meta.Port, Service: meta.Service}
+			node, ok := portGroups[key]
+			if !ok {
+				label := fmt.Sprintf("Port %d", meta.Port)
+				if meta.Service != "" {
+					label += fmt.Sprintf(" (%s)", meta.Service)
+				}
+				node = &TaskTreeNode{Label: label}
+				portGroups[key] = node
+				portKeys = append(portKeys, key)
+			}
+			node.Tasks = append(node.Tasks, task)
+		} else {
+			general = append(general, task)
+		}
+	}
+
+	// ポート番号順にソート
+	sort.Slice(portKeys, func(i, j int) bool {
+		return portKeys[i].Port < portKeys[j].Port
+	})
+
+	for _, key := range portKeys {
+		root.Children = append(root.Children, portGroups[key])
+	}
+
+	if len(general) > 0 {
+		root.Children = append(root.Children, &TaskTreeNode{Label: "General", Tasks: general})
+	}
+
+	return root
+}

--- a/internal/agent/task_tree_test.go
+++ b/internal/agent/task_tree_test.go
@@ -1,0 +1,88 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/0x6d61/pentecter/internal/agent"
+)
+
+func TestBuildTaskTree_GroupByPort(t *testing.T) {
+	// 4つのサブタスクを作成
+	task1 := agent.NewSubTask("task-1", agent.TaskKindRunner, "ssh scan")
+	task1.Metadata = agent.TaskMetadata{Port: 22, Service: "ssh", Phase: "recon"}
+
+	task2 := agent.NewSubTask("task-2", agent.TaskKindRunner, "http scan")
+	task2.Metadata = agent.TaskMetadata{Port: 80, Service: "http", Phase: "recon"}
+
+	task3 := agent.NewSubTask("task-3", agent.TaskKindSmart, "http enum")
+	task3.Metadata = agent.TaskMetadata{Port: 80, Service: "http", Phase: "enum"}
+
+	task4 := agent.NewSubTask("task-4", agent.TaskKindRunner, "general recon")
+	// task4: port=0 (no port metadata)
+
+	tasks := []*agent.SubTask{task1, task2, task3, task4}
+	root := agent.BuildTaskTree("10.0.0.5", tasks)
+
+	// ルートラベルの確認
+	if root.Label != "10.0.0.5" {
+		t.Errorf("root.Label: got %q, want %q", root.Label, "10.0.0.5")
+	}
+
+	// 3つの子ノード: "Port 22 (ssh)", "Port 80 (http)", "General"
+	if len(root.Children) != 3 {
+		t.Fatalf("root.Children: got %d, want 3", len(root.Children))
+	}
+
+	// ポート番号順にソートされるので Port 22 が最初
+	if root.Children[0].Label != "Port 22 (ssh)" {
+		t.Errorf("child[0].Label: got %q, want %q", root.Children[0].Label, "Port 22 (ssh)")
+	}
+	if len(root.Children[0].Tasks) != 1 {
+		t.Errorf("Port 22 tasks: got %d, want 1", len(root.Children[0].Tasks))
+	}
+
+	if root.Children[1].Label != "Port 80 (http)" {
+		t.Errorf("child[1].Label: got %q, want %q", root.Children[1].Label, "Port 80 (http)")
+	}
+	if len(root.Children[1].Tasks) != 2 {
+		t.Errorf("Port 80 tasks: got %d, want 2", len(root.Children[1].Tasks))
+	}
+
+	if root.Children[2].Label != "General" {
+		t.Errorf("child[2].Label: got %q, want %q", root.Children[2].Label, "General")
+	}
+	if len(root.Children[2].Tasks) != 1 {
+		t.Errorf("General tasks: got %d, want 1", len(root.Children[2].Tasks))
+	}
+}
+
+func TestBuildTaskTree_EmptyTasks(t *testing.T) {
+	root := agent.BuildTaskTree("10.0.0.5", nil)
+
+	if root.Label != "10.0.0.5" {
+		t.Errorf("root.Label: got %q, want %q", root.Label, "10.0.0.5")
+	}
+	if len(root.Children) != 0 {
+		t.Errorf("root.Children: got %d, want 0", len(root.Children))
+	}
+}
+
+func TestBuildTaskTree_AllGeneral(t *testing.T) {
+	task1 := agent.NewSubTask("task-1", agent.TaskKindRunner, "general scan 1")
+	// port=0 (default)
+	task2 := agent.NewSubTask("task-2", agent.TaskKindRunner, "general scan 2")
+	// port=0 (default)
+
+	tasks := []*agent.SubTask{task1, task2}
+	root := agent.BuildTaskTree("10.0.0.5", tasks)
+
+	if len(root.Children) != 1 {
+		t.Fatalf("root.Children: got %d, want 1", len(root.Children))
+	}
+	if root.Children[0].Label != "General" {
+		t.Errorf("child[0].Label: got %q, want %q", root.Children[0].Label, "General")
+	}
+	if len(root.Children[0].Tasks) != 2 {
+		t.Errorf("General tasks: got %d, want 2", len(root.Children[0].Tasks))
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -527,6 +527,10 @@ func (m *Model) handleAgentEvent(e agent.Event) {
 			Type:     agent.EventCommandResult,
 			ExitCode: e.ExitCode,
 		})
+	case agent.EventSubTaskLog:
+		t.AddLog(e.Source, e.Message)
+	case agent.EventSubTaskComplete:
+		t.AddLog(agent.SourceSystem, "Task completed: "+e.Message)
 	}
 
 	m.syncListItems()

--- a/pkg/schema/action.go
+++ b/pkg/schema/action.go
@@ -29,6 +29,18 @@ const (
 	// ActionCallMCP は MCP サーバーのツールを呼び出す。
 	// Brain が MCP ツール（Playwright ブラウザ操作等）を使用する際に使用する。
 	ActionCallMCP ActionType = "call_mcp"
+
+	// ActionSpawnTask はバックグラウンドタスクを生成する。
+	ActionSpawnTask ActionType = "spawn_task"
+
+	// ActionWait は実行中の SubTask の完了を待つ。
+	ActionWait ActionType = "wait"
+
+	// ActionCheckTask は実行中の SubTask の部分出力を取得する。
+	ActionCheckTask ActionType = "check_task"
+
+	// ActionKillTask は実行中の SubTask をキャンセルする。
+	ActionKillTask ActionType = "kill_task"
 )
 
 // Action is the JSON payload emitted by the Brain (LLM).
@@ -53,6 +65,15 @@ type Action struct {
 	MCPTool   string         `json:"mcp_tool,omitempty"`
 	// MCPArgs は MCP ツールに渡す引数（ActionCallMCP 時に使用）。
 	MCPArgs   map[string]any `json:"mcp_args,omitempty"`
+
+	// SubTask 関連フィールド
+	TaskID       string `json:"task_id,omitempty"`        // wait/check_task/kill_task: 対象タスクID
+	TaskKind     string `json:"task_kind,omitempty"`      // spawn_task: "runner" or "smart"
+	TaskGoal     string `json:"task_goal,omitempty"`      // spawn_task: タスクの目的
+	TaskMaxTurns int    `json:"task_max_turns,omitempty"` // spawn_task (smart): 最大ターン数
+	TaskPort     int    `json:"task_port,omitempty"`      // spawn_task: メタデータ - ポート
+	TaskService  string `json:"task_service,omitempty"`   // spawn_task: メタデータ - サービス名
+	TaskPhase    string `json:"task_phase,omitempty"`     // spawn_task: メタデータ - フェーズ
 }
 
 // Memory は Brain がナレッジグラフに記録する発見物。


### PR DESCRIPTION
## Summary
- Redesign agent loop from sequential blocking to non-blocking orchestrator with background SubTasks
- **TaskRunner** (no LLM): fire-and-forget command execution in goroutines
- **SmartSubAgent** (small LLM): multi-step autonomous sub-agent with mini brain loop
- **TaskManager**: centralized task lifecycle management (spawn/wait/check/kill)
- **TaskTree**: auto-generated task grouping by port/service/phase
- 4 new Brain action types: `spawn_task`, `wait`, `check_task`, `kill_task`
- SubBrain configuration via `SUBAGENT_MODEL` / `SUBAGENT_PROVIDER` env vars

## New files (12)
- `internal/agent/subtask.go` — SubTask type with pull-based output buffer
- `internal/agent/task_runner.go` — TaskRunner (no LLM)
- `internal/agent/smart_subagent.go` — SmartSubAgent (small LLM)
- `internal/agent/task_manager.go` — TaskManager lifecycle
- `internal/agent/task_tree.go` — TaskTree auto-generation
- `internal/agent/loop_tasks.go` — Loop handler methods for new actions
- `docs/architecture_design/subagent-architecture.md` — Design document
- 6 test files (subtask, task_runner, smart_subagent, task_manager, task_tree, loop integration)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/...` — all 7 packages pass
- [x] `golangci-lint run` — 0 issues
- [ ] Manual test: spawn nmap scan as background task, wait for results

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)