### PR TITLE
feat: ReconTree — structured reconnaissance control

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -46,3 +46,11 @@ blacklist:
 
   # フォークボム
   - ':\(\)\{.*\|.*:.*\}'
+
+# --- Recon Tree ---
+# Controls structured reconnaissance behavior.
+# max_parallel: Maximum concurrent recon tasks (default: 2)
+#   Higher values speed up recon but increase load on target.
+#   Use 1 for stealth, 2-3 for normal, 4+ for aggressive.
+recon:
+  max_parallel: 2

--- a/docs/architecture_design/recon-tree.md
+++ b/docs/architecture_design/recon-tree.md
@@ -1,0 +1,324 @@
+# Recon Tree — 構造的偵察制御
+
+## 課題
+
+現状の ASSESSMENT WORKFLOW はプロンプトで偵察手順を指示しているが、LLM の判断に依存するため：
+- vhost を発見しても endpoint 列挙をスキップする
+- 一部の endpoint だけ param fuzz して残りを飛ばす
+- ffuf の再帰的深堀りを途中でやめる
+- nmap 結果を LLM が要約すると情報が落ちる（「メモうっすい」問題）
+
+**偵察 = 成功率**。漏れを構造的に防ぐ必要がある。
+
+## 設計方針
+
+- **ReconTree**: ターゲットの偵察状態をツリー構造で管理するタスクキュー
+- **生出力はファイル保存**: nmap/ffuf/curl の出力はディスクに保存、ReconTree はファイルパスを参照しない（LLM が必要時に `cat` で読む）
+- **pending がある限り RECON を抜けられない**: コードレベルで強制
+- **LLM は Tree が指示するタスクを実行するだけ**: 「何をスキャンするか」の判断を LLM に委ねない
+
+## データ構造
+
+```go
+type TaskStatus int
+
+const (
+    StatusPending    TaskStatus = iota
+    StatusInProgress
+    StatusComplete
+)
+
+type ReconNode struct {
+    Host         string       // "10.10.11.100" or "dev.example.com" (vhost)
+    Port         int          // 80, 443, 22... (0 = endpoint node)
+    Service      string       // "http", "ssh", "smb"
+    Banner       string       // "Apache 2.4.49", "OpenSSH 8.2"
+    Path         string       // "/", "/api", "/api/v1" (endpoint nodes only)
+
+    // タスクステータス（ノードタイプによって使うフィールドが異なる）
+    EndpointEnum TaskStatus   // ffuf でサブディレクトリ列挙
+    ParamFuzz    TaskStatus   // ffuf でパラメータ発見
+    Profiling    TaskStatus   // curl でレスポンス特性把握
+    VhostDiscov  TaskStatus   // ffuf で仮想ホスト探索
+
+    Children     []*ReconNode
+}
+```
+
+### ノードタイプの区別
+
+| 条件 | ノードタイプ | 使うフィールド |
+|------|------------|--------------|
+| `Port > 0 && Service == "http/https"` | HTTP ポート | VhostDiscov, EndpointEnum, ParamFuzz, Profiling + Children |
+| `Port > 0 && Service != "http"` | 非 HTTP ポート | なし（葉ノード、バナー情報のみ） |
+| `Port == 0 && Path != ""` | Endpoint | EndpointEnum, ParamFuzz, Profiling + Children |
+| `Host != root && Port == 0 && Path == ""` | Vhost ルート | VhostDiscov, EndpointEnum + Children |
+
+## ツリー構造の例
+
+```
+10.10.11.100 (root)
+├── 22/ssh OpenSSH 8.2                    ← nmap から（葉ノード）
+├── 80/http Apache 2.4.49                 ← nmap から
+│   ├── vhost_discovery: ✅
+│   ├── endpoint_enum(/): ✅
+│   ├── param_fuzz(/): ✅
+│   ├── profiling(/): ✅
+│   ├── /api
+│   │   ├── endpoint_enum: ✅
+│   │   ├── param_fuzz: ⏳               ← endpoint 発見時に自動追加
+│   │   ├── profiling: ⏳
+│   │   └── /api/v1
+│   │       ├── endpoint_enum: ✅ (子なし → 自動完了)
+│   │       ├── param_fuzz: ⏳
+│   │       ├── profiling: ⏳
+│   │       └── /api/v1/user
+│   │           ├── endpoint_enum: ✅ (子なし)
+│   │           ├── param_fuzz: ⏳
+│   │           └── profiling: ⏳
+│   ├── /login
+│   │   ├── endpoint_enum: ✅ (子なし)
+│   │   ├── param_fuzz: ✅
+│   │   └── profiling: ✅
+│   └── /admin
+│       ├── endpoint_enum: ⏳
+│       ├── param_fuzz: ⏳
+│       └── profiling: ⏳
+├── 445/smb Samba 4.6.2                   ← nmap から（葉ノード）
+│
+└── [vhost] dev.example.com → port 80
+    ├── vhost_discovery: ⏳               ← サブ vhost チェック
+    ├── endpoint_enum(/): ⏳
+    └── (endpoints discovered later...)
+```
+
+## 自動タスク生成ルール
+
+| イベント | Tree への効果 |
+|----------|--------------|
+| nmap が HTTP ポート発見 | ポートノード追加 + `VhostDiscov: pending` + `EndpointEnum: pending` |
+| nmap が非 HTTP ポート発見 | ポートノード追加（葉、タスクなし） |
+| ffuf (dir) が endpoint 発見 | 子ノード追加 + `EndpointEnum: pending` + `ParamFuzz: pending` + `Profiling: pending` |
+| ffuf (dir) が結果ゼロ | そのノードの `EndpointEnum → complete` |
+| ffuf (vhost) が vhost 発見 | vhost ノード追加 + `VhostDiscov: pending` + `EndpointEnum: pending` |
+| ffuf (vhost) が結果ゼロ | そのノードの `VhostDiscov → complete` |
+| ffuf (param) 完了 | そのノードの `ParamFuzz → complete` |
+| curl profiling 完了 | そのノードの `Profiling → complete` |
+
+## 生出力のファイル保存
+
+ツール出力は ReconTree に含めず、既存の memory ディレクトリ配下に保存：
+
+```
+memory/<host>/
+├── vulnerability.txt          ← 既存（LLM の分析結果）
+├── credential.txt             ← 既存
+├── artifact.txt               ← 既存
+├── finding.txt                ← 既存
+└── raw/                       ← 新規（ツール生出力）
+    ├── nmap.txt
+    ├── ffuf_dir_80_root.json
+    ├── ffuf_dir_80_api.json
+    ├── ffuf_dir_80_api_v1.json
+    ├── ffuf_vhost_80.json
+    ├── ffuf_param_80_login.json
+    └── curl_80_login.txt
+```
+
+- 既存の `memory/<host>/` 構造と一貫性がある
+- `.gitignore` で `memory/*` は除外済み
+- セッション終了後も残る（`/tmp/` と違って消えない）
+- LLM が参照したいときは `cat memory/<host>/raw/nmap.txt` で読める
+- コンテキストに全部詰めない — 必要なときだけ読む
+
+## コアフロー
+
+```
+1. Agent が nmap/ffuf/curl を実行
+       ↓
+2. evaluateResult() がツール出力を検知
+       ↓
+3. Parser がツール出力から結果を抽出
+   - nmap -oX → encoding/xml でパース → ポートノード生成
+   - ffuf -of json → JSON パース → endpoint/vhost ノード生成
+   - curl → exit code + ヘッダで profiling 完了判定
+       ↓
+4. ReconTree に子ノード追加（pending タスク自動生成）
+       ↓
+5. 次の LLM 呼び出し時、プロンプトに pending タスクを注入:
+   "RECON QUEUE (3 pending):
+    1. endpoint_enum: /admin on 10.10.11.100:80
+    2. param_fuzz: /api/v1 on 10.10.11.100:80
+    3. profiling: /api/v1/user on 10.10.11.100:80"
+       ↓
+6. LLM は Queue の先頭を実行するだけ
+       ↓
+7. pending が 0 になったら → RECON 完了 → ANALYZE フェーズへ進行許可
+```
+
+## RECON 完了判定
+
+```go
+func (t *ReconTree) HasPending() bool {
+    // ツリーを走査して pending ノードがあるか確認
+    return t.countPending() > 0
+}
+
+func (t *ReconTree) NextPending() *ReconNode {
+    // DFS で最初の pending タスクを返す
+    // 優先順位: endpoint_enum > param_fuzz > profiling > vhost_discovery
+}
+```
+
+`HasPending() == true` の間は、`evaluateResult()` が RECON フェーズを強制。
+LLM が `think` や `memory` で ANALYZE に進もうとしても、プロンプトに
+「RECON QUEUE に pending タスクがあります。先にこれを実行してください」と注入。
+
+## プロンプト注入フォーマット
+
+```
+RECON STATUS:
+  Ports: 22/ssh, 80/http, 445/smb (3 discovered)
+  Endpoints: 8 discovered, 5 profiled
+  Vhosts: 1 discovered (dev.example.com)
+  Parameters: 3 endpoints fuzzed
+
+RECON QUEUE (3 pending):
+  1. [endpoint_enum] /admin on 10.10.11.100:80
+     → ffuf -w /usr/share/wordlists/dirb/common.txt -u http://10.10.11.100/admin/FUZZ
+  2. [param_fuzz] /api/v1 on 10.10.11.100:80
+     → ffuf -w burp-parameter-names.txt -u "http://10.10.11.100/api/v1?FUZZ=value" -fs <size>
+  3. [profiling] /api/v1/user on 10.10.11.100:80
+     → curl -ik http://10.10.11.100/api/v1/user
+
+Execute the next pending task. Do NOT skip to ANALYZE while tasks remain.
+```
+
+コマンドまで生成してあげることで、LLM は JSON を返すだけ。
+
+## 並列制御
+
+偵察タスクを非同期（spawn_task）で実行する場合、同時実行数を制限しないと
+ターゲットに対する DoS になりうる。ユーザーが設定可能な並列数制御を導入する。
+
+### 設定
+
+```yaml
+# config/config.yaml
+recon:
+  max_parallel: 2    # 同時実行する偵察タスクの最大数（デフォルト: 2）
+```
+
+```go
+// config.go に追加
+type ReconConfig struct {
+    MaxParallel int `yaml:"max_parallel"`
+}
+
+type AppConfig struct {
+    Knowledge []KnowledgeEntry `yaml:"knowledge"`
+    Blacklist []string         `yaml:"blacklist"`
+    Recon     ReconConfig      `yaml:"recon"`
+}
+```
+
+デフォルト値: `max_parallel = 2`（未設定時）
+
+### ReconTree での制御
+
+```go
+type ReconTree struct {
+    Root        *ReconNode
+    MaxParallel int          // config から取得
+    active      int          // 現在実行中のタスク数
+}
+
+func (t *ReconTree) NextBatch() []*ReconTask {
+    available := t.MaxParallel - t.active
+    if available <= 0 {
+        return nil
+    }
+    return t.pickPending(available)
+}
+```
+
+### プロンプトへの反映
+
+```
+RECON QUEUE (5 pending, 2 active, max_parallel=2):
+  [active] endpoint_enum: /api on 10.10.11.100:80
+  [active] param_fuzz: /login on 10.10.11.100:80
+  [next]   profiling: /api/v1/user on 10.10.11.100:80
+  [queued] endpoint_enum: /admin on 10.10.11.100:80
+  [queued] vhost_discovery: dev.example.com
+```
+
+- `active` が `max_parallel` に達している → LLM に `wait` を指示
+- タスク完了で空きが出たら → 次の pending を実行
+
+## /recontree コマンド（TUI）
+
+ユーザーが偵察の進捗をリアルタイムで確認できる TUI コマンド。
+Log ペインにコードブロックとして出力する（glamour のレンダリング崩れを防止）。
+
+### 表示例
+
+```
+/recontree
+
+10.10.11.100
+|-- 22/ssh OpenSSH 8.2
+|-- 80/http Apache 2.4.49
+|   |-- vhost_discovery [x]
+|   |-- / [x][x][x] (enum/param/profile)
+|   |-- /api [x][ ][ ]
+|   |   +-- /api/v1 [x][ ][ ]
+|   |       +-- /api/v1/user [x][ ][ ]
+|   |-- /login [x][x][x]
+|   +-- /admin [ ][ ][ ]
+|-- 445/smb Samba 4.6.2
++-- [vhost] dev.example.com
+    |-- vhost_discovery [ ]
+    +-- / [ ][ ][ ]
+
+Progress: 8/21 tasks complete (38%)
+Active: 2/2 (max_parallel=2)
+```
+
+### 凡例
+
+- `[x][x][x]` = endpoint_enum / param_fuzz / profiling すべて完了
+- `[x][ ][ ]` = endpoint_enum 完了、param_fuzz と profiling が pending
+- `[>]` = in_progress
+- 非 HTTP ポートはステータスなし（バナー情報のみ）
+
+### 表示の実装方針
+
+- ASCII 文字のみ使用（`|-- +-- [ ] [x] [>]`）。絵文字は端末幅の不整合を起こすため不使用。
+- `RenderTree() string` が返すテキストを TUI 側でコードブロック（`` ``` ``）で囲んで出力
+- glamour のマークダウンレンダリングがコードブロック内はそのまま表示するため崩れない
+
+### 実装
+
+- `internal/agent/recon_tree.go` に `RenderTree() string` メソッドを追加
+- `internal/tui/update.go` に `/recontree` コマンドハンドラを追加
+- Log ペインにコードブロックとして出力
+
+## 既存コードへの影響
+
+| ファイル | 変更内容 |
+|----------|---------|
+| `internal/agent/recon_tree.go` | **新規**: ReconTree, ReconNode, パーサー, RenderTree |
+| `internal/agent/recon_tree_test.go` | **新規**: ユニットテスト |
+| `internal/agent/loop.go` | `evaluateResult()` にパーサー呼び出し + 並列制御追加 |
+| `internal/brain/prompt.go` | `buildPrompt()` に RECON QUEUE 注入 |
+| `internal/brain/prompt_test.go` | RECON QUEUE 注入テスト |
+| `internal/config/config.go` | `ReconConfig` 追加（max_parallel） |
+| `internal/config/config_test.go` | ReconConfig テスト追加 |
+| `config/config.example.yaml` | `recon:` セクション追加 |
+| `internal/tui/update.go` | `/recontree` コマンド追加 |
+
+## 将来拡張
+
+- 非 HTTP サービスの偵察タスク（SMB share_enum, FTP anon_check 等）
+- Attack Graph との接続: ReconTree の profiling 結果 → Attack Graph の requires/provides

--- a/internal/agent/recon_parser_test.go
+++ b/internal/agent/recon_parser_test.go
@@ -1,0 +1,194 @@
+package agent
+
+import (
+	"testing"
+)
+
+const testNmapXML = `<?xml version="1.0"?>
+<nmaprun>
+<host><status state="up"/>
+<ports>
+<port protocol="tcp" portid="22"><state state="open"/><service name="ssh" product="OpenSSH" version="8.2p1"/></port>
+<port protocol="tcp" portid="80"><state state="open"/><service name="http" product="Apache httpd" version="2.4.49"/></port>
+<port protocol="tcp" portid="443"><state state="filtered"/><service name="https"/></port>
+</ports>
+</host>
+</nmaprun>`
+
+const testFfufDirJSON = `{"commandline":"ffuf -w wordlist -u http://10.10.11.100/FUZZ","results":[{"input":{"FUZZ":"api"},"status":301,"length":0,"url":"http://10.10.11.100/api"},{"input":{"FUZZ":"login"},"status":200,"length":4532,"url":"http://10.10.11.100/login"}]}`
+
+const testFfufEmptyJSON = `{"commandline":"ffuf -w wordlist -u http://10.10.11.100/api/FUZZ","results":[]}`
+
+const testFfufVhostJSON = `{"commandline":"ffuf -w wordlist -u http://10.10.11.100 -H 'Host: FUZZ.example.com'","results":[{"input":{"FUZZ":"dev"},"status":200,"length":1234,"url":"http://10.10.11.100/"},{"input":{"FUZZ":"staging"},"status":200,"length":5678,"url":"http://10.10.11.100/"}]}`
+
+func TestParseNmapXML(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	err := ParseNmapXML(testNmapXML, tree)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// open ポートのみ追加される（22, 80）、filtered(443) は除外
+	if len(tree.Ports) != 2 {
+		t.Fatalf("Ports count = %d, want 2", len(tree.Ports))
+	}
+
+	ssh := tree.Ports[0]
+	if ssh.Port != 22 || ssh.Service != "ssh" {
+		t.Errorf("port 0: %d/%s, want 22/ssh", ssh.Port, ssh.Service)
+	}
+	if ssh.Banner != "OpenSSH 8.2p1" {
+		t.Errorf("banner = %q, want 'OpenSSH 8.2p1'", ssh.Banner)
+	}
+
+	http := tree.Ports[1]
+	if http.Port != 80 || http.Service != "http" {
+		t.Errorf("port 1: %d/%s, want 80/http", http.Port, http.Service)
+	}
+	if http.Banner != "Apache httpd 2.4.49" {
+		t.Errorf("banner = %q, want 'Apache httpd 2.4.49'", http.Banner)
+	}
+}
+
+func TestParseNmapXML_OnlyOpenPorts(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	_ = ParseNmapXML(testNmapXML, tree)
+	// 443 は filtered なので追加されない
+	for _, p := range tree.Ports {
+		if p.Port == 443 {
+			t.Error("filtered port 443 should not be added")
+		}
+	}
+}
+
+func TestParseNmapXML_HTTPGetsPending(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	_ = ParseNmapXML(testNmapXML, tree)
+
+	http := tree.Ports[1] // port 80
+	if http.EndpointEnum != StatusPending {
+		t.Errorf("HTTP EndpointEnum = %d, want pending", http.EndpointEnum)
+	}
+	if http.VhostDiscov != StatusPending {
+		t.Errorf("HTTP VhostDiscov = %d, want pending", http.VhostDiscov)
+	}
+
+	ssh := tree.Ports[0] // port 22
+	if ssh.EndpointEnum != StatusNone {
+		t.Errorf("SSH EndpointEnum = %d, want none", ssh.EndpointEnum)
+	}
+}
+
+func TestParseFfufJSON_Endpoints(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	err := ParseFfufJSON(testFfufDirJSON, tree, "10.10.11.100", 80, "/", TaskEndpointEnum)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// /api と /login が追加される
+	node := tree.Ports[0]
+	if len(node.Children) != 2 {
+		t.Fatalf("Children count = %d, want 2", len(node.Children))
+	}
+	if node.Children[0].Path != "/api" {
+		t.Errorf("child 0 path = %q, want /api", node.Children[0].Path)
+	}
+	if node.Children[1].Path != "/login" {
+		t.Errorf("child 1 path = %q, want /login", node.Children[1].Path)
+	}
+}
+
+func TestParseFfufJSON_Empty(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+
+	err := ParseFfufJSON(testFfufEmptyJSON, tree, "10.10.11.100", 80, "/api", TaskEndpointEnum)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 結果ゼロ → タスク完了
+	apiNode := tree.Ports[0].Children[0]
+	if apiNode.EndpointEnum != StatusComplete {
+		t.Errorf("EndpointEnum = %d, want complete", apiNode.EndpointEnum)
+	}
+}
+
+func TestParseFfufJSON_Vhost(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	err := ParseFfufJSON(testFfufVhostJSON, tree, "10.10.11.100", 80, "", TaskVhostDiscov)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tree.Vhosts) != 2 {
+		t.Fatalf("Vhosts count = %d, want 2", len(tree.Vhosts))
+	}
+	if tree.Vhosts[0].Host != "dev.example.com" {
+		t.Errorf("vhost 0 = %q, want dev.example.com", tree.Vhosts[0].Host)
+	}
+	if tree.Vhosts[1].Host != "staging.example.com" {
+		t.Errorf("vhost 1 = %q, want staging.example.com", tree.Vhosts[1].Host)
+	}
+}
+
+func TestDetectAndParse_Nmap(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	err := DetectAndParse("nmap -sV -sC 10.10.11.100", testNmapXML, tree, "10.10.11.100")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tree.Ports) != 2 {
+		t.Errorf("Ports count = %d, want 2", len(tree.Ports))
+	}
+}
+
+func TestDetectAndParse_Ffuf(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	err := DetectAndParse(
+		"ffuf -w /usr/share/wordlists/dirb/common.txt -u http://10.10.11.100/FUZZ",
+		testFfufDirJSON,
+		tree, "10.10.11.100",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tree.Ports[0].Children) != 2 {
+		t.Errorf("Children = %d, want 2", len(tree.Ports[0].Children))
+	}
+}
+
+func TestDetectAndParse_Curl(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/login")
+
+	err := DetectAndParse(
+		"curl -ik http://10.10.11.100/login",
+		"HTTP/1.1 200 OK\r\nContent-Type: text/html",
+		tree, "10.10.11.100",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loginNode := tree.Ports[0].Children[0]
+	if loginNode.Profiling != StatusComplete {
+		t.Errorf("Profiling = %d, want complete", loginNode.Profiling)
+	}
+}
+
+func TestDetectAndParse_Unknown(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	err := DetectAndParse("echo hello", "hello", tree, "10.10.11.100")
+	if err != nil {
+		t.Errorf("unknown command should not error, got: %v", err)
+	}
+}

--- a/internal/agent/recon_tree.go
+++ b/internal/agent/recon_tree.go
@@ -1,0 +1,590 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReconStatus は偵察タスクの状態
+type ReconStatus int
+
+const (
+	// StatusNone はタスクが存在しない（非 HTTP ポート等）
+	StatusNone ReconStatus = iota
+	// StatusPending は未実行
+	StatusPending
+	// StatusInProgress は実行中
+	StatusInProgress
+	// StatusComplete は完了
+	StatusComplete
+)
+
+// ReconTaskType は偵察タスクの種類
+type ReconTaskType int
+
+const (
+	TaskEndpointEnum ReconTaskType = iota
+	TaskParamFuzz
+	TaskProfiling
+	TaskVhostDiscov
+)
+
+func (t ReconTaskType) String() string {
+	switch t {
+	case TaskEndpointEnum:
+		return "endpoint_enum"
+	case TaskParamFuzz:
+		return "param_fuzz"
+	case TaskProfiling:
+		return "profiling"
+	case TaskVhostDiscov:
+		return "vhost_discovery"
+	default:
+		return "unknown"
+	}
+}
+
+// ReconNode はツリーの各ノード
+type ReconNode struct {
+	Host    string // "10.10.11.100" or "dev.example.com" (vhost)
+	Port    int    // 80, 443, 22... (0 = endpoint node)
+	Service string // "http", "ssh", "smb"
+	Banner  string // "Apache 2.4.49", "OpenSSH 8.2"
+	Path    string // "/", "/api", "/api/v1" (endpoint nodes only)
+
+	// タスクステータス（ノードタイプによって使うフィールドが異なる）
+	EndpointEnum ReconStatus
+	ParamFuzz    ReconStatus
+	Profiling    ReconStatus
+	VhostDiscov  ReconStatus
+
+	Children []*ReconNode
+}
+
+// isHTTP は HTTP/HTTPS サービスかどうか
+func (n *ReconNode) isHTTP() bool {
+	return n.Service == "http" || n.Service == "https" ||
+		n.Service == "http-proxy" || n.Service == "https-alt"
+}
+
+// getReconStatus は指定タスクタイプのステータスを返す
+func (n *ReconNode) getReconStatus(taskType ReconTaskType) ReconStatus {
+	switch taskType {
+	case TaskEndpointEnum:
+		return n.EndpointEnum
+	case TaskParamFuzz:
+		return n.ParamFuzz
+	case TaskProfiling:
+		return n.Profiling
+	case TaskVhostDiscov:
+		return n.VhostDiscov
+	default:
+		return StatusNone
+	}
+}
+
+// setReconStatus は指定タスクタイプのステータスを設定する
+func (n *ReconNode) setReconStatus(taskType ReconTaskType, status ReconStatus) {
+	switch taskType {
+	case TaskEndpointEnum:
+		n.EndpointEnum = status
+	case TaskParamFuzz:
+		n.ParamFuzz = status
+	case TaskProfiling:
+		n.Profiling = status
+	case TaskVhostDiscov:
+		n.VhostDiscov = status
+	}
+}
+
+// countTasks はノードとその子孫の pending/complete/total を再帰的に数える
+func (n *ReconNode) countTasks() (pending, complete, total int) {
+	for _, st := range []ReconStatus{n.EndpointEnum, n.ParamFuzz, n.Profiling, n.VhostDiscov} {
+		switch st {
+		case StatusPending:
+			pending++
+			total++
+		case StatusInProgress:
+			total++
+		case StatusComplete:
+			complete++
+			total++
+		}
+	}
+	for _, child := range n.Children {
+		p, c, t := child.countTasks()
+		pending += p
+		complete += c
+		total += t
+	}
+	return
+}
+
+// ReconTask は pending キューの1エントリ
+type ReconTask struct {
+	Type ReconTaskType
+	Node *ReconNode
+	Host string
+	Port int
+	Path string
+}
+
+// ReconTree はターゲットの偵察状態を管理するツリー
+type ReconTree struct {
+	Host        string
+	MaxParallel int
+	active      int
+	Ports       []*ReconNode // ポートレベルノード
+	Vhosts      []*ReconNode // vhost ルートノード
+}
+
+// NewReconTree は新しい ReconTree を作成する。maxParallel が 0 ならデフォルト 2。
+func NewReconTree(host string, maxParallel int) *ReconTree {
+	if maxParallel <= 0 {
+		maxParallel = 2
+	}
+	return &ReconTree{
+		Host:        host,
+		MaxParallel: maxParallel,
+	}
+}
+
+// AddPort は nmap で発見したポートをツリーに追加する。
+// HTTP 系なら EndpointEnum + VhostDiscov を pending にする。
+func (t *ReconTree) AddPort(port int, service, banner string) {
+	node := &ReconNode{
+		Host:    t.Host,
+		Port:    port,
+		Service: service,
+		Banner:  banner,
+	}
+	if node.isHTTP() {
+		node.EndpointEnum = StatusPending
+		node.VhostDiscov = StatusPending
+	}
+	t.Ports = append(t.Ports, node)
+}
+
+// AddEndpoint は ffuf で発見した endpoint を親ノードの子として追加する。
+// EndpointEnum + ParamFuzz + Profiling を pending にする。
+func (t *ReconTree) AddEndpoint(host string, port int, parentPath, newPath string) {
+	parent := t.findNode(host, port, parentPath)
+	if parent == nil {
+		return
+	}
+	child := &ReconNode{
+		Host:         host,
+		Port:         port,
+		Path:         newPath,
+		EndpointEnum: StatusPending,
+		ParamFuzz:    StatusPending,
+		Profiling:    StatusPending,
+	}
+	parent.Children = append(parent.Children, child)
+}
+
+// AddVhost は ffuf で発見した仮想ホストをツリーに追加する。
+// VhostDiscov + EndpointEnum を pending にする。
+func (t *ReconTree) AddVhost(parentHost string, port int, vhostName string) {
+	node := &ReconNode{
+		Host:         vhostName,
+		Port:         port,
+		Service:      "http", // vhost は HTTP 前提
+		EndpointEnum: StatusPending,
+		VhostDiscov:  StatusPending,
+	}
+	t.Vhosts = append(t.Vhosts, node)
+}
+
+// CompleteTask は指定タスクを完了にする。
+// path が空文字列の場合はポートレベルノードを対象とする。
+func (t *ReconTree) CompleteTask(host string, port int, path string, taskType ReconTaskType) {
+	node := t.findNode(host, port, path)
+	if node == nil {
+		return
+	}
+	node.setReconStatus(taskType, StatusComplete)
+}
+
+// HasPending はツリーに pending タスクがあるか
+func (t *ReconTree) HasPending() bool {
+	return t.CountPending() > 0
+}
+
+// CountPending は pending タスクの総数
+func (t *ReconTree) CountPending() int {
+	pending := 0
+	for _, node := range t.Ports {
+		p, _, _ := node.countTasks()
+		pending += p
+	}
+	for _, node := range t.Vhosts {
+		p, _, _ := node.countTasks()
+		pending += p
+	}
+	return pending
+}
+
+// CountComplete は完了タスクの総数
+func (t *ReconTree) CountComplete() int {
+	complete := 0
+	for _, node := range t.Ports {
+		_, c, _ := node.countTasks()
+		complete += c
+	}
+	for _, node := range t.Vhosts {
+		_, c, _ := node.countTasks()
+		complete += c
+	}
+	return complete
+}
+
+// CountTotal は全タスクの総数
+func (t *ReconTree) CountTotal() int {
+	total := 0
+	for _, node := range t.Ports {
+		_, _, tt := node.countTasks()
+		total += tt
+	}
+	for _, node := range t.Vhosts {
+		_, _, tt := node.countTasks()
+		total += tt
+	}
+	return total
+}
+
+// NextBatch は MaxParallel - active 個の pending タスクを優先順で返す。
+// 優先順: endpoint_enum > param_fuzz > profiling > vhost_discovery
+func (t *ReconTree) NextBatch() []*ReconTask {
+	available := t.MaxParallel - t.active
+	if available <= 0 {
+		return nil
+	}
+
+	var tasks []*ReconTask
+	// 優先順にタスクを収集
+	for _, taskType := range []ReconTaskType{TaskEndpointEnum, TaskParamFuzz, TaskProfiling, TaskVhostDiscov} {
+		t.collectPending(&tasks, taskType, available)
+		if len(tasks) >= available {
+			break
+		}
+	}
+
+	if len(tasks) > available {
+		tasks = tasks[:available]
+	}
+	return tasks
+}
+
+// collectPending は指定タイプの pending タスクを DFS で収集する
+func (t *ReconTree) collectPending(tasks *[]*ReconTask, taskType ReconTaskType, limit int) {
+	for _, node := range t.Ports {
+		if len(*tasks) >= limit {
+			return
+		}
+		t.collectPendingFromNode(tasks, node, taskType, limit)
+	}
+	for _, node := range t.Vhosts {
+		if len(*tasks) >= limit {
+			return
+		}
+		t.collectPendingFromNode(tasks, node, taskType, limit)
+	}
+}
+
+func (t *ReconTree) collectPendingFromNode(tasks *[]*ReconTask, node *ReconNode, taskType ReconTaskType, limit int) {
+	if len(*tasks) >= limit {
+		return
+	}
+	if node.getReconStatus(taskType) == StatusPending {
+		*tasks = append(*tasks, &ReconTask{
+			Type: taskType,
+			Node: node,
+			Host: node.Host,
+			Port: node.Port,
+			Path: node.Path,
+		})
+	}
+	for _, child := range node.Children {
+		if len(*tasks) >= limit {
+			return
+		}
+		t.collectPendingFromNode(tasks, child, taskType, limit)
+	}
+}
+
+// StartTask はタスクを実行中にし、active カウントを増やす
+func (t *ReconTree) StartTask(task *ReconTask) {
+	task.Node.setReconStatus(task.Type, StatusInProgress)
+	t.active++
+}
+
+// FinishTask はタスクを完了にし、active カウントを減らす
+func (t *ReconTree) FinishTask(task *ReconTask) {
+	task.Node.setReconStatus(task.Type, StatusComplete)
+	if t.active > 0 {
+		t.active--
+	}
+}
+
+// findNode はホスト/ポート/パスでノードを検索する。
+// path が "/" かつポートノードの Path が "" の場合はポートノード自身を返す（ルート扱い）。
+func (t *ReconTree) findNode(host string, port int, path string) *ReconNode {
+	// ポートノードを探索
+	for _, node := range t.Ports {
+		if node.Host == host && node.Port == port && matchPath(node.Path, path) {
+			return node
+		}
+		if found := findNodeRecursive(node, host, port, path); found != nil {
+			return found
+		}
+	}
+	// vhost ノードを探索
+	for _, node := range t.Vhosts {
+		if node.Host == host && node.Port == port && matchPath(node.Path, path) {
+			return node
+		}
+		if found := findNodeRecursive(node, host, port, path); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// matchPath はパスの一致判定。"" と "/" は同一視する。
+func matchPath(nodePath, searchPath string) bool {
+	if nodePath == searchPath {
+		return true
+	}
+	// ポートノード（Path=""）は "/" でも一致
+	if (nodePath == "" && searchPath == "/") || (nodePath == "/" && searchPath == "") {
+		return true
+	}
+	return false
+}
+
+func findNodeRecursive(node *ReconNode, host string, port int, path string) *ReconNode {
+	for _, child := range node.Children {
+		if child.Host == host && child.Port == port && child.Path == path {
+			return child
+		}
+		if found := findNodeRecursive(child, host, port, path); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// statusIcon はステータスの ASCII 表現
+func statusIcon(s ReconStatus) string {
+	switch s {
+	case StatusComplete:
+		return "[x]"
+	case StatusInProgress:
+		return "[>]"
+	case StatusPending:
+		return "[ ]"
+	default:
+		return ""
+	}
+}
+
+// RenderTree は ASCII ツリーを返す（/recontree 用）
+func (t *ReconTree) RenderTree() string {
+	var sb strings.Builder
+	sb.WriteString(t.Host)
+	sb.WriteString("\n")
+
+	allNodes := make([]*ReconNode, 0, len(t.Ports)+len(t.Vhosts))
+	allNodes = append(allNodes, t.Ports...)
+	// vhost はラベル付きで追加
+	allNodes = append(allNodes, t.Vhosts...)
+
+	for i, node := range allNodes {
+		isLast := i == len(allNodes)-1
+		prefix := "|-- "
+		if isLast {
+			prefix = "+-- "
+		}
+		childPrefix := "|   "
+		if isLast {
+			childPrefix = "    "
+		}
+
+		isVhost := i >= len(t.Ports)
+		renderNode(&sb, node, prefix, childPrefix, isVhost)
+	}
+
+	// Progress 行
+	complete := t.CountComplete()
+	total := t.CountTotal()
+	if total > 0 {
+		pct := complete * 100 / total
+		fmt.Fprintf(&sb, "\nProgress: %d/%d tasks complete (%d%%)\n", complete, total, pct)
+	}
+	if t.active > 0 || t.MaxParallel > 0 {
+		fmt.Fprintf(&sb, "Active: %d/%d\n", t.active, t.MaxParallel)
+	}
+
+	return sb.String()
+}
+
+func renderNode(sb *strings.Builder, node *ReconNode, prefix, childPrefix string, isVhost bool) {
+	if node.Port > 0 && node.Path == "" {
+		// ポートレベルノード
+		if isVhost {
+			fmt.Fprintf(sb, "%s[vhost] %s (%d/%s)", prefix, node.Host, node.Port, node.Service)
+		} else {
+			fmt.Fprintf(sb, "%s%d/%s %s", prefix, node.Port, node.Service, node.Banner)
+		}
+
+		if node.isHTTP() {
+			// vhost + endpoint ステータス表示
+			sb.WriteString("\n")
+			hasChildren := len(node.Children) > 0
+			vhostPrefix := childPrefix + "|-- "
+			if !hasChildren {
+				vhostPrefix = childPrefix + "+-- "
+			}
+			fmt.Fprintf(sb, "%svhost %s\n", vhostPrefix, statusIcon(node.VhostDiscov))
+
+			// endpoint ノードのステータス（ルートレベル）
+			rootStatus := ""
+			if node.EndpointEnum != StatusNone {
+				rootStatus = fmt.Sprintf("%s%s%s",
+					statusIcon(node.EndpointEnum),
+					statusIcon(node.ParamFuzz),
+					statusIcon(node.Profiling))
+			}
+			if rootStatus != "" && !hasChildren {
+				fmt.Fprintf(sb, "%s/ %s\n", childPrefix+"+-- ", rootStatus)
+			} else if rootStatus != "" {
+				fmt.Fprintf(sb, "%s/ %s\n", childPrefix+"|-- ", rootStatus)
+			}
+
+			// 子ノード
+			for j, child := range node.Children {
+				isLastChild := j == len(node.Children)-1
+				cp := childPrefix + "|-- "
+				ccp := childPrefix + "|   "
+				if isLastChild {
+					cp = childPrefix + "+-- "
+					ccp = childPrefix + "    "
+				}
+				renderEndpointNode(sb, child, cp, ccp)
+			}
+		} else {
+			sb.WriteString("\n")
+		}
+	} else {
+		// endpoint ノード
+		renderEndpointNode(sb, node, prefix, childPrefix)
+	}
+}
+
+func renderEndpointNode(sb *strings.Builder, node *ReconNode, prefix, childPrefix string) {
+	status := fmt.Sprintf("%s%s%s",
+		statusIcon(node.EndpointEnum),
+		statusIcon(node.ParamFuzz),
+		statusIcon(node.Profiling))
+	fmt.Fprintf(sb, "%s%s %s\n", prefix, node.Path, status)
+
+	for j, child := range node.Children {
+		isLast := j == len(node.Children)-1
+		cp := childPrefix + "|-- "
+		ccp := childPrefix + "|   "
+		if isLast {
+			cp = childPrefix + "+-- "
+			ccp = childPrefix + "    "
+		}
+		renderEndpointNode(sb, child, cp, ccp)
+	}
+}
+
+// RenderQueue は RECON QUEUE をプロンプト注入用に返す。
+// pending がない場合は空文字列を返す。
+func (t *ReconTree) RenderQueue() string {
+	if !t.HasPending() {
+		return ""
+	}
+
+	pending := t.CountPending()
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "RECON QUEUE (%d pending, %d active, max_parallel=%d):\n",
+		pending, t.active, t.MaxParallel)
+
+	// active タスクを表示
+	t.renderActiveTasks(&sb)
+
+	// pending タスクを優先順で表示（最大10個）
+	shown := 0
+	first := true
+	for _, taskType := range []ReconTaskType{TaskEndpointEnum, TaskParamFuzz, TaskProfiling, TaskVhostDiscov} {
+		for _, node := range t.allNodes() {
+			if shown >= 10 {
+				break
+			}
+			if node.getReconStatus(taskType) == StatusPending {
+				label := "queued"
+				if first {
+					label = "next"
+					first = false
+				}
+				host := node.Host
+				if host == "" {
+					host = t.Host
+				}
+				path := node.Path
+				if path == "" {
+					path = "/"
+				}
+				fmt.Fprintf(&sb, "  [%s]  %s: %s on %s:%d\n",
+					label, taskType, path, host, node.Port)
+				shown++
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+// renderActiveTasks は実行中のタスクを表示する
+func (t *ReconTree) renderActiveTasks(sb *strings.Builder) {
+	for _, taskType := range []ReconTaskType{TaskEndpointEnum, TaskParamFuzz, TaskProfiling, TaskVhostDiscov} {
+		for _, node := range t.allNodes() {
+			if node.getReconStatus(taskType) == StatusInProgress {
+				host := node.Host
+				if host == "" {
+					host = t.Host
+				}
+				path := node.Path
+				if path == "" {
+					path = "/"
+				}
+				fmt.Fprintf(sb, "  [active] %s: %s on %s:%d\n",
+					taskType, path, host, node.Port)
+			}
+		}
+	}
+}
+
+// allNodes はポート + vhost + 全子ノードをフラットに返す
+func (t *ReconTree) allNodes() []*ReconNode {
+	var nodes []*ReconNode
+	for _, node := range t.Ports {
+		nodes = append(nodes, node)
+		collectAllChildren(&nodes, node)
+	}
+	for _, node := range t.Vhosts {
+		nodes = append(nodes, node)
+		collectAllChildren(&nodes, node)
+	}
+	return nodes
+}
+
+func collectAllChildren(nodes *[]*ReconNode, node *ReconNode) {
+	for _, child := range node.Children {
+		*nodes = append(*nodes, child)
+		collectAllChildren(nodes, child)
+	}
+}

--- a/internal/agent/recon_tree_test.go
+++ b/internal/agent/recon_tree_test.go
@@ -1,0 +1,341 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewReconTree(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 0)
+	if tree.Host != "10.10.11.100" {
+		t.Errorf("Host = %q, want %q", tree.Host, "10.10.11.100")
+	}
+	// デフォルト MaxParallel = 2
+	if tree.MaxParallel != 2 {
+		t.Errorf("MaxParallel = %d, want 2", tree.MaxParallel)
+	}
+
+	tree2 := NewReconTree("10.10.11.100", 4)
+	if tree2.MaxParallel != 4 {
+		t.Errorf("MaxParallel = %d, want 4", tree2.MaxParallel)
+	}
+}
+
+func TestAddPort_HTTP(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache 2.4.49")
+
+	if len(tree.Ports) != 1 {
+		t.Fatalf("Ports count = %d, want 1", len(tree.Ports))
+	}
+	node := tree.Ports[0]
+	if node.Port != 80 || node.Service != "http" || node.Banner != "Apache 2.4.49" {
+		t.Errorf("port node = %d/%s %s", node.Port, node.Service, node.Banner)
+	}
+	// HTTP ポートは EndpointEnum と VhostDiscov が pending
+	if node.EndpointEnum != StatusPending {
+		t.Errorf("EndpointEnum = %d, want pending", node.EndpointEnum)
+	}
+	if node.VhostDiscov != StatusPending {
+		t.Errorf("VhostDiscov = %d, want pending", node.VhostDiscov)
+	}
+}
+
+func TestAddPort_NonHTTP(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	if len(tree.Ports) != 1 {
+		t.Fatalf("Ports count = %d, want 1", len(tree.Ports))
+	}
+	node := tree.Ports[0]
+	// 非 HTTP はタスクなし
+	if node.EndpointEnum != StatusNone {
+		t.Errorf("EndpointEnum = %d, want none", node.EndpointEnum)
+	}
+	if node.VhostDiscov != StatusNone {
+		t.Errorf("VhostDiscov = %d, want none", node.VhostDiscov)
+	}
+	if node.ParamFuzz != StatusNone {
+		t.Errorf("ParamFuzz = %d, want none", node.ParamFuzz)
+	}
+}
+
+func TestAddEndpoint(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache 2.4.49")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+
+	node := tree.Ports[0]
+	if len(node.Children) != 1 {
+		t.Fatalf("Children count = %d, want 1", len(node.Children))
+	}
+	child := node.Children[0]
+	if child.Path != "/api" {
+		t.Errorf("Path = %q, want /api", child.Path)
+	}
+	if child.EndpointEnum != StatusPending {
+		t.Errorf("EndpointEnum = %d, want pending", child.EndpointEnum)
+	}
+	if child.ParamFuzz != StatusPending {
+		t.Errorf("ParamFuzz = %d, want pending", child.ParamFuzz)
+	}
+	if child.Profiling != StatusPending {
+		t.Errorf("Profiling = %d, want pending", child.Profiling)
+	}
+}
+
+func TestAddEndpoint_Nested(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddEndpoint("10.10.11.100", 80, "/api", "/api/v1")
+	tree.AddEndpoint("10.10.11.100", 80, "/api/v1", "/api/v1/user")
+
+	// / → /api → /api/v1 → /api/v1/user
+	api := tree.Ports[0].Children[0]
+	if api.Path != "/api" {
+		t.Errorf("Path = %q, want /api", api.Path)
+	}
+	if len(api.Children) != 1 {
+		t.Fatalf("api children = %d, want 1", len(api.Children))
+	}
+	v1 := api.Children[0]
+	if v1.Path != "/api/v1" {
+		t.Errorf("Path = %q, want /api/v1", v1.Path)
+	}
+	if len(v1.Children) != 1 {
+		t.Fatalf("v1 children = %d, want 1", len(v1.Children))
+	}
+	user := v1.Children[0]
+	if user.Path != "/api/v1/user" {
+		t.Errorf("Path = %q, want /api/v1/user", user.Path)
+	}
+}
+
+func TestAddVhost(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddVhost("10.10.11.100", 80, "dev.example.com")
+
+	if len(tree.Vhosts) != 1 {
+		t.Fatalf("Vhosts count = %d, want 1", len(tree.Vhosts))
+	}
+	vhost := tree.Vhosts[0]
+	if vhost.Host != "dev.example.com" {
+		t.Errorf("Host = %q, want dev.example.com", vhost.Host)
+	}
+	if vhost.Port != 80 {
+		t.Errorf("Port = %d, want 80", vhost.Port)
+	}
+	if vhost.VhostDiscov != StatusPending {
+		t.Errorf("VhostDiscov = %d, want pending", vhost.VhostDiscov)
+	}
+	if vhost.EndpointEnum != StatusPending {
+		t.Errorf("EndpointEnum = %d, want pending", vhost.EndpointEnum)
+	}
+}
+
+func TestCompleteTask(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+
+	tree.CompleteTask("10.10.11.100", 80, "/api", TaskEndpointEnum)
+	child := tree.Ports[0].Children[0]
+	if child.EndpointEnum != StatusComplete {
+		t.Errorf("EndpointEnum = %d, want complete", child.EndpointEnum)
+	}
+	// 他のタスクは変わらない
+	if child.ParamFuzz != StatusPending {
+		t.Errorf("ParamFuzz = %d, want pending", child.ParamFuzz)
+	}
+}
+
+func TestHasPending(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	// 空のツリーには pending なし
+	if tree.HasPending() {
+		t.Error("empty tree should not have pending")
+	}
+
+	tree.AddPort(22, "ssh", "OpenSSH")
+	// 非 HTTP は pending なし
+	if tree.HasPending() {
+		t.Error("non-HTTP port should not have pending")
+	}
+
+	tree.AddPort(80, "http", "Apache")
+	if !tree.HasPending() {
+		t.Error("HTTP port should have pending")
+	}
+
+	// すべて完了させる
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "", TaskVhostDiscov)
+	if tree.HasPending() {
+		t.Error("all tasks complete, should not have pending")
+	}
+}
+
+func TestCountPending(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	// HTTP ポート: EndpointEnum + VhostDiscov = 2 pending
+	if got := tree.CountPending(); got != 2 {
+		t.Errorf("CountPending = %d, want 2", got)
+	}
+
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	// + EndpointEnum + ParamFuzz + Profiling = 5 pending
+	if got := tree.CountPending(); got != 5 {
+		t.Errorf("CountPending = %d, want 5", got)
+	}
+
+	tree.CompleteTask("10.10.11.100", 80, "/api", TaskEndpointEnum)
+	if got := tree.CountPending(); got != 4 {
+		t.Errorf("CountPending = %d, want 4", got)
+	}
+}
+
+func TestCountTotal(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddPort(22, "ssh", "OpenSSH")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	// HTTP ポート: 2 tasks + endpoint: 3 tasks = 5
+	if got := tree.CountTotal(); got != 5 {
+		t.Errorf("CountTotal = %d, want 5", got)
+	}
+}
+
+func TestNextBatch_RespectsMaxParallel(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/login")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/admin")
+
+	batch := tree.NextBatch()
+	if len(batch) != 2 {
+		t.Errorf("NextBatch len = %d, want 2 (max_parallel)", len(batch))
+	}
+
+	// active を増やすと batch が減る
+	for _, task := range batch {
+		tree.StartTask(task)
+	}
+	batch2 := tree.NextBatch()
+	if len(batch2) != 0 {
+		t.Errorf("NextBatch len = %d, want 0 (at max_parallel)", len(batch2))
+	}
+}
+
+func TestNextBatch_Priority(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 10) // 高い max_parallel で全部返す
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddVhost("10.10.11.100", 80, "dev.example.com")
+
+	batch := tree.NextBatch()
+	if len(batch) == 0 {
+		t.Fatal("NextBatch returned empty")
+	}
+	// 最初のタスクは endpoint_enum であるべき（最高優先度）
+	if batch[0].Type != TaskEndpointEnum {
+		t.Errorf("first task type = %d, want endpoint_enum(%d)", batch[0].Type, TaskEndpointEnum)
+	}
+}
+
+func TestStartTask_FinishTask(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	batch := tree.NextBatch()
+	if len(batch) == 0 {
+		t.Fatal("no tasks")
+	}
+	task := batch[0]
+	tree.StartTask(task)
+
+	if tree.active != 1 {
+		t.Errorf("active = %d, want 1", tree.active)
+	}
+
+	// ノードのステータスが in_progress に
+	node := tree.findNode(task.Host, task.Port, task.Path)
+	if node == nil {
+		t.Fatal("findNode returned nil")
+	}
+	status := node.getReconStatus(task.Type)
+	if status != StatusInProgress {
+		t.Errorf("status = %d, want in_progress", status)
+	}
+
+	tree.FinishTask(task)
+	if tree.active != 0 {
+		t.Errorf("active = %d, want 0", tree.active)
+	}
+	status = node.getReconStatus(task.Type)
+	if status != StatusComplete {
+		t.Errorf("status = %d, want complete", status)
+	}
+}
+
+func TestRenderTree(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddPort(80, "http", "Apache 2.4.49")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/login")
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "/login", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "/login", TaskParamFuzz)
+	tree.CompleteTask("10.10.11.100", 80, "/login", TaskProfiling)
+
+	output := tree.RenderTree()
+
+	// 基本的な内容が含まれるか確認
+	checks := []string{
+		"10.10.11.100",
+		"22/ssh OpenSSH 8.2",
+		"80/http Apache 2.4.49",
+		"/api",
+		"/login",
+		"[x]",
+		"[ ]",
+		"Progress:",
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderTree missing %q\noutput:\n%s", check, output)
+		}
+	}
+}
+
+func TestRenderQueue(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+
+	output := tree.RenderQueue()
+
+	checks := []string{
+		"RECON QUEUE",
+		"pending",
+		"max_parallel=2",
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderQueue missing %q\noutput:\n%s", check, output)
+		}
+	}
+}
+
+func TestRenderQueue_Empty(t *testing.T) {
+	tree := NewReconTree("10.10.11.100", 2)
+	output := tree.RenderQueue()
+	if output != "" {
+		t.Errorf("empty tree should return empty queue, got: %q", output)
+	}
+}

--- a/internal/agent/target.go
+++ b/internal/agent/target.go
@@ -73,6 +73,9 @@ type Target struct {
 	// Entities はツール出力から抽出された発見済みエンティティ（ナレッジグラフ）。
 	// Brain のスナップショット生成に使われる。
 	Entities []tools.Entity
+	// ReconTree は偵察状態を管理するツリー。
+	// Loop goroutine から SetReconTree で設定、TUI goroutine から GetReconTree で読み取る。
+	ReconTree *ReconTree
 }
 
 // GetStatus は Status をスレッドセーフに返す。
@@ -161,4 +164,18 @@ func (t *Target) ClearProposal() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.Proposal = nil
+}
+
+// GetReconTree は ReconTree をスレッドセーフに返す。
+func (t *Target) GetReconTree() *ReconTree {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.ReconTree
+}
+
+// SetReconTree は ReconTree をスレッドセーフに設定する。Loop goroutine から使用。
+func (t *Target) SetReconTree(rt *ReconTree) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ReconTree = rt
 }

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -79,6 +79,8 @@ type Input struct {
 	TurnCount int
 	// Memory は対象ホストの過去の発見物テキスト。空でも可。
 	Memory string
+	// ReconQueue は構造的偵察キューのプロンプト注入テキスト。空でも可。
+	ReconQueue string
 }
 
 // Brain は LLM との対話インターフェース。

--- a/internal/brain/prompt.go
+++ b/internal/brain/prompt.go
@@ -362,6 +362,12 @@ func buildPrompt(input Input) string {
 		sb.WriteString("\n")
 	}
 
+	if input.ReconQueue != "" {
+		sb.WriteString("\n## Reconnaissance Queue\n")
+		sb.WriteString(input.ReconQueue)
+		sb.WriteString("\n")
+	}
+
 	// Last Command セクション（Target State の後、Last Assessment Output の前）
 	if input.LastCommand != "" {
 		sb.WriteString("\n## Last Command\n")

--- a/internal/brain/prompt_test.go
+++ b/internal/brain/prompt_test.go
@@ -154,6 +154,35 @@ func TestBuildPrompt_NoHistory(t *testing.T) {
 	}
 }
 
+
+func TestBuildPrompt_ContainsReconQueue(t *testing.T) {
+	input := Input{
+		TargetSnapshot: `{"host":"10.10.11.100"}`,
+		ReconQueue:     "RECON QUEUE (3 pending, 0 active, max_parallel=2):\n  [next]  endpoint_enum: /api on 10.10.11.100:80\n",
+	}
+	got := buildPrompt(input)
+	if !strings.Contains(got, "Reconnaissance Queue") {
+		t.Error("buildPrompt should contain Reconnaissance Queue section")
+	}
+	if !strings.Contains(got, "RECON QUEUE") {
+		t.Error("buildPrompt should contain RECON QUEUE content")
+	}
+	if !strings.Contains(got, "endpoint_enum") {
+		t.Error("buildPrompt should contain task details")
+	}
+}
+
+func TestBuildPrompt_EmptyReconQueue(t *testing.T) {
+	input := Input{
+		TargetSnapshot: `{"host":"10.10.11.100"}`,
+		ReconQueue:     "",
+	}
+	got := buildPrompt(input)
+	if strings.Contains(got, "Reconnaissance Queue") {
+		t.Error("buildPrompt should NOT contain Reconnaissance Queue when empty")
+	}
+}
+
 // --- parseActionJSON tests ---
 
 func TestParseActionJSON_RawJSON(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,3 +118,37 @@ func TestLoad_MissingSections(t *testing.T) {
 		t.Errorf("expected 0 blacklist patterns for missing section, got %d", len(cfg.Blacklist))
 	}
 }
+
+func TestLoad_ReconConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	os.WriteFile(cfgPath, []byte(`
+recon:
+  max_parallel: 4
+`), 0o644)
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Recon.MaxParallel != 4 {
+		t.Errorf("MaxParallel = %d, want 4", cfg.Recon.MaxParallel)
+	}
+}
+
+func TestLoad_ReconConfig_Default(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	os.WriteFile(cfgPath, []byte(`
+knowledge: []
+`), 0o644)
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Default should be 2
+	if cfg.Recon.MaxParallel != 2 {
+		t.Errorf("MaxParallel = %d, want default 2", cfg.Recon.MaxParallel)
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -254,6 +254,12 @@ func (m *Model) submitInput() {
 		return
 	}
 
+	// /recontree command — show recon tree for the active target
+	if fullText == "/recontree" {
+		m.handleReconTreeCommand()
+		return
+	}
+
 	// ターゲット追加: IP アドレスまたは /target <host>
 	if host, ok := parseTargetInput(fullText); ok && m.team != nil {
 		m.addTarget(host)
@@ -499,6 +505,24 @@ func (m *Model) handleTargetsCommand() {
 		},
 	)
 }
+
+// handleReconTreeCommand は /recontree コマンドを処理する。
+func (m *Model) handleReconTreeCommand() {
+	if m.selected < 0 || m.selected >= len(m.targets) {
+		m.logSystem("No target selected.")
+		return
+	}
+	target := m.targets[m.selected]
+	rt := target.GetReconTree()
+	if rt == nil {
+		m.logSystem("No recon tree available for this target.")
+		return
+	}
+	output := rt.RenderTree()
+	// コードブロックで囲んで glamour の崩れを防止
+	m.logSystem("```\n" + output + "```")
+}
+
 
 // logSystem adds a system message to the active target as a Block.
 func (m *Model) logSystem(msg string) {


### PR DESCRIPTION
## Summary
- Add `ReconTree` data structure that tracks recon progress as a tree (ports → endpoints → children)
- **Parsers**: nmap XML, ffuf JSON, curl output — automatically update tree from tool results
- **Auto-task generation**: discovering new endpoints/vhosts creates pending tasks (enum + param_fuzz + profiling)
- **Parallel control**: `config.yaml` `recon.max_parallel` (default: 2) prevents DoS
- **`/recontree` TUI command**: ASCII tree view of recon progress with `[x][ ][>]` status indicators
- **RECON QUEUE prompt injection**: pending tasks injected into LLM prompt, LLM just executes next task
- **evaluateResult() integration**: tool output parsed automatically, tree updated after each command

## Architecture
See `docs/architecture_design/recon-tree.md` for full design.

```
Agent runs nmap/ffuf/curl
    ↓
evaluateResult() → DetectAndParse() → ReconTree updated
    ↓
Next LLM call: RECON QUEUE injected in prompt
    ↓
LLM executes next pending task
    ↓
Repeat until 0 pending → ANALYZE phase
```

## Files changed (14 files, +1905 lines)
| File | Change |
|------|--------|
| `internal/agent/recon_tree.go` | **New**: ReconTree, ReconNode, RenderTree, RenderQueue |
| `internal/agent/recon_tree_test.go` | **New**: 16 tests |
| `internal/agent/recon_parser.go` | **New**: ParseNmapXML, ParseFfufJSON, DetectAndParse |
| `internal/agent/recon_parser_test.go` | **New**: 10 tests |
| `internal/agent/loop.go` | WithReconTree, buildReconQueue, evaluateResult integration |
| `internal/agent/target.go` | GetReconTree/SetReconTree (thread-safe) |
| `internal/brain/brain.go` | ReconQueue field in Input |
| `internal/brain/prompt.go` | Reconnaissance Queue section injection |
| `internal/brain/prompt_test.go` | 2 new tests |
| `internal/config/config.go` | ReconConfig (max_parallel) |
| `internal/config/config_test.go` | 2 new tests |
| `config/config.example.yaml` | recon section |
| `internal/tui/update.go` | /recontree command |
| `docs/architecture_design/recon-tree.md` | Design doc |

Closes #78

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./internal/... -count=1` — all 9 packages green
- [x] 28 new tests all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)