### PR TITLE
feat: searchsploit skill + ASSESSMENT WORKFLOW integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ skills/*
 !skills/.gitkeep
 !skills/curl.md
 !skills/ssh.md
+!skills/searchsploit.md
 
 # Config — only example files tracked
 config/*.yaml

--- a/internal/brain/prompt.go
+++ b/internal/brain/prompt.go
@@ -85,15 +85,18 @@ Proceeding to EXECUTE without completing steps 1-3 is a critical error.
    e.g., "1433/tcp | ms-sql-s | Microsoft SQL Server 2019 | Authentication required"
    Record EVERY open port — not just the ones you plan to attack.
 
-2. ANALYZE: For EACH discovered service, use "search_knowledge" to find attack techniques.
-   Then use "think" action to create a prioritized attack scenario considering
-   ALL discovered services — not just web. For each service, evaluate:
-   - Known CVEs for the specific version (use search_knowledge)
-   - Default credentials or misconfigurations
-   - Service-specific attack vectors and tools
+2. ANALYZE: For EACH discovered service:
+   a. Use "search_knowledge" to find attack techniques from the knowledge base.
+   b. Use "run" with searchsploit to find known exploits for the specific version:
+      searchsploit "<service> <version>" (e.g., searchsploit "Apache 2.4.49")
+   c. Use "think" action to create a prioritized attack scenario considering
+      ALL discovered services — not just web. For each service, evaluate:
+      - Known CVEs and exploits (from searchsploit results)
+      - Default credentials or misconfigurations
+      - Service-specific attack vectors and tools
    Use search_knowledge once per service — do NOT search the same service twice.
-   Once you have knowledge results, move on to the next service or to PLAN.
-   Example: nmap finds MSSQL 1433 → search_knowledge "mssql pentesting impacket" → done for MSSQL, move on
+   Once you have knowledge + searchsploit results, move on to the next service or to PLAN.
+   Example: nmap finds MSSQL 1433 → search_knowledge "mssql pentesting" → searchsploit "Microsoft SQL Server 2019" → done for MSSQL, move on
 
 3. PLAN: Record a numbered attack plan with "memory" action (type: note).
    Each entry MUST include the specific tool to use:

--- a/internal/brain/prompt_test.go
+++ b/internal/brain/prompt_test.go
@@ -532,6 +532,15 @@ func TestBuildSystemPrompt_WorkflowRequiresSearchKnowledge(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPrompt_WorkflowRequiresSearchsploit(t *testing.T) {
+	prompt := buildSystemPrompt(nil, nil, false)
+
+	// ANALYZE ステップで searchsploit の使用が必須であること
+	if !strings.Contains(prompt, "searchsploit") {
+		t.Error("ASSESSMENT WORKFLOW ANALYZE step should require searchsploit for exploit lookup")
+	}
+}
+
 func TestBuildSystemPrompt_ContainsServicePriority(t *testing.T) {
 	prompt := buildSystemPrompt(nil, nil, false)
 

--- a/skills/searchsploit.md
+++ b/skills/searchsploit.md
@@ -1,0 +1,74 @@
+---
+name: searchsploit
+description: Search ExploitDB for known exploits using searchsploit
+---
+
+Use searchsploit to find known exploits, PoCs, and shellcode from ExploitDB.
+
+## Basic Search
+
+1. Search by software name and version:
+   searchsploit apache 2.4.49
+   searchsploit openssh 8.0
+   searchsploit vsftpd 2.3.4
+
+2. Search by CVE:
+   searchsploit --cve 2021-41773
+   searchsploit --cve 2018-15473
+
+3. Search with exact match (avoid noise):
+   searchsploit -e "Apache 2.4.49"
+
+## Output Control
+
+4. Show full path to exploit files:
+   searchsploit -p 12345
+
+5. JSON output (machine-readable):
+   searchsploit --json apache 2.4.49
+
+6. Show only exploits (exclude shellcode/papers):
+   searchsploit -t apache 2.4.49
+
+7. Exclude results containing a term:
+   searchsploit apache 2.4 --exclude="Denial of Service"
+
+## Copy & Use Exploits
+
+8. Copy exploit to current directory:
+   searchsploit -m 50383
+   searchsploit -m exploits/linux/remote/50383.py
+
+9. Examine exploit before running:
+   searchsploit -x 50383
+
+## Workflow: nmap to searchsploit
+
+10. Parse nmap XML output directly:
+    nmap -sV -oX nmap_output.xml <target>
+    searchsploit --nmap nmap_output.xml
+
+11. Manual workflow (recommended):
+    # Step 1: Identify services
+    nmap -sV <target>
+    # Step 2: Search for each service version
+    searchsploit "OpenSSH 8.0"
+    searchsploit "Apache httpd 2.4.49"
+    searchsploit "ProFTPD 1.3.5"
+    # Step 3: Copy promising exploit
+    searchsploit -m <exploit-id>
+    # Step 4: Read and adapt
+    cat <exploit-file>
+
+## Update Database
+
+12. Update ExploitDB database:
+    searchsploit -u
+
+## Tips
+
+- Always search with version numbers for precise results
+- Use `searchsploit -m` to copy, never modify the original DB files
+- Check exploit language (Python 2 vs 3, Ruby, etc.) before running
+- Read the exploit source — some need target-specific modifications
+- Combine with `searchsploit --nmap` for automated bulk lookups after scans


### PR DESCRIPTION
## Summary
- Add `skills/searchsploit.md` — ExploitDB search patterns (basic search, CVE lookup, nmap integration, copy/use exploits)
- Update ASSESSMENT WORKFLOW ANALYZE step to include `searchsploit` for version-specific exploit lookup
- Agent now follows: nmap → search_knowledge + searchsploit → think → plan → execute

## Test plan
- [x] `TestBuildSystemPrompt_WorkflowRequiresSearchsploit` — GREEN
- [x] `golangci-lint run` — 0 issues
- [x] All existing tests pass

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)