### PR TITLE
feat: add parameter value fuzzing support

### DIFF
--- a/internal/agent/fuzz_categories.go
+++ b/internal/agent/fuzz_categories.go
@@ -1,0 +1,26 @@
+package agent
+
+// FuzzCategory はバリューファジングのカテゴリ
+type FuzzCategory struct {
+	Name        string // カテゴリ識別子 (e.g. "sqli")
+	Description string // SubAgent プロンプト用の説明
+}
+
+// MinFuzzCategories は必須ファジングカテゴリ（SubAgent は全カテゴリを必ずテストする）
+var MinFuzzCategories = []FuzzCategory{
+	{Name: "numeric", Description: "IDOR/privilege escalation: sequential IDs (0, 1, 2, -1, 99999)"},
+	{Name: "sqli", Description: "SQL Injection: quotes, comments, boolean logic"},
+	{Name: "path", Description: "Path Traversal: ../ sequences, encoding variants"},
+	{Name: "ssti", Description: "Template Injection: {{7*7}}, ${7*7}, #{7*7}"},
+	{Name: "cmdi", Description: "Command Injection: ;id, |id, `id`, $(id)"},
+	{Name: "xss_probe", Description: "XSS: script tags, event handlers, javascript: URI"},
+}
+
+// FuzzCategoryNames は MinFuzzCategories の名前リストを返す（プロンプト注入用）
+func FuzzCategoryNames() []string {
+	names := make([]string, len(MinFuzzCategories))
+	for i, c := range MinFuzzCategories {
+		names[i] = c.Name
+	}
+	return names
+}

--- a/internal/agent/fuzz_categories_test.go
+++ b/internal/agent/fuzz_categories_test.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"testing"
+)
+
+// TestMinFuzzCategories_Count は MinFuzzCategories が正確に6カテゴリであることを検証する
+func TestMinFuzzCategories_Count(t *testing.T) {
+	t.Helper()
+
+	want := 6
+	got := len(MinFuzzCategories)
+	if got != want {
+		t.Errorf("MinFuzzCategories count = %d, want %d", got, want)
+	}
+}
+
+// TestMinFuzzCategories_UniqueNames は全カテゴリ名がユニークであることを検証する
+func TestMinFuzzCategories_UniqueNames(t *testing.T) {
+	t.Helper()
+
+	seen := make(map[string]bool)
+	for _, c := range MinFuzzCategories {
+		if seen[c.Name] {
+			t.Errorf("duplicate category name: %q", c.Name)
+		}
+		seen[c.Name] = true
+	}
+}
+
+// TestMinFuzzCategories_RequiredCategories は必須カテゴリが全て含まれていることを検証する
+func TestMinFuzzCategories_RequiredCategories(t *testing.T) {
+	t.Helper()
+
+	required := []string{"sqli", "path", "ssti", "cmdi", "xss_probe", "numeric"}
+
+	names := make(map[string]bool)
+	for _, c := range MinFuzzCategories {
+		names[c.Name] = true
+	}
+
+	for _, r := range required {
+		if !names[r] {
+			t.Errorf("required category %q not found in MinFuzzCategories", r)
+		}
+	}
+}
+
+// TestFuzzCategoryNames は FuzzCategoryNames() が正しい名前リストを返すことを検証する
+func TestFuzzCategoryNames(t *testing.T) {
+	t.Helper()
+
+	got := FuzzCategoryNames()
+
+	if len(got) != len(MinFuzzCategories) {
+		t.Fatalf("FuzzCategoryNames() returned %d names, want %d", len(got), len(MinFuzzCategories))
+	}
+
+	for i, c := range MinFuzzCategories {
+		if got[i] != c.Name {
+			t.Errorf("FuzzCategoryNames()[%d] = %q, want %q", i, got[i], c.Name)
+		}
+	}
+}
+
+// TestMinFuzzCategories_NonEmpty は全カテゴリの Name と Description が空でないことを検証する
+func TestMinFuzzCategories_NonEmpty(t *testing.T) {
+	t.Helper()
+
+	for i, c := range MinFuzzCategories {
+		if c.Name == "" {
+			t.Errorf("MinFuzzCategories[%d].Name is empty", i)
+		}
+		if c.Description == "" {
+			t.Errorf("MinFuzzCategories[%d].Description is empty", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add Phase 2 value fuzzing to ReconRunner's web recon SubAgent
- After parameter discovery (ffuf), SubAgent tests each parameter with 6 mandatory fuzz categories: numeric, sqli, path, ssti, cmdi, xss_probe
- Code-side baseline comparison detects status code change, content-length ±10%, response time 5x anomalies
- Findings stored in ReconTree and rendered in `/recontree` output

## Changes
| File | Description |
|------|-------------|
| `fuzz_categories.go` | `FuzzCategory` type + `MinFuzzCategories` (6 categories) + `FuzzCategoryNames()` |
| `recon_tree.go` | `Finding` struct, `AddFinding()`, `CountFindings()`, finding rendering in tree |
| `recon_runner.go` | `buildWebReconPrompt()` Phase 2 with dynamic category list + baseline instructions |
| `recon_parser.go` | `CurlMetrics`, `ParseCurlMetrics()`, `Anomaly`, `CompareBaseline()` |

## Test plan
- [x] 24 new tests across 4 test files
- [x] All existing tests pass (full `go test ./internal/... ./pkg/...`)
- [x] `go build`, `go vet`, `golangci-lint` all clean
- [ ] Integration test with vulnerable target (Metasploitable2 / DVWA)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)