### PR TITLE
feat: single-pane UI + /targets command

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -12,19 +12,10 @@ var (
 	colorMuted        = lipgloss.Color("#555577") // dim gray — timestamps / hints
 	colorBorder       = lipgloss.Color("#333355") // default border
 	colorBorderActive = lipgloss.Color("#00D7FF") // focused border
-	colorTitle        = lipgloss.Color("#FFFFFF") // pane titles
 )
 
 // Pane borders
 var (
-	leftPaneStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorBorder)
-
-	leftPaneActiveStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(colorBorderActive)
-
 	rightPaneStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(colorBorder)
@@ -63,15 +54,6 @@ var confirmQuitBoxStyle = lipgloss.NewStyle().
 	BorderForeground(colorDanger).
 	Padding(0, 2)
 
-// Status icon color styles
-var (
-	statusIdleStyle     = lipgloss.NewStyle().Foreground(colorMuted)
-	statusScanningStyle = lipgloss.NewStyle().Foreground(colorWarning)
-	statusRunningStyle  = lipgloss.NewStyle().Foreground(colorPrimary)
-	statusPausedStyle   = lipgloss.NewStyle().Foreground(colorWarning).Bold(true)
-	statusPwnedStyle    = lipgloss.NewStyle().Foreground(colorSuccess).Bold(true)
-	statusFailedStyle   = lipgloss.NewStyle().Foreground(colorDanger).Bold(true)
-)
 
 // foldIndicatorStyle は折りたたみ行の「⋯ +N Lines (Ctrl+O)」スタイル。
 var foldIndicatorStyle = lipgloss.NewStyle().Foreground(colorMuted).Italic(true)

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -16,17 +16,6 @@ import (
 // cycleFocus
 // ---------------------------------------------------------------------------
 
-func TestCycleFocus_ListToViewport(t *testing.T) {
-	m := NewWithTargets(nil)
-	m.focus = FocusList
-
-	m.cycleFocus()
-
-	if m.focus != FocusViewport {
-		t.Errorf("expected FocusViewport after cycling from FocusList, got %d", m.focus)
-	}
-}
-
 func TestCycleFocus_ViewportToInput(t *testing.T) {
 	m := NewWithTargets(nil)
 	m.focus = FocusViewport
@@ -38,27 +27,26 @@ func TestCycleFocus_ViewportToInput(t *testing.T) {
 	}
 }
 
-func TestCycleFocus_InputToList(t *testing.T) {
+func TestCycleFocus_InputToViewport(t *testing.T) {
 	m := NewWithTargets(nil)
 	m.focus = FocusInput
 
 	m.cycleFocus()
 
-	if m.focus != FocusList {
-		t.Errorf("expected FocusList after cycling from FocusInput, got %d", m.focus)
+	if m.focus != FocusViewport {
+		t.Errorf("expected FocusViewport after cycling from FocusInput, got %d", m.focus)
 	}
 }
 
 func TestCycleFocus_FullCycle(t *testing.T) {
 	m := NewWithTargets(nil)
-	m.focus = FocusList
+	m.focus = FocusViewport
 
-	m.cycleFocus() // List -> Viewport
 	m.cycleFocus() // Viewport -> Input
-	m.cycleFocus() // Input -> List
+	m.cycleFocus() // Input -> Viewport
 
-	if m.focus != FocusList {
-		t.Errorf("expected FocusList after full cycle, got %d", m.focus)
+	if m.focus != FocusViewport {
+		t.Errorf("expected FocusViewport after full cycle, got %d", m.focus)
 	}
 }
 
@@ -711,13 +699,13 @@ func TestUpdate_TabCyclesFocus(t *testing.T) {
 	m := NewWithTargets(nil)
 	m.handleResize(120, 40)
 	m.ready = true
-	m.focus = FocusList
+	m.focus = FocusViewport
 
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	rm := result.(Model)
 
-	if rm.focus != FocusViewport {
-		t.Errorf("expected FocusViewport after Tab from FocusList, got %d", rm.focus)
+	if rm.focus != FocusInput {
+		t.Errorf("expected FocusInput after Tab from FocusViewport, got %d", rm.focus)
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -17,30 +17,17 @@ func (m Model) View() string {
 	// ── Status bar (1 line) ──────────────────────────────────────────────────
 	statusBar := m.renderStatusBar()
 
-	// ── Left pane: target list ───────────────────────────────────────────────
-	leftContent := m.list.View()
-	var leftStyle lipgloss.Style
-	if m.focus == FocusList {
-		leftStyle = leftPaneActiveStyle.Width(leftPaneOuterWidth - 2)
-	} else {
-		leftStyle = leftPaneStyle.Width(leftPaneOuterWidth - 2)
-	}
-	leftPane := leftStyle.Render(leftContent)
-
-	// ── Right pane: session log ──────────────────────────────────────────────
-	rightOuterW := m.width - leftPaneOuterWidth
-	rightContentW := rightOuterW - 2 // subtract left+right borders
-	rightContent := m.viewport.View()
-	var rightStyle lipgloss.Style
+	// ── Main pane: session log (full width) ─────────────────────────────────
+	mainOuterW := m.width
+	mainContentW := mainOuterW - 2 // subtract left+right borders
+	mainContent := m.viewport.View()
+	var mainStyle lipgloss.Style
 	if m.focus == FocusViewport {
-		rightStyle = rightPaneActiveStyle.Width(rightContentW)
+		mainStyle = rightPaneActiveStyle.Width(mainContentW)
 	} else {
-		rightStyle = rightPaneStyle.Width(rightContentW)
+		mainStyle = rightPaneStyle.Width(mainContentW)
 	}
-	rightPane := rightStyle.Render(rightContent)
-
-	// ── Join panes side by side ──────────────────────────────────────────────
-	panesRow := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+	panesRow := mainStyle.Render(mainContent)
 
 	// ── Input bar (3 lines) ──────────────────────────────────────────────────
 	inputBar := m.renderInputBar()
@@ -85,37 +72,12 @@ func (m Model) renderStatusBar() string {
 			fmt.Sprintf("Model: %s", m.CurrentProvider))
 	}
 
-	hint := lipgloss.NewStyle().Foreground(colorMuted).Render("[Tab] Switch pane  [y/n/e] Proposal")
-	focusIndicator := m.renderFocusIndicator()
-
-	left := appName + "  " + targetInfo + "  " + focusIndicator
+	left := appName + "  " + targetInfo
 	if modelInfo != "" {
 		left += "  " + modelInfo
 	}
-	gap := strings.Repeat(" ", max(0, m.width-lipgloss.Width(left)-lipgloss.Width(hint)-2))
 
-	return statusBarStyle.Width(m.width).Render(left + gap + hint)
-}
-
-// renderFocusIndicator shows which pane is currently focused.
-func (m Model) renderFocusIndicator() string {
-	dim := lipgloss.NewStyle().Foreground(colorMuted)
-	active := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
-
-	list := dim.Render("[LIST]")
-	log := dim.Render("[LOG]")
-	input := dim.Render("[INPUT]")
-
-	switch m.focus {
-	case FocusList:
-		list = active.Render("[LIST]")
-	case FocusViewport:
-		log = active.Render("[LOG]")
-	case FocusInput:
-		input = active.Render("[INPUT]")
-	}
-
-	return fmt.Sprintf("%s %s %s", list, log, input)
+	return statusBarStyle.Width(m.width).Render(left)
 }
 
 // renderInputBar renders the bottom input area with context-aware prefix.
@@ -128,8 +90,6 @@ func (m Model) renderInputBar() string {
 
 	var prefix string
 	switch m.focus {
-	case FocusList:
-		prefix = lipgloss.NewStyle().Foreground(colorMuted).Render("[List] ↑↓ Select target")
 	case FocusViewport:
 		prefix = lipgloss.NewStyle().Foreground(colorMuted).Render("[Log]  ↑↓ Scroll")
 	case FocusInput:

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -97,76 +97,8 @@ func TestRenderStatusBar_NoTarget(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// renderFocusIndicator
-// ---------------------------------------------------------------------------
-
-func TestRenderFocusIndicator_List(t *testing.T) {
-	m := NewWithTargets(nil)
-	m.focus = FocusList
-
-	output := m.renderFocusIndicator()
-
-	if !strings.Contains(output, "[LIST]") {
-		t.Error("expected [LIST] in focus indicator")
-	}
-	if !strings.Contains(output, "[LOG]") {
-		t.Error("expected [LOG] in focus indicator")
-	}
-	if !strings.Contains(output, "[INPUT]") {
-		t.Error("expected [INPUT] in focus indicator")
-	}
-}
-
-func TestRenderFocusIndicator_Viewport(t *testing.T) {
-	m := NewWithTargets(nil)
-	m.focus = FocusViewport
-
-	output := m.renderFocusIndicator()
-
-	if !strings.Contains(output, "[LIST]") {
-		t.Error("expected [LIST] in focus indicator")
-	}
-	if !strings.Contains(output, "[LOG]") {
-		t.Error("expected [LOG] in focus indicator")
-	}
-	if !strings.Contains(output, "[INPUT]") {
-		t.Error("expected [INPUT] in focus indicator")
-	}
-}
-
-func TestRenderFocusIndicator_Input(t *testing.T) {
-	m := NewWithTargets(nil)
-	m.focus = FocusInput
-
-	output := m.renderFocusIndicator()
-
-	if !strings.Contains(output, "[LIST]") {
-		t.Error("expected [LIST] in focus indicator")
-	}
-	if !strings.Contains(output, "[LOG]") {
-		t.Error("expected [LOG] in focus indicator")
-	}
-	if !strings.Contains(output, "[INPUT]") {
-		t.Error("expected [INPUT] in focus indicator")
-	}
-}
-
-// ---------------------------------------------------------------------------
 // renderInputBar
 // ---------------------------------------------------------------------------
-
-func TestRenderInputBar_FocusList(t *testing.T) {
-	m := NewWithTargets(nil)
-	m.handleResize(120, 40)
-	m.ready = true
-	m.focus = FocusList
-
-	output := m.renderInputBar()
-
-	if !strings.Contains(output, "Select target") {
-		t.Errorf("expected '[List]' hint in input bar, got %q", output)
-	}
-}
 
 func TestRenderInputBar_FocusViewport(t *testing.T) {
 	m := NewWithTargets(nil)
@@ -366,91 +298,6 @@ func TestMax_Zero(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// targetListItem — Title, Description, FilterValue
-// ---------------------------------------------------------------------------
-
-func TestTargetListItem_Title_AllStatuses(t *testing.T) {
-	statuses := []struct {
-		status agent.Status
-		icon   string
-	}{
-		{agent.StatusIdle, "○"},
-		{agent.StatusScanning, "◎"},
-		{agent.StatusRunning, "▶"},
-		{agent.StatusPaused, "⏸"},
-		{agent.StatusPwned, "⚡"},
-		{agent.StatusFailed, "✗"},
-	}
-
-	for _, tt := range statuses {
-		t.Run(string(tt.status), func(t *testing.T) {
-			target := agent.NewTarget(1, "10.0.0.1")
-			target.Status = tt.status
-			item := targetListItem{t: target}
-
-			title := item.Title()
-			if !strings.Contains(title, tt.icon) {
-				t.Errorf("expected icon %q in title for status %s, got %q", tt.icon, tt.status, title)
-			}
-			if !strings.Contains(title, "10.0.0.1") {
-				t.Errorf("expected host in title, got %q", title)
-			}
-		})
-	}
-}
-
-func TestTargetListItem_Description_NoProposal(t *testing.T) {
-	target := agent.NewTarget(1, "10.0.0.1")
-	target.Status = agent.StatusScanning
-	item := targetListItem{t: target}
-
-	desc := item.Description()
-	if !strings.Contains(desc, "SCANNING") {
-		t.Errorf("expected SCANNING in description, got %q", desc)
-	}
-	if strings.Contains(desc, "APPROVAL") {
-		t.Error("should not contain APPROVAL without a proposal")
-	}
-}
-
-func TestTargetListItem_Description_WithProposal(t *testing.T) {
-	target := agent.NewTarget(1, "10.0.0.1")
-	target.SetProposal(&agent.Proposal{
-		Description: "Run nmap",
-		Tool:        "nmap",
-		Args:        []string{"-sV"},
-	})
-	item := targetListItem{t: target}
-
-	desc := item.Description()
-	if !strings.Contains(desc, "APPROVAL") {
-		t.Errorf("expected APPROVAL in description when proposal is set, got %q", desc)
-	}
-}
-
-func TestTargetListItem_FilterValue(t *testing.T) {
-	target := agent.NewTarget(1, "10.0.0.5")
-	item := targetListItem{t: target}
-
-	fv := item.FilterValue()
-	if fv != "10.0.0.5" {
-		t.Errorf("expected filter value '10.0.0.5', got %q", fv)
-	}
-}
-
-func TestTargetListItem_Title_UnknownStatus(t *testing.T) {
-	target := agent.NewTarget(1, "10.0.0.1")
-	target.Status = agent.Status("UNKNOWN")
-	item := targetListItem{t: target}
-
-	title := item.Title()
-	// Unknown status should use the default (idle) style
-	if !strings.Contains(title, "10.0.0.1") {
-		t.Errorf("expected host in title for unknown status, got %q", title)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // renderConfirmQuit overlay
 // ---------------------------------------------------------------------------
 
@@ -485,27 +332,4 @@ func TestRenderConfirmQuit_Content(t *testing.T) {
 	}
 }
 
-func TestTargetListItem_Description_AllStatuses(t *testing.T) {
-	statuses := []agent.Status{
-		agent.StatusIdle,
-		agent.StatusScanning,
-		agent.StatusRunning,
-		agent.StatusPaused,
-		agent.StatusPwned,
-		agent.StatusFailed,
-	}
-
-	for _, status := range statuses {
-		t.Run(string(status), func(t *testing.T) {
-			target := agent.NewTarget(1, "10.0.0.1")
-			target.Status = status
-			item := targetListItem{t: target}
-
-			desc := item.Description()
-			if !strings.Contains(desc, string(status)) {
-				t.Errorf("expected status %q in description, got %q", status, desc)
-			}
-		})
-	}
-}
 


### PR DESCRIPTION
## Summary
- Remove left target list pane — viewport now takes full terminal width
- Simplify FocusState to 2 states (Viewport / Input), remove focus indicator
- Simplify status bar to: app name + target info + model info (no hints)
- Add `/targets` command using existing InputSelect mechanism
- Remove `list.Model` dependency (-420 lines, +69 lines)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/...` all green
- [x] `golangci-lint run` — 0 issues

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)