### PR TITLE
fix: global commands work without target + model display

### DIFF
--- a/cmd/pentecter/main.go
+++ b/cmd/pentecter/main.go
@@ -233,6 +233,10 @@ Chat commands:
 	m := tui.NewWithTargets(targets)
 	m.ConnectTeam(team, events, approveMap, userMsgMap)
 
+	// Set initial model info for status bar
+	m.CurrentProvider = string(selectedProvider)
+	m.CurrentModel = brainCfg.Model
+
 	// Connect CommandRunner for /approve command
 	m.Runner = runner
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -78,6 +78,13 @@ type Model struct {
 	// logsExpanded が true の場合、すべてのログ内容を折りたたまずに表示する。
 	logsExpanded bool
 
+	// Global system logs — shown when no target is active
+	globalLogs []string
+
+	// Current model info — displayed in status bar
+	CurrentProvider string
+	CurrentModel    string
+
 	// Select mode fields — used by /model, /approve to show interactive selection.
 	inputMode      InputMode
 	selectOptions  []SelectOption
@@ -225,7 +232,18 @@ func (m *Model) activeTarget() *agent.Target {
 func (m *Model) rebuildViewport() {
 	t := m.activeTarget()
 	if t == nil {
-		m.viewport.SetContent("  No target selected.\n\n  Add a target by entering an IP address:\n    e.g. 10.0.0.5 / /target example.com\n\n  Skills: /web-recon, /full-scan, /sqli-check")
+		var sb strings.Builder
+		sb.WriteString("  No target selected.\n\n")
+		sb.WriteString("  Add a target by entering an IP address:\n")
+		sb.WriteString("    e.g. 10.0.0.5 / /target example.com\n\n")
+		sb.WriteString("  Commands: /model, /approve, /curl, /ssh\n")
+		if len(m.globalLogs) > 0 {
+			sb.WriteString("\n")
+			for _, log := range m.globalLogs {
+				sb.WriteString("  [SYS] " + log + "\n")
+			}
+		}
+		m.viewport.SetContent(sb.String())
 		return
 	}
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -478,6 +478,8 @@ func (m *Model) switchModel(provider brain.Provider, model string) {
 	if m.team != nil {
 		m.team.SetBrain(newBrain)
 	}
+	m.CurrentProvider = string(provider)
+	m.CurrentModel = model
 	msg := fmt.Sprintf("Switched to %s", provider)
 	if model != "" {
 		msg += "/" + model
@@ -489,6 +491,8 @@ func (m *Model) switchModel(provider brain.Provider, model string) {
 func (m *Model) logSystem(msg string) {
 	if t := m.activeTarget(); t != nil {
 		t.AddBlock(agent.NewSystemBlock(msg))
+	} else {
+		m.globalLogs = append(m.globalLogs, msg)
 	}
 	m.syncListItems()
 	m.rebuildViewport()

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -75,10 +75,23 @@ func (m Model) renderStatusBar() string {
 		targetInfo = lipgloss.NewStyle().Foreground(colorMuted).Render("No target selected")
 	}
 
+	// Model info
+	var modelInfo string
+	if m.CurrentModel != "" {
+		modelInfo = lipgloss.NewStyle().Foreground(colorMuted).Render(
+			fmt.Sprintf("Model: %s/%s", m.CurrentProvider, m.CurrentModel))
+	} else if m.CurrentProvider != "" {
+		modelInfo = lipgloss.NewStyle().Foreground(colorMuted).Render(
+			fmt.Sprintf("Model: %s", m.CurrentProvider))
+	}
+
 	hint := lipgloss.NewStyle().Foreground(colorMuted).Render("[Tab] Switch pane  [y/n/e] Proposal")
 	focusIndicator := m.renderFocusIndicator()
 
-	left := fmt.Sprintf("%s  %s  %s", appName, targetInfo, focusIndicator)
+	left := appName + "  " + targetInfo + "  " + focusIndicator
+	if modelInfo != "" {
+		left += "  " + modelInfo
+	}
 	gap := strings.Repeat(" ", max(0, m.width-lipgloss.Width(left)-lipgloss.Width(hint)-2))
 
 	return statusBarStyle.Width(m.width).Render(left + gap + hint)


### PR DESCRIPTION
## Summary
- `/model` and `/approve` now show feedback even without an active target
- Status bar displays current model: `Model: anthropic/claude-sonnet-4-6`
- System logs fall back to `globalLogs` when no target is selected

## Test plan
- [x] All 9 packages pass
- [x] Build and vet clean

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)