### PR TITLE
feat: ASSESSMENT WORKFLOW 強化 + SERVICE PRIORITY (#54)

### DIFF
--- a/internal/brain/prompt_test.go
+++ b/internal/brain/prompt_test.go
@@ -523,6 +523,46 @@ func TestBuildSystemPrompt_ContainsAssessmentWorkflow(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPrompt_WorkflowRequiresSearchKnowledge(t *testing.T) {
+	prompt := buildSystemPrompt(nil, nil, false)
+
+	// ANALYZE ステップで search_knowledge の使用が必須であること
+	if !strings.Contains(prompt, "search_knowledge") {
+		t.Error("ASSESSMENT WORKFLOW ANALYZE step should require search_knowledge")
+	}
+}
+
+func TestBuildSystemPrompt_ContainsServicePriority(t *testing.T) {
+	prompt := buildSystemPrompt(nil, nil, false)
+
+	if !strings.Contains(prompt, "SERVICE PRIORITY") {
+		t.Error("expected SERVICE PRIORITY section in main agent prompt")
+	}
+	// 非 Web サービスが Web より前にリストされていること
+	for _, svc := range []string{"Database", "Authentication", "Remote access"} {
+		if !strings.Contains(prompt, svc) {
+			t.Errorf("SERVICE PRIORITY should list %q", svc)
+		}
+	}
+}
+
+func TestBuildSystemPrompt_PlanRequiresConcreteTools(t *testing.T) {
+	prompt := buildSystemPrompt(nil, nil, false)
+
+	// PLAN ステップで具体的なツール名を含む攻撃計画が必要であること
+	if !strings.Contains(prompt, "numbered attack plan") {
+		t.Error("PLAN step should require numbered attack plan with concrete tools")
+	}
+}
+
+func TestBuildSystemPrompt_SubAgent_ExcludesServicePriority(t *testing.T) {
+	prompt := buildSystemPrompt(nil, nil, true)
+
+	if strings.Contains(prompt, "SERVICE PRIORITY") {
+		t.Error("SubAgent prompt should NOT contain SERVICE PRIORITY")
+	}
+}
+
 func TestBuildSystemPrompt_ContainsRestrictedActions(t *testing.T) {
 	prompt := buildSystemPrompt(nil, nil, false)
 


### PR DESCRIPTION
## Summary
- RECORD ステップ: 全ポートをテーブル形式で記録必須化
- ANALYZE ステップ: 各サービスに対し `search_knowledge` の使用を MUST 化
- PLAN ステップ: 具体的なツール名を含む番号付き攻撃計画を必須化
- SERVICE PRIORITY セクション追加: Database > Auth > File sharing > Remote access > Web（Web は最後）

## 背景
HTB Eighteen テストで nmap が MSSQL (1433), Kerberos (88), WinRM (5985) を検出しているにも関わらず、エージェントが Web 偵察に走る問題が継続していた。

## Test plan
- [x] `go build ./...` — OK
- [x] `go vet ./...` — OK
- [x] `go test ./internal/... ./pkg/...` — 全9パッケージ GREEN
- [x] `golangci-lint run` — 0 issues
- [ ] HTB Eighteen で実機テスト（ビルド後に確認）

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)