### PR TITLE
feat: Log folding UI — auto-collapse long tool output

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -94,3 +94,6 @@ var (
 				Foreground(colorDanger).
 				Bold(true)
 )
+
+// foldIndicatorStyle は折りたたみ行の「⋯ +N Lines (Ctrl+O)」スタイル。
+var foldIndicatorStyle = lipgloss.NewStyle().Foreground(colorMuted).Italic(true)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -141,6 +141,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case FocusViewport:
+			if msg.String() == "ctrl+o" {
+				m.logsExpanded = !m.logsExpanded
+				m.rebuildViewport()
+				return m, nil
+			}
 			m.viewport, cmd = m.viewport.Update(msg)
 			cmds = append(cmds, cmd)
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -8,6 +8,13 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
+const (
+	// foldThreshold はこの行数を超えるツール出力を自動折りたたみする閾値。
+	foldThreshold = 5
+	// foldPreviewLines は折りたたみ時に表示するプレビュー行数。
+	foldPreviewLines = 3
+)
+
 // View implements tea.Model and renders the full Commander Console layout.
 func (m Model) View() string {
 	if !m.ready {
@@ -325,4 +332,17 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// foldToolOutput は長いツール出力を折りたたむ。
+// foldThreshold 行超のメッセージの場合、最初の foldPreviewLines 行 + "⋯ +N Lines (Ctrl+O)" を返す。
+func foldToolOutput(message string) (folded string, wasFolded bool) {
+	lines := strings.Split(message, "\n")
+	if len(lines) <= foldThreshold {
+		return message, false
+	}
+	preview := strings.Join(lines[:foldPreviewLines], "\n")
+	remaining := len(lines) - foldPreviewLines
+	indicator := foldIndicatorStyle.Render(fmt.Sprintf("  ⋯ +%d Lines (Ctrl+O)", remaining))
+	return preview + "\n" + indicator, true
 }


### PR DESCRIPTION
## Summary
- Auto-fold SourceTool logs exceeding 5 lines to first 3 lines + `⋯ +N Lines (Ctrl+O)`
- Ctrl+O toggles all folds (expand/collapse) when viewport is focused
- AI/System/User logs are never folded

## Changes
- `internal/tui/view.go` — `foldToolOutput()` function + constants
- `internal/tui/model.go` — `logsExpanded` flag + integration in `rebuildViewport()`
- `internal/tui/update.go` — Ctrl+O keybinding
- `internal/tui/styles.go` — `foldIndicatorStyle`
- `internal/tui/view_test.go` — 4 new tests

## Test plan
- [x] `go test ./internal/tui/...` — all pass (4 new fold tests)
- [x] `go test ./internal/...` — all 7 packages pass
- [x] `golangci-lint run` — 0 issues
- [ ] Manual: verify long curl/nmap output folds in TUI, Ctrl+O expands

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)