### PR TITLE
fix: Target mutex synchronization for race conditions

### DIFF
--- a/internal/agent/target.go
+++ b/internal/agent/target.go
@@ -2,6 +2,8 @@
 package agent
 
 import (
+	"sync"
+
 	"github.com/0x6d61/pentecter/internal/tools"
 )
 
@@ -56,19 +58,57 @@ type Proposal struct {
 
 // Target represents a discovered host and the full state of its pentest session.
 // Host は IP アドレスまたはドメイン名（例: "10.0.0.5", "example.com"）。
+//
+// mu は Status, Proposal, Entities フィールドを保護する RWMutex。
+// Loop goroutine は SetStatusSafe / SetProposal / ClearProposal / AddEntities で書き込み、
+// TUI goroutine は GetStatus / GetProposal / SnapshotEntities で安全に読み取る。
+// Blocks は TUI goroutine のみが読み書きするため mu の保護対象外。
 type Target struct {
-	ID     int
-	Host   string // IP アドレスまたはドメイン名
-	Status Status
-	Blocks   []*DisplayBlock // grouped display blocks
+	mu       sync.RWMutex
+	ID       int
+	Host     string // IP アドレスまたはドメイン名
+	Status   Status
+	Blocks   []*DisplayBlock // grouped display blocks (TUI-only, no mutex needed)
 	Proposal *Proposal
 	// Entities はツール出力から抽出された発見済みエンティティ（ナレッジグラフ）。
 	// Brain のスナップショット生成に使われる。
 	Entities []tools.Entity
 }
 
+// GetStatus は Status をスレッドセーフに返す。
+func (t *Target) GetStatus() Status {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.Status
+}
+
+// SetStatusSafe は Status をスレッドセーフに設定する。Loop goroutine から使用。
+func (t *Target) SetStatusSafe(s Status) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Status = s
+}
+
+// GetProposal は Proposal をスレッドセーフに返す。
+func (t *Target) GetProposal() *Proposal {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.Proposal
+}
+
+// SnapshotEntities はエンティティのコピーをスレッドセーフに返す。
+func (t *Target) SnapshotEntities() []tools.Entity {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	cp := make([]tools.Entity, len(t.Entities))
+	copy(cp, t.Entities)
+	return cp
+}
+
 // AddEntities は新しいエンティティを重複なしで追加する。
 func (t *Target) AddEntities(entities []tools.Entity) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	seen := make(map[string]bool, len(t.Entities))
 	for _, e := range t.Entities {
 		seen[string(e.Type)+":"+e.Value] = true
@@ -108,6 +148,8 @@ func (t *Target) LastBlock() *DisplayBlock {
 
 // SetProposal queues a pending action and transitions status to PAUSED.
 func (t *Target) SetProposal(p *Proposal) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.Proposal = p
 	if p != nil {
 		t.Status = StatusPaused
@@ -116,5 +158,7 @@ func (t *Target) SetProposal(p *Proposal) {
 
 // ClearProposal removes the pending proposal without changing status.
 func (t *Target) ClearProposal() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.Proposal = nil
 }

--- a/internal/agent/team.go
+++ b/internal/agent/team.go
@@ -126,11 +126,14 @@ func (t *Team) SetBrain(br brain.Brain) {
 	}
 }
 
-// Loops は管理している全 Loop を返す（TUI のターゲットリスト表示用）。
+// Loops は管理している全 Loop のコピーを返す（TUI のターゲットリスト表示用）。
+// 返されるスライスは呼び出し元で安全にイテレートできる。
 func (t *Team) Loops() []*Loop {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.loops
+	cp := make([]*Loop, len(t.loops))
+	copy(cp, t.loops)
+	return cp
 }
 
 // TaskManager は TaskManager を返す（TUI からアクセス用）。

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -99,9 +99,10 @@ type targetListItem struct {
 }
 
 func (i targetListItem) Title() string {
-	icon := i.t.Status.Icon()
+	status := i.t.GetStatus()
+	icon := status.Icon()
 	var coloredIcon string
-	switch i.t.Status {
+	switch status {
 	case agent.StatusPwned:
 		coloredIcon = statusPwnedStyle.Render(icon)
 	case agent.StatusRunning:
@@ -119,11 +120,12 @@ func (i targetListItem) Title() string {
 }
 
 func (i targetListItem) Description() string {
+	status := i.t.GetStatus()
 	extra := ""
-	if i.t.Proposal != nil {
+	if i.t.GetProposal() != nil {
 		extra = lipgloss.NewStyle().Foreground(colorWarning).Render(" ⚠ APPROVAL")
 	}
-	return fmt.Sprintf("[%s]%s", i.t.Status, extra)
+	return fmt.Sprintf("[%s]%s", status, extra)
 }
 
 func (i targetListItem) FilterValue() string { return i.t.Host }
@@ -239,7 +241,7 @@ func (m *Model) rebuildViewport() {
 	content := renderBlocks(t.Blocks, vpWidth, m.logsExpanded, m.spinner.View())
 
 	// プロポーザルをビューポートの末尾に追加
-	if p := t.Proposal; p != nil {
+	if p := t.GetProposal(); p != nil {
 		content += m.renderProposal(p)
 	}
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -69,7 +69,7 @@ func (m Model) renderStatusBar() string {
 		targetInfo = fmt.Sprintf(
 			"Focus: %s [%s]",
 			lipgloss.NewStyle().Foreground(colorWarning).Render(t.Host),
-			t.Status,
+			t.GetStatus(),
 		)
 	} else {
 		targetInfo = lipgloss.NewStyle().Foreground(colorMuted).Render("No target selected")


### PR DESCRIPTION
## Summary
- Add `sync.RWMutex` to `Target` struct to prevent race conditions between Loop and TUI goroutines
- Loop goroutine uses `SetStatusSafe()` instead of direct `target.Status = ...` assignment (15 occurrences fixed)
- TUI goroutine uses `GetStatus()`/`GetProposal()` for reads that may race with Loop writes
- `Team.Loops()` returns slice copy to prevent TOCTOU race on `AddTarget()`
- 8 new concurrency tests (parallel reader/writer stress tests)

## Root Cause
`Target.Status`, `Target.Proposal`, `Target.Entities` were written by Loop goroutine and read by TUI goroutine without synchronization, causing `runtime.boundsError` panics.

## Test plan
- [x] `TestTarget_ConcurrentStatusAccess` — 10 writers x 10 readers x 100 ops
- [x] `TestTarget_ConcurrentProposalAccess` — parallel proposal set/get
- [x] `TestTarget_ConcurrentEntityAccess` — parallel entity add/snapshot
- [x] All existing tests pass (9 packages)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)