### PR TITLE
feat: TUI performance — Glamour cache, block render cache, debounce

### DIFF
--- a/internal/agent/display.go
+++ b/internal/agent/display.go
@@ -51,6 +51,11 @@ type DisplayBlock struct {
 
 	// BlockSystem fields
 	SystemMsg string
+
+	// Render cache fields (TUI performance optimization)
+	RenderedCache string // cached render output
+	CacheWidth    int    // width when cache was set
+	CacheExpanded bool   // expanded state when cache was set
 }
 
 // NewCommandBlock はコマンド実行ブロックを作成する。

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -42,6 +42,9 @@ type SelectOption struct {
 // AgentEventMsg は Agent ループから届く Bubble Tea メッセージ。
 type AgentEventMsg agent.Event
 
+// debounceMsg はビューポート再描画のデバウンスタイマー完了メッセージ。
+type debounceMsg struct{}
+
 // Model is the root Bubble Tea model for the Pentecter Commander Console.
 type Model struct {
 	width    int
@@ -71,6 +74,9 @@ type Model struct {
 
 	// logsExpanded が true の場合、すべてのログ内容を折りたたまずに表示する。
 	logsExpanded bool
+
+	// viewportDirty が true の場合、次のスピナーティックまたはデバウンスタイマーでビューポートを再描画する。
+	viewportDirty bool
 
 	// Global system logs — shown when no target is active
 	globalLogs []string


### PR DESCRIPTION
## Summary
- Glamour レンダラーを width 別にキャッシュ（毎回 NewTermRenderer() 排除）
- 完了済みブロックのレンダーキャッシュ（再レンダリングスキップ）
- EventCmdOutput のビューポート再描画をデバウンス（スピナーティックでフラッシュ）
- hasActiveSpinner() を逆方向イテレーションに最適化

**Benchmark**: 50 blocks cached **18μs** vs uncached **2.3ms** (~125x faster)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/...` all green (16 new tests + 3 benchmarks)
- [x] `golangci-lint run` — 0 issues
- [x] Benchmark confirms ~125x speedup for cached block rendering

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)