### PR TITLE
fix: check_task ポーリング無限ループ防止 + SubTask タイトル折り返し

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -67,6 +67,10 @@ type Loop struct {
 
 	// コマンド実行時間計測用
 	cmdStartTime time.Time
+
+	// CheckTaskCooldown は check_task で新出力がないときのクールダウン時間。
+	// 0 の場合はデフォルト (checkTaskCooldown) を使用。テスト用にオーバーライド可。
+	CheckTaskCooldown time.Duration
 }
 
 // NewLoop は Loop を構築する。
@@ -222,7 +226,7 @@ func (l *Loop) Run(ctx context.Context) {
 			l.handleWait(ctx, action)
 
 		case schema.ActionCheckTask:
-			l.handleCheckTask(action)
+			l.handleCheckTask(ctx, action)
 
 		case schema.ActionKillTask:
 			l.handleKillTask(action)

--- a/internal/agent/task_manager.go
+++ b/internal/agent/task_manager.go
@@ -110,6 +110,13 @@ func (tm *TaskManager) GetTask(id string) (*SubTask, bool) {
 	return task, ok
 }
 
+// InjectTask はテスト用にタスクを直接注入する。
+func (tm *TaskManager) InjectTask(id string, task *SubTask) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.tasks[id] = task
+}
+
 // WaitAny は完了したサブタスクの ID を1つ返す。
 // コンテキストがキャンセルされた場合は空文字を返す。
 func (tm *TaskManager) WaitAny(ctx context.Context) string {


### PR DESCRIPTION
## Summary
- **check_task クールダウン**: 新しい出力がなくタスクが running の場合、10秒待ってから返す。自律ループの高速ポーリングを防止
- **SubTask タイトル折り返し**: ビューポート幅を超えるゴールテキストを折り返して表示

## 変更内容

### check_task クールダウン
```
Before: check_task → 即座に返る → Brain.Think() → check_task → 即座に返る → ∞
After:  check_task → 10秒待つ → 再取得 → 返す → Brain.Think() → check_task → 10秒待つ → ...
```
- `ctx.Done()` でユーザー操作中断可能
- `Loop.CheckTaskCooldown` でテスト用にオーバーライド可
- `TaskManager.InjectTask()` テストヘルパー追加

### SubTask タイトル折り返し
- `renderSubTaskBlock(b, width, spinnerFrame)` に `width` パラメータ追加
- 長いゴールはインデント付きで複数行に折り返し

## Test plan
- [x] `go build ./...` — ビルド成功
- [x] `go vet ./...` — 静的解析パス
- [x] `go test ./internal/...` — 全テストパス
- [x] `TestCheckTaskCooldown_Unit` — クールダウン発動を確認
- [x] `TestRenderSubTaskBlock_LongGoal_Wraps` — 折り返し動作確認

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)