### PR TITLE
feat: RECON phase lock with /skip-recon override

### DIFF
--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -260,6 +260,12 @@ func (m *Model) submitInput() {
 		return
 	}
 
+	// /skip-recon command — unlock RECON phase for the active target
+	if fullText == "/skip-recon" {
+		m.handleSkipReconCommand()
+		return
+	}
+
 	// ターゲット追加: IP アドレスまたは /target <host>
 	if host, ok := parseTargetInput(fullText); ok && m.team != nil {
 		m.addTarget(host)
@@ -523,6 +529,26 @@ func (m *Model) handleReconTreeCommand() {
 	m.logSystem("```\n" + output + "```")
 }
 
+// handleSkipReconCommand は /skip-recon コマンドを処理する。
+func (m *Model) handleSkipReconCommand() {
+	if m.selected < 0 || m.selected >= len(m.targets) {
+		m.logSystem("No target selected.")
+		return
+	}
+	target := m.targets[m.selected]
+	rt := target.GetReconTree()
+	if rt == nil {
+		m.logSystem("No recon tree available for this target.")
+		return
+	}
+	if !rt.IsLocked() {
+		m.logSystem("RECON phase is already unlocked.")
+		return
+	}
+	pending := rt.CountPending()
+	rt.Unlock()
+	m.logSystem(fmt.Sprintf("RECON phase unlocked (%d pending tasks skipped). Agent will proceed to ANALYZE.", pending))
+}
 
 // logSystem adds a system message to the active target as a Block.
 func (m *Model) logSystem(msg string) {


### PR DESCRIPTION
## Summary

- ReconTree にロック機能追加（デフォルト ON）
- `locked=true` の間はプロンプトに MANDATORY 指令を注入し、LLM が RECON を勝手にスキップするのを防止
- 全 pending タスク完了で自動解除
- `/skip-recon` TUI コマンドでユーザー手動解除（timeout 続出時など）

## Changes

| File | Change |
|------|--------|
| `recon_tree.go` | `locked` field, `IsLocked()`, `Unlock()`, `RenderQueue()` MANDATORY 文言 |
| `recon_tree_test.go` | 6 new tests |
| `tui/update.go` | `/skip-recon` command + handler |

## Test plan

- [x] `go test ./internal/agent/...` — 全テスト PASS
- [x] `go build ./...` — ビルド成功
- [x] `go vet ./...` — 問題なし
- [x] `golangci-lint run` — 0 issues

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)