### PR TITLE
test: improve test coverage across all packages

### DIFF
--- a/internal/agent/evaluate_test.go
+++ b/internal/agent/evaluate_test.go
@@ -1,7 +1,14 @@
 package agent
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/memory"
+	"github.com/0x6d61/pentecter/internal/tools"
+	"github.com/0x6d61/pentecter/pkg/schema"
 )
 
 func TestIsFailedOutput(t *testing.T) {
@@ -194,6 +201,421 @@ func TestBuildHistory_EmptySummary_NoColon(t *testing.T) {
 	// summary が空なら "exit 0" のみで、コロンは付かない
 	if containsCI(got, "exit 0:") {
 		t.Errorf("empty summary should not produce colon, got:\n%s", got)
+	}
+}
+
+// =============================================================================
+// recordMemory 直接テスト（package agent 内部） (#90)
+// =============================================================================
+
+func TestRecordMemory_Nil(t *testing.T) {
+	evCh := make(chan Event, 32)
+	l := &Loop{
+		target: NewTarget(1, "10.0.0.1"),
+		events: evCh,
+	}
+	// nil を渡してもパニックしない
+	l.recordMemory(nil)
+	// イベントは発行されない
+	select {
+	case e := <-evCh:
+		t.Errorf("expected no event for nil memory, got: %v", e)
+	default:
+	}
+}
+
+func TestRecordMemory_WithoutStore(t *testing.T) {
+	evCh := make(chan Event, 32)
+	l := &Loop{
+		target:      NewTarget(1, "10.0.0.1"),
+		events:      evCh,
+		memoryStore: nil,
+	}
+
+	m := &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "XSS",
+		Description: "reflected XSS in /search",
+		Severity:    "high",
+	}
+	l.recordMemory(m)
+
+	// ログイベントが発行されること
+	select {
+	case e := <-evCh:
+		if e.Type != EventLog {
+			t.Errorf("expected EventLog, got %v", e.Type)
+		}
+		if !strings.Contains(e.Message, "XSS") {
+			t.Errorf("expected 'XSS' in message, got: %s", e.Message)
+		}
+	default:
+		t.Error("expected an event to be emitted")
+	}
+}
+
+func TestRecordMemory_WithStore(t *testing.T) {
+	evCh := make(chan Event, 32)
+	memDir := t.TempDir()
+	memStore := memory.NewStore(memDir)
+
+	l := &Loop{
+		target:      NewTarget(1, "10.0.0.1"),
+		events:      evCh,
+		memoryStore: memStore,
+	}
+
+	m := &schema.Memory{
+		Type:        schema.MemoryCredential,
+		Title:       "SSH key",
+		Description: "found private key in /home/user/.ssh/id_rsa",
+		Severity:    "critical",
+	}
+	l.recordMemory(m)
+
+	// ログイベントが発行されること
+	select {
+	case e := <-evCh:
+		if !strings.Contains(e.Message, "SSH key") {
+			t.Errorf("expected 'SSH key' in message, got: %s", e.Message)
+		}
+	default:
+		t.Error("expected an event to be emitted")
+	}
+
+	// Memory Store に永続化されていること
+	content := memStore.Read("10.0.0.1")
+	if !strings.Contains(content, "SSH key") {
+		t.Errorf("expected memory content to contain 'SSH key', got: %s", content)
+	}
+}
+
+// =============================================================================
+// streamAndCollect 直接テスト（package agent 内部） (#90)
+// =============================================================================
+
+func TestStreamAndCollect_SuccessfulResult(t *testing.T) {
+	evCh := make(chan Event, 64)
+	l := &Loop{
+		target:       NewTarget(1, "10.0.0.1"),
+		events:       evCh,
+		lastCommand:  "echo test",
+		cmdStartTime: time.Now(),
+	}
+
+	linesCh := make(chan tools.OutputLine, 10)
+	resultCh := make(chan *tools.ToolResult, 1)
+
+	linesCh <- tools.OutputLine{Time: time.Now(), Content: "hello", IsError: false}
+	linesCh <- tools.OutputLine{Time: time.Now(), Content: "", IsError: false} // 空行（skip される）
+	linesCh <- tools.OutputLine{Time: time.Now(), Content: "world", IsError: false}
+	close(linesCh)
+
+	resultCh <- &tools.ToolResult{
+		ToolName:   "echo",
+		ExitCode:   0,
+		Truncated:  "hello\nworld",
+		Entities:   []tools.Entity{{Type: tools.EntityPort, Value: "80", Context: "open port"}},
+		StartedAt:  time.Now(),
+		FinishedAt: time.Now(),
+	}
+
+	ctx := t.Context()
+	l.streamAndCollect(ctx, linesCh, resultCh)
+
+	// lastToolOutput が設定されること
+	if l.lastToolOutput != "hello\nworld" {
+		t.Errorf("lastToolOutput: got %q, want %q", l.lastToolOutput, "hello\nworld")
+	}
+	// lastExitCode が設定されること
+	if l.lastExitCode != 0 {
+		t.Errorf("lastExitCode: got %d, want 0", l.lastExitCode)
+	}
+	// history にエントリが追加されること
+	if len(l.history) != 1 {
+		t.Fatalf("history len: got %d, want 1", len(l.history))
+	}
+	if l.history[0].Command != "echo test" {
+		t.Errorf("history[0].Command: got %q, want %q", l.history[0].Command, "echo test")
+	}
+	// Entities が Target に追加されること
+	entities := l.target.SnapshotEntities()
+	found := false
+	for _, e := range entities {
+		if e.Type == tools.EntityPort && e.Value == "80" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected Entity port:80 to be added to target")
+	}
+}
+
+func TestStreamAndCollect_ErrorResult(t *testing.T) {
+	evCh := make(chan Event, 64)
+	l := &Loop{
+		target:       NewTarget(1, "10.0.0.1"),
+		events:       evCh,
+		lastCommand:  "failing-cmd",
+		cmdStartTime: time.Now(),
+	}
+
+	linesCh := make(chan tools.OutputLine, 10)
+	resultCh := make(chan *tools.ToolResult, 1)
+
+	close(linesCh) // 出力なし
+
+	resultCh <- &tools.ToolResult{
+		ToolName:   "failing-cmd",
+		ExitCode:   1,
+		Truncated:  "",
+		Err:        fmt.Errorf("exec failed: command not found"),
+		StartedAt:  time.Now(),
+		FinishedAt: time.Now(),
+	}
+
+	ctx := t.Context()
+	l.streamAndCollect(ctx, linesCh, resultCh)
+
+	// Err がある場合は "Error: ..." が lastToolOutput に設定される
+	if !strings.Contains(l.lastToolOutput, "Error:") {
+		t.Errorf("lastToolOutput should contain 'Error:', got: %q", l.lastToolOutput)
+	}
+	if !strings.Contains(l.lastToolOutput, "exec failed") {
+		t.Errorf("lastToolOutput should contain error message, got: %q", l.lastToolOutput)
+	}
+}
+
+func TestStreamAndCollect_HistoryTruncatedSummary(t *testing.T) {
+	evCh := make(chan Event, 64)
+	l := &Loop{
+		target:       NewTarget(1, "10.0.0.1"),
+		events:       evCh,
+		lastCommand:  "long-output-cmd",
+		cmdStartTime: time.Now(),
+	}
+
+	linesCh := make(chan tools.OutputLine, 10)
+	resultCh := make(chan *tools.ToolResult, 1)
+
+	close(linesCh)
+
+	longOutput := strings.Repeat("X", 300)
+	resultCh <- &tools.ToolResult{
+		ToolName:   "long-output-cmd",
+		ExitCode:   0,
+		Truncated:  longOutput,
+		StartedAt:  time.Now(),
+		FinishedAt: time.Now(),
+	}
+
+	ctx := t.Context()
+	l.streamAndCollect(ctx, linesCh, resultCh)
+
+	// history の Summary が 200 文字に切り捨てられること
+	if len(l.history) != 1 {
+		t.Fatalf("history len: got %d, want 1", len(l.history))
+	}
+	if len(l.history[0].Summary) != 200 {
+		t.Errorf("history[0].Summary len: got %d, want 200", len(l.history[0].Summary))
+	}
+}
+
+func TestStreamAndCollect_HistoryCap(t *testing.T) {
+	evCh := make(chan Event, 256)
+	l := &Loop{
+		target:       NewTarget(1, "10.0.0.1"),
+		events:       evCh,
+		cmdStartTime: time.Now(),
+	}
+
+	// 12 エントリを追加
+	for i := 0; i < 12; i++ {
+		linesCh := make(chan tools.OutputLine)
+		resultCh := make(chan *tools.ToolResult, 1)
+		close(linesCh)
+
+		l.lastCommand = strings.Repeat("a", i+1) // ユニークなコマンド名
+		resultCh <- &tools.ToolResult{
+			ToolName:   "cmd",
+			ExitCode:   0,
+			Truncated:  "output",
+			StartedAt:  time.Now(),
+			FinishedAt: time.Now(),
+		}
+
+		ctx := t.Context()
+		l.streamAndCollect(ctx, linesCh, resultCh)
+	}
+
+	// history は最大10件
+	if len(l.history) != 10 {
+		t.Errorf("history len: got %d, want 10 (cap)", len(l.history))
+	}
+	// 最古のエントリ（長さ1の "a"）は削除されているはず
+	if l.history[0].Command == "a" {
+		t.Error("oldest entry should have been evicted")
+	}
+}
+
+// =============================================================================
+// buildHistory テスト: 5件超の history (#90)
+// =============================================================================
+
+func TestBuildHistory_MoreThan5_ShowsLast5(t *testing.T) {
+	evCh := make(chan Event, 32)
+	entries := make([]commandEntry, 8)
+	for i := 0; i < 8; i++ {
+		entries[i] = commandEntry{
+			Command:  strings.Repeat("c", i+1),
+			ExitCode: 0,
+			Summary:  "ok",
+		}
+	}
+	l := &Loop{
+		target:  NewTarget(1, "10.0.0.1"),
+		events:  evCh,
+		history: entries,
+	}
+	got := l.buildHistory()
+
+	// 最新5件のみ表示（entries[3]〜entries[7]）
+	// entries[0]（"c"）は最古なので表示されないはず
+	// ただし部分一致するため、最短コマンド "c" 単独では判定できない
+	// entries[2]（"ccc"）が表示されないことで、最古3件が除外されていることを間接確認
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) != 5 {
+		t.Errorf("expected 5 history lines, got %d:\n%s", len(lines), got)
+	}
+	// 最新のエントリ entries[7]（"cccccccc"）は必ず含まれる
+	if !strings.Contains(got, "cccccccc") {
+		t.Errorf("expected latest entry in history, got:\n%s", got)
+	}
+	// 5行しかないことを確認（番号 1.〜5.）
+	lineCount := strings.Count(got, "\n")
+	if lineCount != 5 {
+		t.Errorf("expected 5 lines in history output, got %d lines:\n%s", lineCount, got)
+	}
+}
+
+// =============================================================================
+// buildReconQueue / buildMemory テスト (#90)
+// =============================================================================
+
+func TestBuildMemory_NilStore(t *testing.T) {
+	l := &Loop{
+		target:      NewTarget(1, "10.0.0.1"),
+		events:      make(chan Event, 32),
+		memoryStore: nil,
+	}
+	got := l.buildMemory()
+	if got != "" {
+		t.Errorf("buildMemory with nil store should return empty, got: %q", got)
+	}
+}
+
+func TestBuildMemory_WithStore(t *testing.T) {
+	memDir := t.TempDir()
+	memStore := memory.NewStore(memDir)
+	// 事前にメモリを記録
+	_ = memStore.Record("10.0.0.1", &schema.Memory{
+		Type:        schema.MemoryVulnerability,
+		Title:       "Test Vuln",
+		Description: "test description",
+		Severity:    "high",
+	})
+
+	l := &Loop{
+		target:      NewTarget(1, "10.0.0.1"),
+		events:      make(chan Event, 32),
+		memoryStore: memStore,
+	}
+	got := l.buildMemory()
+	if !strings.Contains(got, "Test Vuln") {
+		t.Errorf("buildMemory should contain recorded memory, got: %q", got)
+	}
+}
+
+func TestBuildReconQueue_NilTree(t *testing.T) {
+	l := &Loop{
+		target:    NewTarget(1, "10.0.0.1"),
+		events:    make(chan Event, 32),
+		reconTree: nil,
+	}
+	got := l.buildReconQueue()
+	if got != "" {
+		t.Errorf("buildReconQueue with nil tree should return empty, got: %q", got)
+	}
+}
+
+func TestBuildSnapshot_JSONFormat(t *testing.T) {
+	l := &Loop{
+		target: NewTarget(1, "10.0.0.1"),
+		events: make(chan Event, 32),
+	}
+	got := l.buildSnapshot()
+	if !strings.Contains(got, "10.0.0.1") {
+		t.Errorf("buildSnapshot should contain host, got: %q", got)
+	}
+	if !strings.Contains(got, "host") {
+		t.Errorf("buildSnapshot should contain 'host' key, got: %q", got)
+	}
+}
+
+// =============================================================================
+// evaluateResult: 連続失敗カウント (#90)
+// =============================================================================
+
+func TestEvaluateResult_ConsecutiveFailures_Reset(t *testing.T) {
+	evCh := make(chan Event, 32)
+	l := &Loop{
+		target:              NewTarget(1, "10.0.0.1"),
+		lastExitCode:        1,
+		lastToolOutput:      "some error",
+		consecutiveFailures: 2,
+		events:              evCh,
+	}
+	l.evaluateResult()
+	if l.consecutiveFailures != 3 {
+		t.Errorf("consecutiveFailures: got %d, want 3", l.consecutiveFailures)
+	}
+
+	// 成功でリセット
+	l.lastExitCode = 0
+	l.lastToolOutput = "PORT 80 open"
+	l.evaluateResult()
+	if l.consecutiveFailures != 0 {
+		t.Errorf("consecutiveFailures after success: got %d, want 0", l.consecutiveFailures)
+	}
+}
+
+func TestEvaluateResult_SignalB_FailedOutputPattern(t *testing.T) {
+	// exit code 0 でも出力パターンが failure → 失敗カウント増加
+	evCh := make(chan Event, 32)
+	l := &Loop{
+		target:         NewTarget(1, "10.0.0.1"),
+		lastExitCode:   0,
+		lastToolOutput: "0 hosts up", // Signal B: failure pattern
+		events:         evCh,
+	}
+	l.evaluateResult()
+	if l.consecutiveFailures != 1 {
+		t.Errorf("consecutiveFailures: got %d, want 1 (Signal B should detect failure)", l.consecutiveFailures)
+	}
+}
+
+func TestEvaluateResult_EmptyOutput_Failure(t *testing.T) {
+	// 空出力 → isFailedOutput returns true → 失敗
+	evCh := make(chan Event, 32)
+	l := &Loop{
+		target:         NewTarget(1, "10.0.0.1"),
+		lastExitCode:   0,
+		lastToolOutput: "",
+		events:         evCh,
+	}
+	l.evaluateResult()
+	if l.consecutiveFailures != 1 {
+		t.Errorf("consecutiveFailures: got %d, want 1 (empty output = failure)", l.consecutiveFailures)
 	}
 }
 

--- a/internal/agent/loop_tasks_test.go
+++ b/internal/agent/loop_tasks_test.go
@@ -1,0 +1,439 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0x6d61/pentecter/internal/agent"
+	"github.com/0x6d61/pentecter/internal/tools"
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// TestHandleKillTask_NoTaskManager tests kill_task with nil taskMgr returns error.
+func TestHandleKillTask_NoTaskManager(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "killing task", Action: schema.ActionKillTask, TaskID: "task-1"},
+		},
+	}
+	loop, events, _, _ := newTestLoop(target, mb)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(4 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				toolOutput := mb.inputs[1].ToolOutput
+				if !strings.Contains(toolOutput, "Error") {
+					t.Errorf("should contain Error, got: %s", toolOutput)
+				}
+				if !strings.Contains(toolOutput, "TaskManager not configured") {
+					t.Errorf("should mention TaskManager, got: %s", toolOutput)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestHandleKillTask_TaskNotFound tests kill_task with nonexistent TaskID.
+func TestHandleKillTask_TaskNotFound(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "killing nonexistent", Action: schema.ActionKillTask, TaskID: "task-999"},
+		},
+	}
+	loop, _, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(4 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				toolOutput := mb.inputs[1].ToolOutput
+				if !strings.Contains(toolOutput, "Error") {
+					t.Errorf("should contain Error, got: %s", toolOutput)
+				}
+				if !strings.Contains(toolOutput, "not found") {
+					t.Errorf("should mention not found, got: %s", toolOutput)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestBuildTaskResult_WithFindings tests that Findings appear in result text.
+func TestBuildTaskResult_WithFindings(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "waiting", Action: schema.ActionWait, TaskID: "task-inject-1"},
+		},
+	}
+	loop, taskMgr, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	task := agent.NewSubTask("task-inject-1", agent.TaskKindSmart, "find vulns")
+	task.Findings = []string{
+		"SQL injection in /api/users",
+		"XSS in /search",
+	}
+	task.Status = agent.TaskStatusCompleted
+	task.Complete()
+	taskMgr.InjectTask("task-inject-1", task)
+	taskMgr.InjectDone("task-inject-1")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				toolOutput := mb.inputs[1].ToolOutput
+				if !strings.Contains(toolOutput, "findings") {
+					t.Errorf("should contain findings, got: %s", toolOutput)
+				}
+				if !strings.Contains(toolOutput, "SQL injection") {
+					t.Errorf("should contain SQL injection, got: %s", toolOutput)
+				}
+				if !strings.Contains(toolOutput, "XSS") {
+					t.Errorf("should contain XSS, got: %s", toolOutput)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestBuildTaskResult_LongOutput tests that >2000 char output is truncated.
+func TestBuildTaskResult_LongOutput(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "waiting", Action: schema.ActionWait, TaskID: "task-inject-2"},
+		},
+	}
+	loop, taskMgr, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	task := agent.NewSubTask("task-inject-2", agent.TaskKindSmart, "generate output")
+	longLine := strings.Repeat("A", 3000)
+	task.AppendOutput(longLine)
+	task.Status = agent.TaskStatusCompleted
+	task.Complete()
+	taskMgr.InjectTask("task-inject-2", task)
+	taskMgr.InjectDone("task-inject-2")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				toolOutput := mb.inputs[1].ToolOutput
+				if !strings.Contains(toolOutput, "truncated") {
+					preview := toolOutput
+					if len(preview) > 200 {
+						preview = preview[:200]
+					}
+					t.Errorf("should contain truncated, got (len=%d): %s", len(toolOutput), preview)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestBuildTaskResult_WithEntities tests SubTask Entities are added to Target.
+func TestBuildTaskResult_WithEntities(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "waiting", Action: schema.ActionWait, TaskID: "task-inject-3"},
+		},
+	}
+	loop, taskMgr, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	task := agent.NewSubTask("task-inject-3", agent.TaskKindSmart, "discover entities")
+	task.Entities = []tools.Entity{
+		{Type: tools.EntityPort, Value: "8080", Context: "open port"},
+		{Type: tools.EntityCVE, Value: "CVE-2023-12345", Context: "vulnerability found"},
+	}
+	task.Status = agent.TaskStatusCompleted
+	task.Complete()
+	taskMgr.InjectTask("task-inject-3", task)
+	taskMgr.InjectDone("task-inject-3")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				entities := target.SnapshotEntities()
+				found8080 := false
+				foundCVE := false
+				for _, ent := range entities {
+					if ent.Type == tools.EntityPort && ent.Value == "8080" {
+						found8080 = true
+					}
+					if ent.Type == tools.EntityCVE && ent.Value == "CVE-2023-12345" {
+						foundCVE = true
+					}
+				}
+				if !found8080 {
+					t.Errorf("expected Entity port:8080, entities: %v", entities)
+				}
+				if !foundCVE {
+					t.Errorf("expected Entity cve:CVE-2023-12345, entities: %v", entities)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestBuildTaskResult_EmptyOutput tests empty task has no findings/truncated.
+func TestBuildTaskResult_EmptyOutput(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "waiting", Action: schema.ActionWait, TaskID: "task-inject-4"},
+		},
+	}
+	loop, taskMgr, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	task := agent.NewSubTask("task-inject-4", agent.TaskKindSmart, "no output task")
+	task.Status = agent.TaskStatusCompleted
+	task.Complete()
+	taskMgr.InjectTask("task-inject-4", task)
+	taskMgr.InjectDone("task-inject-4")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				toolOutput := mb.inputs[1].ToolOutput
+				if strings.Contains(toolOutput, "findings") {
+					t.Errorf("should not contain findings, got: %s", toolOutput)
+				}
+				if strings.Contains(toolOutput, "truncated") {
+					t.Errorf("should not contain truncated, got: %s", toolOutput)
+				}
+				if !strings.Contains(toolOutput, "no output task") {
+					t.Errorf("should contain goal text, got: %s", toolOutput)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestHandleWait_NoTaskManager tests wait with nil taskMgr returns error.
+func TestHandleWait_NoTaskManager(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "waiting", Action: schema.ActionWait},
+		},
+	}
+	loop, events, _, _ := newTestLoop(target, mb)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(4 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				toolOutput := mb.inputs[1].ToolOutput
+				if !strings.Contains(toolOutput, "Error") {
+					t.Errorf("should contain Error, got: %s", toolOutput)
+				}
+				if !strings.Contains(toolOutput, "TaskManager not configured") {
+					t.Errorf("should mention TaskManager, got: %s", toolOutput)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestHandleWait_SpecificTask tests waiting for a specific task ID.
+func TestHandleWait_SpecificTask(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "waiting for injected", Action: schema.ActionWait, TaskID: "task-inject-5"},
+		},
+	}
+	loop, taskMgr, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	task := agent.NewSubTask("task-inject-5", agent.TaskKindSmart, "specific task")
+	task.AppendOutput("hello from specific task")
+	task.Status = agent.TaskStatusCompleted
+	task.Complete()
+	taskMgr.InjectTask("task-inject-5", task)
+	taskMgr.InjectDone("task-inject-5")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				toolOutput := mb.inputs[1].ToolOutput
+				if !strings.Contains(toolOutput, "specific task") {
+					t.Errorf("should contain goal text, got: %s", toolOutput)
+				}
+				if !strings.Contains(toolOutput, "hello from specific task") {
+					t.Errorf("should contain task output, got: %s", toolOutput)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestHandleWait_ContextCancelled tests context cancellation stops the wait.
+func TestHandleWait_ContextCancelled(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "spawning", Action: schema.ActionSpawnTask,
+				Command: "sleep 60", TaskGoal: "long task"},
+			{Thought: "waiting forever", Action: schema.ActionWait, TaskID: "task-1"},
+		},
+	}
+	loop, _, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventLog && strings.Contains(e.Message, "Agent stopped") {
+				return
+			}
+		case <-deadline:
+			if ctx.Err() != nil {
+				return
+			}
+			t.Fatal("timeout: loop did not stop after context cancellation")
+		}
+	}
+}
+
+// TestDrainCompletedTasks_NoTaskManager tests drain with nil taskMgr.
+func TestDrainCompletedTasks_NoTaskManager(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "echo test", Action: schema.ActionRun, Command: "echo hello"},
+		},
+	}
+	loop, events, _, _ := newTestLoop(target, mb)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(4 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestDrainCompletedTasks_PushModel tests auto-injection of completed subtask results.
+func TestDrainCompletedTasks_PushModel(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "checking", Action: schema.ActionThink},
+		},
+	}
+	loop, taskMgr, events, _, _ := newTestLoopWithTaskManager(target, mb)
+	task := agent.NewSubTask("task-drain-1", agent.TaskKindSmart, "auto drain task")
+	task.Findings = []string{"push model finding"}
+	task.Status = agent.TaskStatusCompleted
+	task.Complete()
+	taskMgr.InjectTask("task-drain-1", task)
+	taskMgr.InjectDone("task-drain-1")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				foundDrainResult := false
+				for _, input := range mb.inputs {
+					if strings.Contains(input.ToolOutput, "SubTask Completed") &&
+						strings.Contains(input.ToolOutput, "push model finding") {
+						foundDrainResult = true
+						break
+					}
+				}
+				if !foundDrainResult {
+					t.Errorf("expected drained subtask result in Think() ToolOutput")
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -643,3 +643,1207 @@ func TestAnthropicBrain_ExtractTarget_APIError(t *testing.T) {
 		t.Error("expected error for API error response, got nil")
 	}
 }
+
+// --- Provider() テスト ---
+
+func TestAnthropicBrain_Provider(t *testing.T) {
+	// brain.New で anthropicBrain を生成し、Provider() が "anthropic" を返すことを確認。
+	// モックサーバーは不要（Provider() はネットワークアクセスしない）。
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-provider",
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	got := b.Provider()
+	if got != "anthropic" {
+		t.Errorf("Provider(): got %q, want %q", got, "anthropic")
+	}
+}
+
+func TestOpenAIBrain_Provider(t *testing.T) {
+	// brain.New で openAIBrain を生成し、Provider() が "openai" を返すことを確認。
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test-provider",
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	got := b.Provider()
+	if got != "openai" {
+		t.Errorf("Provider(): got %q, want %q", got, "openai")
+	}
+}
+
+func TestOllamaBrain_Provider(t *testing.T) {
+	// Ollama は OpenAI 互換ラッパーだが Provider() は "ollama" を返すはず。
+	// 既存の TestOllamaBrain_Think でも検証済みだが、明示的なテストとして追加。
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOllama,
+		Model:    "llama3.2",
+		BaseURL:  "http://localhost:11434",
+	})
+	if err != nil {
+		t.Fatalf("brain.New (ollama): %v", err)
+	}
+
+	got := b.Provider()
+	if got != "ollama" {
+		t.Errorf("Provider(): got %q, want %q", got, "ollama")
+	}
+}
+
+// =============================================================================
+// parseAnthropicResponse エッジケース
+// =============================================================================
+
+// parseAnthropicResponse: 不正な JSON を渡すと unmarshal エラーになること。
+func TestAnthropicBrain_Think_MalformedJSON(t *testing.T) {
+	// サーバーが不正な JSON を返す場合
+	srv := mockAnthropicServer(t, `{this is not valid json}`)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for malformed JSON response, got nil")
+	}
+}
+
+// parseAnthropicResponse: content 配列が空の場合、"no text content" エラーになること。
+func TestAnthropicBrain_Think_EmptyContent(t *testing.T) {
+	// content 配列が空のレスポンス
+	emptyContentResp := `{
+		"id": "msg_test",
+		"type": "message",
+		"role": "assistant",
+		"content": [],
+		"model": "claude-sonnet-4-6",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 0}
+	}`
+	srv := mockAnthropicServer(t, emptyContentResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for empty content array, got nil")
+	}
+}
+
+// parseAnthropicResponse: content に text 以外のタイプ（例: tool_use）のみが含まれる場合。
+func TestAnthropicBrain_Think_NonTextContentOnly(t *testing.T) {
+	nonTextResp := `{
+		"id": "msg_test",
+		"type": "message",
+		"role": "assistant",
+		"content": [{"type": "tool_use", "text": ""}],
+		"model": "claude-sonnet-4-6",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 5}
+	}`
+	srv := mockAnthropicServer(t, nonTextResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error when content has only non-text blocks, got nil")
+	}
+}
+
+// parseAnthropicResponse: text ブロック内の action JSON が不正な場合。
+func TestAnthropicBrain_Think_InvalidActionJSON(t *testing.T) {
+	// text ブロックはあるが、中身が有効な action JSON ではない
+	invalidActionResp := anthropicResponse(`not a valid action json`)
+	srv := mockAnthropicServer(t, invalidActionResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for invalid action JSON in text block, got nil")
+	}
+}
+
+// parseAnthropicResponse: text ブロックに action フィールドがない場合。
+func TestAnthropicBrain_Think_MissingActionField(t *testing.T) {
+	missingAction := `{"thought":"analyzing"}`
+	srv := mockAnthropicServer(t, anthropicResponse(missingAction))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for missing action field, got nil")
+	}
+}
+
+// =============================================================================
+// parseOpenAIResponse エッジケース
+// =============================================================================
+
+// parseOpenAIResponse: 不正な JSON を渡すと unmarshal エラーになること。
+func TestOpenAIBrain_Think_MalformedJSON(t *testing.T) {
+	srv := mockOpenAIServer(t, `{not valid json at all}`)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for malformed JSON response, got nil")
+	}
+}
+
+// parseOpenAIResponse: choices 配列が空の場合。
+func TestOpenAIBrain_Think_EmptyChoices(t *testing.T) {
+	emptyChoicesResp := `{
+		"id": "chatcmpl-test",
+		"object": "chat.completion",
+		"choices": [],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 0}
+	}`
+	srv := mockOpenAIServer(t, emptyChoicesResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for empty choices, got nil")
+	}
+}
+
+// parseOpenAIResponse: message.content 内のアクション JSON が不正な場合。
+func TestOpenAIBrain_Think_InvalidActionJSON(t *testing.T) {
+	invalidActionResp := openAIResponse(`this is not action json`)
+	srv := mockOpenAIServer(t, invalidActionResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for invalid action JSON in message content, got nil")
+	}
+}
+
+// parseOpenAIResponse: message.content に action フィールドがない場合。
+func TestOpenAIBrain_Think_MissingActionField(t *testing.T) {
+	missingAction := `{"thought":"analyzing"}`
+	srv := mockOpenAIServer(t, openAIResponse(missingAction))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for missing action field, got nil")
+	}
+}
+
+// =============================================================================
+// Anthropic Think — API エラーパス
+// =============================================================================
+
+// Anthropic Think: API が非 200 ステータスを返す場合。
+func TestAnthropicBrain_Think_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"type":"rate_limit_error","message":"too many requests"}}`))
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for API error response, got nil")
+	}
+}
+
+// Anthropic Think: コンテキストがキャンセルされた場合。
+func TestAnthropicBrain_Think_ContextCanceled(t *testing.T) {
+	// リクエストが来たらブロックするサーバー（キャンセルでエラーになるはず）
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 即座にキャンセル
+
+	_, err = b.Think(ctx, brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for canceled context, got nil")
+	}
+}
+
+// =============================================================================
+// OpenAI Think — API エラーパス
+// =============================================================================
+
+// OpenAI Think: API が非 200 ステータスを返す場合。
+func TestOpenAIBrain_Think_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"internal server error"}}`))
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for API error response, got nil")
+	}
+}
+
+// OpenAI Think: コンテキストがキャンセルされた場合。
+func TestOpenAIBrain_Think_ContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.Think(ctx, brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for canceled context, got nil")
+	}
+}
+
+// =============================================================================
+// ExtractTarget (Anthropic) エッジケース
+// =============================================================================
+
+// Anthropic ExtractTarget: レスポンスが不正な JSON の場合。
+func TestAnthropicBrain_ExtractTarget_MalformedJSON(t *testing.T) {
+	srv := mockAnthropicServer(t, `{invalid json}`)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "eighteen.htbを攻略して")
+	if err == nil {
+		t.Error("expected error for malformed JSON response, got nil")
+	}
+}
+
+// Anthropic ExtractTarget: content 配列が空の場合。
+func TestAnthropicBrain_ExtractTarget_EmptyContent(t *testing.T) {
+	emptyContentResp := `{
+		"id": "msg_test",
+		"type": "message",
+		"role": "assistant",
+		"content": [],
+		"model": "claude-sonnet-4-6",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 0}
+	}`
+	srv := mockAnthropicServer(t, emptyContentResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "eighteen.htbを攻略して")
+	if err == nil {
+		t.Error("expected error for empty content array, got nil")
+	}
+}
+
+// Anthropic ExtractTarget: content に text 以外のタイプのみ含まれる場合。
+func TestAnthropicBrain_ExtractTarget_NonTextContentOnly(t *testing.T) {
+	nonTextResp := `{
+		"id": "msg_test",
+		"type": "message",
+		"role": "assistant",
+		"content": [{"type": "tool_use", "text": ""}],
+		"model": "claude-sonnet-4-6",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 5}
+	}`
+	srv := mockAnthropicServer(t, nonTextResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "eighteen.htbを攻略して")
+	if err == nil {
+		t.Error("expected error when content has only non-text blocks, got nil")
+	}
+}
+
+// Anthropic ExtractTarget: text ブロック内の JSON が不正な場合。
+func TestAnthropicBrain_ExtractTarget_InvalidTargetJSON(t *testing.T) {
+	invalidTargetResp := anthropicResponse(`this is not valid extract target json`)
+	srv := mockAnthropicServer(t, invalidTargetResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "eighteen.htbを攻略して")
+	if err == nil {
+		t.Error("expected error for invalid target JSON in text block, got nil")
+	}
+}
+
+// Anthropic ExtractTarget: コンテキストキャンセル。
+func TestAnthropicBrain_ExtractTarget_ContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err = b.ExtractTarget(ctx, "eighteen.htbを攻略して")
+	if err == nil {
+		t.Error("expected error for canceled context, got nil")
+	}
+}
+
+// Anthropic ExtractTarget: OAuth 認証で成功する場合。
+func TestAnthropicBrain_ExtractTarget_OAuthToken(t *testing.T) {
+	extractJSON := `{"host":"ten.htb","instruction":"scan it"}`
+	// OAuth 認証ヘッダーを検証するカスタムサーバー
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			http.Error(w, "missing Authorization header", http.StatusUnauthorized)
+			return
+		}
+		beta := r.Header.Get("anthropic-beta")
+		if beta == "" {
+			http.Error(w, "missing anthropic-beta header", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(anthropicResponse(extractJSON))) //nolint:errcheck // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter -- テスト専用 httptest サーバー
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthOAuthToken,
+		Token:    "sk-ant-ocp01-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	host, instruction, err := b.ExtractTarget(context.Background(), "ten.htbをスキャンして")
+	if err != nil {
+		t.Fatalf("ExtractTarget: %v", err)
+	}
+	if host != "ten.htb" {
+		t.Errorf("host: got %q, want %q", host, "ten.htb")
+	}
+	if instruction != "scan it" {
+		t.Errorf("instruction: got %q, want %q", instruction, "scan it")
+	}
+}
+
+// =============================================================================
+// ExtractTarget (OpenAI) エッジケース
+// =============================================================================
+
+// OpenAI ExtractTarget: API エラー（非 200）。
+func TestOpenAIBrain_ExtractTarget_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad request"}}`))
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "192.168.1.1 をスキャンして")
+	if err == nil {
+		t.Error("expected error for API error response, got nil")
+	}
+}
+
+// OpenAI ExtractTarget: 不正な JSON レスポンス。
+func TestOpenAIBrain_ExtractTarget_MalformedJSON(t *testing.T) {
+	srv := mockOpenAIServer(t, `{invalid json}`)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "192.168.1.1 をスキャンして")
+	if err == nil {
+		t.Error("expected error for malformed JSON response, got nil")
+	}
+}
+
+// OpenAI ExtractTarget: choices 配列が空の場合。
+func TestOpenAIBrain_ExtractTarget_EmptyChoices(t *testing.T) {
+	emptyChoicesResp := `{
+		"id": "chatcmpl-test",
+		"object": "chat.completion",
+		"choices": [],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 0}
+	}`
+	srv := mockOpenAIServer(t, emptyChoicesResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "192.168.1.1 をスキャンして")
+	if err == nil {
+		t.Error("expected error for empty choices, got nil")
+	}
+}
+
+// OpenAI ExtractTarget: message.content 内の target JSON が不正。
+func TestOpenAIBrain_ExtractTarget_InvalidTargetJSON(t *testing.T) {
+	invalidTargetResp := openAIResponse(`not a valid extract target json at all`)
+	srv := mockOpenAIServer(t, invalidTargetResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "192.168.1.1 をスキャンして")
+	if err == nil {
+		t.Error("expected error for invalid target JSON in message content, got nil")
+	}
+}
+
+// OpenAI ExtractTarget: コンテキストキャンセル。
+func TestOpenAIBrain_ExtractTarget_ContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err = b.ExtractTarget(ctx, "192.168.1.1 をスキャンして")
+	if err == nil {
+		t.Error("expected error for canceled context, got nil")
+	}
+}
+
+// =============================================================================
+// LoadConfig エッジケース
+// =============================================================================
+
+// LoadConfig: Anthropic で全認証環境変数が未設定の場合のエラー。
+func TestLoadConfig_Anthropic_NoCredentials(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+
+	_, err := brain.LoadConfig(brain.ConfigHint{Provider: brain.ProviderAnthropic})
+	if err == nil {
+		t.Error("expected error when no Anthropic credentials are set, got nil")
+	}
+}
+
+// LoadConfig: Anthropic のデフォルトモデルが設定されること。
+func TestLoadConfig_Anthropic_DefaultModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{
+		Provider: brain.ProviderAnthropic,
+		// Model は空 → デフォルトが使われるはず
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Model == "" {
+		t.Error("expected default model to be set for Anthropic")
+	}
+}
+
+// LoadConfig: Anthropic で CLAUDE_CODE_OAUTH_TOKEN が設定されている場合。
+func TestLoadConfig_Anthropic_ClaudeCodeOAuthToken(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-ocp01-claude-code")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{Provider: brain.ProviderAnthropic})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Token != "sk-ant-ocp01-claude-code" {
+		t.Errorf("Token: got %q, want sk-ant-ocp01-claude-code", cfg.Token)
+	}
+	if cfg.AuthType != brain.AuthOAuthToken {
+		t.Errorf("AuthType: got %q, want %q", cfg.AuthType, brain.AuthOAuthToken)
+	}
+}
+
+// LoadConfig: Anthropic API KEY は OAuth より優先されること。
+func TestLoadConfig_Anthropic_APIKeyPriority(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-apikey")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-ocp01-oauth")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "sk-ant-auth")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{Provider: brain.ProviderAnthropic})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	// API key が優先される
+	if cfg.Token != "sk-ant-apikey" {
+		t.Errorf("Token: got %q, want sk-ant-apikey (API key should take priority)", cfg.Token)
+	}
+	if cfg.AuthType != brain.AuthAPIKey {
+		t.Errorf("AuthType: got %q, want %q", cfg.AuthType, brain.AuthAPIKey)
+	}
+}
+
+// LoadConfig: OpenAI で認証環境変数が未設定の場合のエラー。
+func TestLoadConfig_OpenAI_NoCredentials(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	_, err := brain.LoadConfig(brain.ConfigHint{Provider: brain.ProviderOpenAI})
+	if err == nil {
+		t.Error("expected error when no OpenAI credentials are set, got nil")
+	}
+}
+
+// LoadConfig: OpenAI で認証環境変数が設定されている場合の成功パス。
+func TestLoadConfig_OpenAI_Success(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-openai-from-env")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Token != "sk-openai-from-env" {
+		t.Errorf("Token: got %q, want sk-openai-from-env", cfg.Token)
+	}
+	if cfg.AuthType != brain.AuthAPIKey {
+		t.Errorf("AuthType: got %q, want %q", cfg.AuthType, brain.AuthAPIKey)
+	}
+}
+
+// LoadConfig: 不明なプロバイダーの場合のエラー。
+func TestLoadConfig_UnknownProvider(t *testing.T) {
+	_, err := brain.LoadConfig(brain.ConfigHint{Provider: "unknown-provider"})
+	if err == nil {
+		t.Error("expected error for unknown provider, got nil")
+	}
+}
+
+// LoadConfig: Ollama で hint に BaseURL が指定されている場合は環境変数より優先。
+func TestLoadConfig_Ollama_HintBaseURLPriority(t *testing.T) {
+	t.Setenv("OLLAMA_BASE_URL", "http://env-server:11434")
+	t.Setenv("OLLAMA_MODEL", "env-model")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{
+		Provider: brain.ProviderOllama,
+		BaseURL:  "http://hint-server:11434",
+		Model:    "hint-model",
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	// hint の値が優先される
+	if cfg.BaseURL != "http://hint-server:11434" {
+		t.Errorf("BaseURL: got %q, want http://hint-server:11434", cfg.BaseURL)
+	}
+	if cfg.Model != "hint-model" {
+		t.Errorf("Model: got %q, want hint-model", cfg.Model)
+	}
+}
+
+// LoadConfig: Ollama でモデルが環境変数から読まれること。
+func TestLoadConfig_Ollama_ModelFromEnv(t *testing.T) {
+	t.Setenv("OLLAMA_BASE_URL", "")
+	t.Setenv("OLLAMA_MODEL", "codellama")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{Provider: brain.ProviderOllama})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Model != "codellama" {
+		t.Errorf("Model: got %q, want codellama", cfg.Model)
+	}
+}
+
+// =============================================================================
+// brain.New エッジケース
+// =============================================================================
+
+// brain.New: OpenAI でトークンが空の場合のエラー。
+func TestBrain_New_OpenAI_EmptyToken_ReturnsError(t *testing.T) {
+	_, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "",
+	})
+	if err == nil {
+		t.Error("expected error for empty OpenAI token, got nil")
+	}
+}
+
+// brain.New: Ollama でトークンが空の場合でもダミートークンが設定されること。
+func TestBrain_New_Ollama_EmptyToken_SetsDefault(t *testing.T) {
+	action := `{"thought":"test","action":"think"}`
+	srv := mockOpenAIServer(t, openAIResponse(action))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOllama,
+		Model:    "llama3.2",
+		Token:    "", // 空 → ダミートークンが設定されるはず
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New (ollama, empty token): %v", err)
+	}
+	if b == nil {
+		t.Fatal("brain should not be nil")
+	}
+}
+
+// brain.New: Ollama で BaseURL が空の場合にデフォルト URL が設定されること。
+func TestBrain_New_Ollama_EmptyBaseURL_SetsDefault(t *testing.T) {
+	// BaseURL が空の場合はデフォルト値(localhost:11434)が設定される
+	// （実際の接続はしないが、オブジェクトが正常に作成されることを確認）
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOllama,
+		Model:    "llama3.2",
+		BaseURL:  "", // 空 → デフォルトが使われるはず
+	})
+	if err != nil {
+		t.Fatalf("brain.New (ollama, empty base URL): %v", err)
+	}
+	if b == nil {
+		t.Fatal("brain should not be nil")
+	}
+	if b.Provider() != "ollama" {
+		t.Errorf("Provider(): got %q, want %q", b.Provider(), "ollama")
+	}
+}
+
+// brain.New: Ollama でトークンが空でなく指定されている場合はそのまま使用。
+func TestBrain_New_Ollama_WithToken(t *testing.T) {
+	action := `{"thought":"test","action":"think"}`
+	srv := mockOpenAIServer(t, openAIResponse(action))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOllama,
+		Model:    "llama3.2",
+		Token:    "custom-ollama-token",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New (ollama, with token): %v", err)
+	}
+	if b == nil {
+		t.Fatal("brain should not be nil")
+	}
+}
+
+// =============================================================================
+// Anthropic レスポンスの content に混合ブロック（tool_use + text）がある場合
+// =============================================================================
+
+func TestAnthropicBrain_Think_MixedContentBlocks(t *testing.T) {
+	// 最初のブロックが tool_use で、2番目が text の場合 → text が使われること
+	mixedContentResp := `{
+		"id": "msg_test",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "tool_use", "text": ""},
+			{"type": "text", "text": "{\"thought\":\"found it\",\"action\":\"think\"}"}
+		],
+		"model": "claude-sonnet-4-6",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 20}
+	}`
+	srv := mockAnthropicServer(t, mixedContentResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	result, err := b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err != nil {
+		t.Fatalf("Think: %v", err)
+	}
+	if result.Action != schema.ActionThink {
+		t.Errorf("Action: got %q, want %q", result.Action, schema.ActionThink)
+	}
+	if result.Thought != "found it" {
+		t.Errorf("Thought: got %q, want %q", result.Thought, "found it")
+	}
+}
+
+// Anthropic ExtractTarget: content に混合ブロックがある場合。
+func TestAnthropicBrain_ExtractTarget_MixedContentBlocks(t *testing.T) {
+	mixedContentResp := `{
+		"id": "msg_test",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "tool_use", "text": ""},
+			{"type": "text", "text": "{\"host\":\"mixed.htb\",\"instruction\":\"test\"}"}
+		],
+		"model": "claude-sonnet-4-6",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 10, "output_tokens": 20}
+	}`
+	srv := mockAnthropicServer(t, mixedContentResp)
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderAnthropic,
+		Model:    "claude-sonnet-4-6",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-ant-test-key",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	host, instruction, err := b.ExtractTarget(context.Background(), "mixed.htbを攻略して")
+	if err != nil {
+		t.Fatalf("ExtractTarget: %v", err)
+	}
+	if host != "mixed.htb" {
+		t.Errorf("host: got %q, want %q", host, "mixed.htb")
+	}
+	if instruction != "test" {
+		t.Errorf("instruction: got %q, want %q", instruction, "test")
+	}
+}
+
+// =============================================================================
+// OpenAI Think — BaseURL パスバリエーション
+// =============================================================================
+
+// OpenAI Think: BaseURL が /v1 で終わる場合（Ollama 互換）。
+func TestOpenAIBrain_Think_BaseURLWithV1(t *testing.T) {
+	action := `{"thought":"checking","action":"think"}`
+	srv := mockOpenAIServer(t, openAIResponse(action))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL + "/v1",
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	result, err := b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err != nil {
+		t.Fatalf("Think: %v", err)
+	}
+	if result.Action != schema.ActionThink {
+		t.Errorf("Action: got %q, want %q", result.Action, schema.ActionThink)
+	}
+}
+
+// OpenAI ExtractTarget: BaseURL が /v1 で終わる場合（Ollama 互換）。
+func TestOpenAIBrain_ExtractTarget_BaseURLWithV1(t *testing.T) {
+	extractJSON := `{"host":"v1test.htb","instruction":"test"}`
+	srv := mockOpenAIServer(t, openAIResponse(extractJSON))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenAI,
+		Model:    "gpt-4o",
+		AuthType: brain.AuthAPIKey,
+		Token:    "sk-openai-test",
+		BaseURL:  srv.URL + "/v1",
+	})
+	if err != nil {
+		t.Fatalf("brain.New: %v", err)
+	}
+
+	host, _, err := b.ExtractTarget(context.Background(), "v1test.htbを攻略して")
+	if err != nil {
+		t.Fatalf("ExtractTarget: %v", err)
+	}
+	if host != "v1test.htb" {
+		t.Errorf("host: got %q, want %q", host, "v1test.htb")
+	}
+}
+
+// =============================================================================
+// DetectAvailableProviders 追加テスト
+// =============================================================================
+
+// DetectAvailableProviders: ANTHROPIC_AUTH_TOKEN のみ設定された場合。
+func TestDetectAvailableProviders_AnthropicAuthToken(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "sk-ant-auth-test")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OLLAMA_BASE_URL", "")
+
+	providers := brain.DetectAvailableProviders()
+	if len(providers) == 0 {
+		t.Fatal("expected at least one provider when ANTHROPIC_AUTH_TOKEN is set")
+	}
+	if providers[0] != brain.ProviderAnthropic {
+		t.Errorf("first provider: got %q, want anthropic", providers[0])
+	}
+}
+
+// DetectAvailableProviders: 全プロバイダーが利用可能な場合。
+func TestDetectAvailableProviders_All(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("OPENAI_API_KEY", "sk-openai-test")
+	t.Setenv("OLLAMA_BASE_URL", "http://localhost:11434")
+
+	providers := brain.DetectAvailableProviders()
+	if len(providers) != 3 {
+		t.Fatalf("expected 3 providers, got %d: %v", len(providers), providers)
+	}
+	// 優先順位: Anthropic > OpenAI > Ollama
+	if providers[0] != brain.ProviderAnthropic {
+		t.Errorf("first provider: got %q, want anthropic", providers[0])
+	}
+	if providers[1] != brain.ProviderOpenAI {
+		t.Errorf("second provider: got %q, want openai", providers[1])
+	}
+	if providers[2] != brain.ProviderOllama {
+		t.Errorf("third provider: got %q, want ollama", providers[2])
+	}
+}
+
+// =============================================================================
+// Ollama ExtractTarget エッジケース
+// =============================================================================
+
+// Ollama ExtractTarget: API エラー。
+func TestOllamaBrain_ExtractTarget_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"service unavailable"}`))
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOllama,
+		Model:    "llama3.2",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New (ollama): %v", err)
+	}
+
+	_, _, err = b.ExtractTarget(context.Background(), "target.local をスキャン")
+	if err == nil {
+		t.Error("expected error for API error response, got nil")
+	}
+}
+
+// Ollama Think: API エラー。
+func TestOllamaBrain_Think_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"model not found"}`))
+	}))
+	defer srv.Close()
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOllama,
+		Model:    "llama3.2",
+		BaseURL:  srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("brain.New (ollama): %v", err)
+	}
+
+	_, err = b.Think(context.Background(), brain.Input{
+		TargetSnapshot: `{"ip":"10.0.0.5"}`,
+	})
+	if err == nil {
+		t.Error("expected error for API error response, got nil")
+	}
+}

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -184,6 +184,20 @@ func TestLoadConfig_InvalidYAML(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_ReadError(t *testing.T) {
+	// ファイルが存在するが読み取りエラーが発生する場合（例: ディレクトリを読もうとする）
+	dir := t.TempDir()
+	// ディレクトリパスを config として読もうとする → os.ErrNotExist 以外のエラー
+	_, err := LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected error when reading a directory as config file")
+	}
+	// エラーが返され、nil でないことを確認（os.ErrNotExist とは異なるパス）
+	if err.Error() == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
 func TestLoadConfig_EmptyServers(t *testing.T) {
 	// servers が空配列の場合も正常に読み込めること
 	dir := t.TempDir()

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -442,3 +442,26 @@ func TestStore_Record_TimestampFormat(t *testing.T) {
 		t.Errorf("Expected timestamp starting with [20, got:\n%s", content)
 	}
 }
+
+// --- BaseDir テスト ---
+
+func TestStore_BaseDir(t *testing.T) {
+	dir := t.TempDir()
+	s := memory.NewStore(dir)
+
+	got := s.BaseDir()
+	if got != dir {
+		t.Errorf("BaseDir: got %q, want %q", got, dir)
+	}
+}
+
+func TestStore_BaseDir_CustomPath(t *testing.T) {
+	// 任意のパス文字列がそのまま返ることを確認（ディレクトリの存在は問わない）
+	customDir := "/tmp/pentecter-test-nonexistent-12345"
+	s := memory.NewStore(customDir)
+
+	got := s.BaseDir()
+	if got != customDir {
+		t.Errorf("BaseDir: got %q, want %q", got, customDir)
+	}
+}

--- a/internal/tools/command_runner_test.go
+++ b/internal/tools/command_runner_test.go
@@ -384,3 +384,607 @@ func containsSubstring(ss []string, sub string) bool {
 	}
 	return false
 }
+
+// =============================================================================
+// buildDockerCmd テスト (#90)
+// =============================================================================
+
+func TestBuildDockerCmd_DefaultNetwork(t *testing.T) {
+	// Network 未設定 → "host" がデフォルトで使われる
+	cfg := &tools.DockerConfig{
+		Image: "instrumentisto/nmap",
+	}
+	cmd := tools.BuildDockerCmdForTest(context.Background(), cfg, "nmap", []string{"-sV", "10.0.0.5"})
+
+	args := cmd.Args
+	// docker run --rm --network=host instrumentisto/nmap nmap -sV 10.0.0.5
+	if args[0] != "docker" {
+		t.Errorf("args[0] = %q, want 'docker'", args[0])
+	}
+	if args[1] != "run" {
+		t.Errorf("args[1] = %q, want 'run'", args[1])
+	}
+	if args[2] != "--rm" {
+		t.Errorf("args[2] = %q, want '--rm'", args[2])
+	}
+	if args[3] != "--network=host" {
+		t.Errorf("args[3] = %q, want '--network=host'", args[3])
+	}
+}
+
+func TestBuildDockerCmd_CustomNetwork(t *testing.T) {
+	// カスタムネットワーク指定
+	cfg := &tools.DockerConfig{
+		Image:   "instrumentisto/nmap",
+		Network: "pentest-net",
+	}
+	cmd := tools.BuildDockerCmdForTest(context.Background(), cfg, "nmap", []string{"-sV", "10.0.0.5"})
+
+	args := cmd.Args
+	if args[3] != "--network=pentest-net" {
+		t.Errorf("args[3] = %q, want '--network=pentest-net'", args[3])
+	}
+}
+
+func TestBuildDockerCmd_WithRunFlags(t *testing.T) {
+	// 追加フラグが含まれること
+	cfg := &tools.DockerConfig{
+		Image:    "instrumentisto/nmap",
+		RunFlags: []string{"--cap-add=NET_RAW", "-v", "/tmp:/data"},
+	}
+	cmd := tools.BuildDockerCmdForTest(context.Background(), cfg, "nmap", []string{"-sV"})
+
+	args := cmd.Args
+	// docker run --rm --network=host --cap-add=NET_RAW -v /tmp:/data instrumentisto/nmap nmap -sV
+	expected := []string{
+		"docker", "run", "--rm", "--network=host",
+		"--cap-add=NET_RAW", "-v", "/tmp:/data",
+		"instrumentisto/nmap", "nmap", "-sV",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("args len = %d, want %d\nargs: %v", len(args), len(expected), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want)
+		}
+	}
+}
+
+func TestBuildDockerCmd_WithArgs(t *testing.T) {
+	// binary + args がコマンド末尾に正しく追加されること
+	cfg := &tools.DockerConfig{
+		Image: "my-tool-image",
+	}
+	cmd := tools.BuildDockerCmdForTest(context.Background(), cfg, "nikto", []string{"-h", "http://target/"})
+
+	args := cmd.Args
+	// 末尾3要素: nikto -h http://target/
+	if args[len(args)-3] != "nikto" {
+		t.Errorf("binary position: got %q, want 'nikto'", args[len(args)-3])
+	}
+	if args[len(args)-2] != "-h" {
+		t.Errorf("arg[0] position: got %q, want '-h'", args[len(args)-2])
+	}
+	if args[len(args)-1] != "http://target/" {
+		t.Errorf("arg[1] position: got %q, want 'http://target/'", args[len(args)-1])
+	}
+}
+
+// =============================================================================
+// needsProposal 追加テスト (#90)
+// =============================================================================
+
+func TestNeedsProposal_AutoApproveOverridesAll(t *testing.T) {
+	// autoApprove=true → 全コマンド無条件で needsProposal=false
+	trueVal := true
+	runner := newTestRunner(&tools.ToolDef{
+		Name:             "dangerous-tool",
+		ProposalRequired: &trueVal,
+	})
+	runner.SetAutoApprove(true)
+
+	ctx := context.Background()
+	needsProposal, _, _, err := runner.Run(ctx, "dangerous-tool --exploit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needsProposal {
+		t.Error("autoApprove=true should override ProposalRequired=true")
+	}
+}
+
+func TestNeedsProposal_DockerDefault(t *testing.T) {
+	// Docker 設定あり + ProposalRequired 未設定 → false（Docker = サンドボックス）
+	// 注: Docker が利用できない環境では useDocker=false になるのでフォールバック動作になる
+	runner := newTestRunner(&tools.ToolDef{
+		Name:   "nmap",
+		Docker: &tools.DockerConfig{Image: "instrumentisto/nmap", Fallback: true},
+	})
+
+	// Docker が利用可能でない場合を想定し、IsProposalRequired で検証
+	def := &tools.ToolDef{
+		Name:   "nmap",
+		Docker: &tools.DockerConfig{Image: "instrumentisto/nmap"},
+	}
+	// Docker あり + ProposalRequired nil → IsProposalRequired は false
+	if def.IsProposalRequired() {
+		t.Error("Docker tool with nil ProposalRequired should return false from IsProposalRequired")
+	}
+	_ = runner // runner は生成確認のみ
+}
+
+func TestNeedsProposal_DockerExplicitTrue(t *testing.T) {
+	// Docker + ProposalRequired=true → true（明示指定が優先）
+	trueVal := true
+	def := &tools.ToolDef{
+		Name:             "nmap",
+		Docker:           &tools.DockerConfig{Image: "instrumentisto/nmap"},
+		ProposalRequired: &trueVal,
+	}
+	if !def.IsProposalRequired() {
+		t.Error("Docker tool with ProposalRequired=true should return true")
+	}
+}
+
+func TestNeedsProposal_DockerExplicitFalse(t *testing.T) {
+	// Docker + ProposalRequired=false → false
+	falseVal := false
+	def := &tools.ToolDef{
+		Name:             "nmap",
+		Docker:           &tools.DockerConfig{Image: "instrumentisto/nmap"},
+		ProposalRequired: &falseVal,
+	}
+	if def.IsProposalRequired() {
+		t.Error("Docker tool with ProposalRequired=false should return false")
+	}
+}
+
+func TestNeedsProposal_NilDef(t *testing.T) {
+	// ToolDef 未登録（nil）→ needsProposal=true（未知のコマンド）
+	runner := newTestRunner() // 空レジストリ
+
+	ctx := context.Background()
+	needsProposal, _, _, err := runner.Run(ctx, "unknowntool123 --flag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !needsProposal {
+		t.Error("nil ToolDef should require proposal (unknown command)")
+	}
+}
+
+func TestNeedsProposal_HostRegistered(t *testing.T) {
+	// 登録済みツール（Docker なし、ProposalRequired nil）→ IsProposalRequired が true
+	runner := newTestRunner(&tools.ToolDef{
+		Name: "msfconsole",
+		// ProposalRequired: nil, Docker: nil → ホスト実行 → 要承認
+	})
+
+	ctx := context.Background()
+	needsProposal, _, _, err := runner.Run(ctx, "msfconsole -r exploit.rc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !needsProposal {
+		t.Error("registered host tool without explicit ProposalRequired=false should require proposal")
+	}
+}
+
+// =============================================================================
+// ForceRun テスト (#90)
+// =============================================================================
+
+func TestForceRun_EchoCommand(t *testing.T) {
+	// ForceRun は承認済みコマンドを実行する（ブラックリストチェックなし）
+	runner := newTestRunner(&tools.ToolDef{
+		Name: "echo",
+		Output: tools.OutputConfig{
+			Strategy:  tools.StrategyHeadTail,
+			HeadLines: 5,
+			TailLines: 5,
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lines, resultCh := runner.ForceRun(ctx, "echo hello-forcerun")
+
+	var output []string
+	for l := range lines {
+		output = append(output, l.Content)
+	}
+	res := <-resultCh
+
+	if res.Err != nil {
+		t.Fatalf("ForceRun execution error: %v", res.Err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", res.ExitCode)
+	}
+	if !containsSubstring(output, "hello-forcerun") {
+		t.Errorf("expected 'hello-forcerun' in output, got: %v", output)
+	}
+}
+
+// =============================================================================
+// resolveDocker テスト (#90)
+// =============================================================================
+
+func TestResolveDocker_NilDef(t *testing.T) {
+	// nil ToolDef → useDocker=false, dockerAvailable=false
+	runner := newTestRunner()
+	useDocker, dockerAvail := runner.ResolveDockerForTest(nil)
+	if useDocker {
+		t.Error("nil ToolDef should not use Docker")
+	}
+	if dockerAvail {
+		t.Error("nil ToolDef should report Docker unavailable")
+	}
+}
+
+func TestResolveDocker_NilDockerConfig(t *testing.T) {
+	// ToolDef はあるが Docker 設定なし → useDocker=false, dockerAvailable=false
+	runner := newTestRunner()
+	def := &tools.ToolDef{
+		Name: "curl",
+		// Docker: nil
+	}
+	useDocker, dockerAvail := runner.ResolveDockerForTest(def)
+	if useDocker {
+		t.Error("ToolDef without Docker config should not use Docker")
+	}
+	if dockerAvail {
+		t.Error("ToolDef without Docker config should report Docker unavailable")
+	}
+}
+
+// =============================================================================
+// needsProposal 直接テスト — NeedsProposalForTest 経由 (#90)
+// =============================================================================
+
+func TestNeedsProposal_Direct_AutoApproveTrue(t *testing.T) {
+	// autoApprove=true → needsProposal は常に false
+	runner := newTestRunner()
+	runner.SetAutoApprove(true)
+
+	// 全パターンで false を返すことを確認
+	cases := []struct {
+		name      string
+		def       *tools.ToolDef
+		useDocker bool
+		dockerOK  bool
+	}{
+		{"nil def", nil, false, false},
+		{"host tool", &tools.ToolDef{Name: "msf"}, false, false},
+		{"docker tool", &tools.ToolDef{Name: "nmap", Docker: &tools.DockerConfig{Image: "nmap"}}, true, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := runner.NeedsProposalForTest(c.def, c.useDocker, c.dockerOK)
+			if got {
+				t.Errorf("autoApprove=true should always return false, got true")
+			}
+		})
+	}
+}
+
+func TestNeedsProposal_Direct_DockerWithExplicitProposal(t *testing.T) {
+	// useDocker=true + ProposalRequired 明示指定 → 明示値を優先
+	runner := newTestRunner()
+
+	trueVal := true
+	falseVal := false
+
+	// ProposalRequired=true → needsProposal=true
+	defTrue := &tools.ToolDef{
+		Name:             "nmap",
+		Docker:           &tools.DockerConfig{Image: "nmap"},
+		ProposalRequired: &trueVal,
+	}
+	if !runner.NeedsProposalForTest(defTrue, true, true) {
+		t.Error("Docker + ProposalRequired=true should return true")
+	}
+
+	// ProposalRequired=false → needsProposal=false
+	defFalse := &tools.ToolDef{
+		Name:             "nmap",
+		Docker:           &tools.DockerConfig{Image: "nmap"},
+		ProposalRequired: &falseVal,
+	}
+	if runner.NeedsProposalForTest(defFalse, true, true) {
+		t.Error("Docker + ProposalRequired=false should return false")
+	}
+}
+
+func TestNeedsProposal_Direct_DockerNoExplicit(t *testing.T) {
+	// useDocker=true + ProposalRequired=nil → false（Docker = サンドボックス = 自動承認）
+	runner := newTestRunner()
+
+	def := &tools.ToolDef{
+		Name:   "nmap",
+		Docker: &tools.DockerConfig{Image: "nmap"},
+	}
+	if runner.NeedsProposalForTest(def, true, true) {
+		t.Error("Docker + nil ProposalRequired should return false")
+	}
+}
+
+func TestNeedsProposal_Direct_HostWithDef(t *testing.T) {
+	// useDocker=false + ToolDef あり → IsProposalRequired() に委譲
+	runner := newTestRunner()
+
+	// ProposalRequired=nil, Docker=nil → true
+	defHost := &tools.ToolDef{Name: "msfconsole"}
+	if !runner.NeedsProposalForTest(defHost, false, false) {
+		t.Error("host tool with nil ProposalRequired should return true")
+	}
+
+	// ProposalRequired=false → false
+	falseVal := false
+	defExplicit := &tools.ToolDef{Name: "curl", ProposalRequired: &falseVal}
+	if runner.NeedsProposalForTest(defExplicit, false, false) {
+		t.Error("host tool with ProposalRequired=false should return false")
+	}
+}
+
+func TestNeedsProposal_Direct_NilDef(t *testing.T) {
+	// useDocker=false + nil def → true（未知のコマンド）
+	runner := newTestRunner()
+	if !runner.NeedsProposalForTest(nil, false, false) {
+		t.Error("nil ToolDef should return true (unknown command)")
+	}
+}
+
+// =============================================================================
+// Run のエッジケース: 空コマンド (#90)
+// =============================================================================
+
+func TestCommandRunner_Run_EmptyCommand(t *testing.T) {
+	runner := newTestRunner()
+	ctx := context.Background()
+	_, _, _, err := runner.Run(ctx, "")
+	if err == nil {
+		t.Fatal("expected error for empty command")
+	}
+	if !strings.Contains(err.Error(), "empty command") {
+		t.Errorf("expected 'empty command' error, got: %v", err)
+	}
+}
+
+func TestCommandRunner_Run_WhitespaceOnlyCommand(t *testing.T) {
+	runner := newTestRunner()
+	ctx := context.Background()
+	_, _, _, err := runner.Run(ctx, "   ")
+	if err == nil {
+		t.Fatal("expected error for whitespace-only command")
+	}
+	if !strings.Contains(err.Error(), "empty command") {
+		t.Errorf("expected 'empty command' error, got: %v", err)
+	}
+}
+
+// =============================================================================
+// execute エラーパス: コンテキストタイムアウト (#90)
+// =============================================================================
+
+func TestCommandRunner_Execute_ContextCancelled(t *testing.T) {
+	// コマンド実行中にコンテキストがキャンセルされた場合
+	falseVal := false
+	runner := newTestRunner(&tools.ToolDef{
+		Name:             "echo",
+		ProposalRequired: &falseVal,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	needsProposal, lines, resultCh, err := runner.Run(ctx, "echo start && sleep 3 && echo end")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if needsProposal {
+		t.Error("expected no proposal")
+	}
+
+	// すぐにキャンセル
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	// drain lines
+	for range lines {
+	}
+	res := <-resultCh
+
+	// キャンセルによりコマンドが kill される → exit code != 0 or Err != nil
+	if res.ExitCode == 0 && res.Err == nil {
+		t.Error("expected non-zero exit code or error for cancelled command")
+	}
+}
+
+// =============================================================================
+// execute: 正常パス - ToolDef の TimeoutSec が使われること (#90)
+// =============================================================================
+
+func TestCommandRunner_Execute_CustomTimeout(t *testing.T) {
+	// TimeoutSec=10 の ToolDef でコマンド実行 → 正常完了
+	falseVal := false
+	runner := newTestRunner(&tools.ToolDef{
+		Name:             "echo",
+		ProposalRequired: &falseVal,
+		TimeoutSec:       10,
+		Output: tools.OutputConfig{
+			Strategy:  tools.StrategyHeadTail,
+			HeadLines: 5,
+			TailLines: 5,
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	needsProposal, lines, resultCh, err := runner.Run(ctx, "echo custom-timeout-test")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if needsProposal {
+		t.Error("expected no proposal")
+	}
+
+	var output []string
+	for l := range lines {
+		output = append(output, l.Content)
+	}
+	res := <-resultCh
+
+	if res.Err != nil {
+		t.Fatalf("execution error: %v", res.Err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", res.ExitCode)
+	}
+	if !containsSubstring(output, "custom-timeout-test") {
+		t.Errorf("expected 'custom-timeout-test' in output, got: %v", output)
+	}
+}
+
+// =============================================================================
+// execute: ToolDef nil の場合（デフォルトタイムアウト・出力設定） (#90)
+// =============================================================================
+
+func TestCommandRunner_Execute_NilToolDef_UsesDefaults(t *testing.T) {
+	// 未登録ツール → ToolDef=nil → デフォルトタイムアウト＆デフォルト出力設定
+	// autoApprove=true で needsProposal をバイパス
+	runner := newTestRunner() // 空レジストリ
+	runner.SetAutoApprove(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	needsProposal, lines, resultCh, err := runner.Run(ctx, "echo default-settings")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if needsProposal {
+		t.Error("expected no proposal with auto-approve")
+	}
+
+	var output []string
+	for l := range lines {
+		output = append(output, l.Content)
+	}
+	res := <-resultCh
+
+	if res.Err != nil {
+		t.Fatalf("execution error: %v", res.Err)
+	}
+	if !containsSubstring(output, "default-settings") {
+		t.Errorf("expected 'default-settings' in output, got: %v", output)
+	}
+}
+
+// =============================================================================
+// execute: stderr 出力が取得できること (#90)
+// =============================================================================
+
+func TestCommandRunner_Execute_StderrCapture(t *testing.T) {
+	// stderr に出力するコマンドが取得できること
+	// sh -c 経由で実行されるので echo コマンドでリダイレクトできる
+	falseVal := false
+	runner := newTestRunner(&tools.ToolDef{
+		Name:             "echo",
+		ProposalRequired: &falseVal,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// echo は registry に登録済み。sh -c でリダイレクトを使う
+	needsProposal, lines, resultCh, err := runner.Run(ctx, "echo stderr-test >&2")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if needsProposal {
+		t.Error("expected no proposal")
+	}
+
+	var hasStderr bool
+	for l := range lines {
+		if strings.Contains(l.Content, "stderr-test") {
+			hasStderr = true
+		}
+	}
+	res := <-resultCh
+
+	if res.Err != nil {
+		t.Fatalf("execution error: %v", res.Err)
+	}
+	if !hasStderr {
+		t.Error("expected stderr output to be captured")
+	}
+}
+
+// =============================================================================
+// ForceRun: blacklisted command を承認後に実行できること (#90)
+// =============================================================================
+
+func TestForceRun_IgnoresBlacklist(t *testing.T) {
+	// ForceRun はブラックリストチェックをスキップする
+	runner := newTestRunner() // empty registry (blacklist has rm -rf / pattern)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// ForceRun で echo を実行（ブラックリスト回避テスト用のシンプルなコマンド）
+	lines, resultCh := runner.ForceRun(ctx, "echo force-test")
+	var output []string
+	for l := range lines {
+		output = append(output, l.Content)
+	}
+	res := <-resultCh
+	if res.Err != nil {
+		t.Fatalf("ForceRun error: %v", res.Err)
+	}
+	if !containsSubstring(output, "force-test") {
+		t.Errorf("expected 'force-test' in output, got: %v", output)
+	}
+}
+
+// =============================================================================
+// execute: LogStore への保存確認 (#90)
+// =============================================================================
+
+func TestCommandRunner_Execute_SavesResult(t *testing.T) {
+	falseVal := false
+	reg := tools.NewRegistry()
+	reg.Register(&tools.ToolDef{
+		Name:             "echo",
+		ProposalRequired: &falseVal,
+	})
+	bl := tools.NewBlacklist(nil)
+	store := tools.NewLogStore()
+	runner := tools.NewCommandRunner(reg, bl, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, lines, resultCh, err := runner.Run(ctx, "echo save-test")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for range lines {
+	}
+	res := <-resultCh
+
+	// LogStore にエントリが保存されていること
+	stored, ok := store.Get(res.ID)
+	if !ok {
+		t.Fatal("expected result to be saved in LogStore")
+	}
+	if stored.ToolName != "echo" {
+		t.Errorf("stored ToolName: got %q, want %q", stored.ToolName, "echo")
+	}
+}

--- a/internal/tools/export_test.go
+++ b/internal/tools/export_test.go
@@ -1,0 +1,21 @@
+package tools
+
+import (
+	"context"
+	"os/exec"
+)
+
+// BuildDockerCmdForTest は buildDockerCmd をテストから呼べるようにエクスポートする。
+func BuildDockerCmdForTest(ctx context.Context, cfg *DockerConfig, binary string, args []string) *exec.Cmd {
+	return buildDockerCmd(ctx, cfg, binary, args)
+}
+
+// ResolveDockerForTest は resolveDocker をテストから呼べるようにエクスポートする。
+func (r *CommandRunner) ResolveDockerForTest(def *ToolDef) (useDocker bool, dockerAvailable bool) {
+	return r.resolveDocker(def)
+}
+
+// NeedsProposalForTest は needsProposal をテストから呼べるようにエクスポートする。
+func (r *CommandRunner) NeedsProposalForTest(def *ToolDef, useDocker bool, dockerOK bool) bool {
+	return r.needsProposal(def, useDocker, dockerOK)
+}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1,10 +1,12 @@
 package tui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/0x6d61/pentecter/internal/agent"
@@ -1579,5 +1581,2059 @@ func TestHandleAgentEvent_EventAddTarget_Duplicate(t *testing.T) {
 	// 重複なので追加されないはず
 	if len(m.targets) != 1 {
 		t.Errorf("expected 1 target after duplicate EventAddTarget, got %d", len(m.targets))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleTargetsCommand -- coverage improvement tests
+// ---------------------------------------------------------------------------
+
+// TestHandleTargetsCommand_Empty tests /targets with no targets.
+func TestHandleTargetsCommand_Empty(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleTargetsCommand()
+
+	// No targets -> globalLogs should have a message
+	if len(m.globalLogs) == 0 {
+		t.Fatal("expected globalLogs to have a message for empty targets")
+	}
+	found := false
+	for _, log := range m.globalLogs {
+		if strings.Contains(log, "No targets") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'No targets' message in globalLogs, got: %v", m.globalLogs)
+	}
+}
+
+// TestHandleTargetsCommand_WithTargets tests /targets shows select UI.
+func TestHandleTargetsCommand_WithTargets(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	t2 := agent.NewTarget(2, "10.0.0.2")
+	m := NewWithTargets([]*agent.Target{t1, t2})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleTargetsCommand()
+
+	if m.inputMode != InputSelect {
+		t.Errorf("expected InputSelect mode, got %d", m.inputMode)
+	}
+	if len(m.selectOptions) != 2 {
+		t.Errorf("expected 2 select options, got %d", len(m.selectOptions))
+	}
+	if m.selectTitle == "" {
+		t.Error("expected non-empty selectTitle")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleReconTreeCommand -- coverage improvement tests
+// ---------------------------------------------------------------------------
+
+// TestHandleReconTreeCommand_NoTarget tests /recontree with no target selected.
+func TestHandleReconTreeCommand_NoTarget(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleReconTreeCommand()
+
+	found := false
+	for _, log := range m.globalLogs {
+		if strings.Contains(log, "No target selected") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'No target selected' in globalLogs, got: %v", m.globalLogs)
+	}
+}
+
+// TestHandleReconTreeCommand_NoReconTree tests /recontree when target has no ReconTree.
+func TestHandleReconTreeCommand_NoReconTree(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{target})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleReconTreeCommand()
+
+	// ReconTree is nil -> should log error to target blocks
+	found := false
+	for _, b := range target.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "No recon tree") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'No recon tree' system block on target")
+	}
+}
+
+// TestHandleReconTreeCommand_WithReconTree tests /recontree with valid ReconTree.
+func TestHandleReconTreeCommand_WithReconTree(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	rt := agent.NewReconTree("10.0.0.1", 2)
+	rt.AddPort(80, "http", "Apache 2.4")
+	target.SetReconTree(rt)
+
+	m := NewWithTargets([]*agent.Target{target})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleReconTreeCommand()
+
+	// Should log rendered tree to target blocks
+	found := false
+	for _, b := range target.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "80") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected recon tree output containing port 80 in target blocks")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleSkipReconCommand -- coverage improvement tests
+// ---------------------------------------------------------------------------
+
+// TestHandleSkipReconCommand_NoTarget tests /skip-recon with no target.
+func TestHandleSkipReconCommand_NoTarget(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleSkipReconCommand()
+
+	found := false
+	for _, log := range m.globalLogs {
+		if strings.Contains(log, "No target selected") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'No target selected' in globalLogs, got: %v", m.globalLogs)
+	}
+}
+
+// TestHandleSkipReconCommand_NoReconTree tests /skip-recon when no ReconTree.
+func TestHandleSkipReconCommand_NoReconTree(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{target})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleSkipReconCommand()
+
+	found := false
+	for _, b := range target.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "No recon tree") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'No recon tree' system block on target")
+	}
+}
+
+// TestHandleSkipReconCommand_AlreadyUnlocked tests /skip-recon when already unlocked.
+func TestHandleSkipReconCommand_AlreadyUnlocked(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	rt := agent.NewReconTree("10.0.0.1", 2)
+	rt.Unlock() // unlock before test
+	target.SetReconTree(rt)
+
+	m := NewWithTargets([]*agent.Target{target})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleSkipReconCommand()
+
+	found := false
+	for _, b := range target.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "already unlocked") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'already unlocked' system block on target")
+	}
+}
+
+// TestHandleSkipReconCommand_Success tests /skip-recon successfully unlocks.
+func TestHandleSkipReconCommand_Success(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	rt := agent.NewReconTree("10.0.0.1", 2)
+	rt.AddPort(80, "http", "Apache 2.4") // adds pending tasks
+	target.SetReconTree(rt)
+
+	m := NewWithTargets([]*agent.Target{target})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	if !rt.IsLocked() {
+		t.Fatal("precondition: ReconTree should be locked")
+	}
+
+	m.handleSkipReconCommand()
+
+	if rt.IsLocked() {
+		t.Error("expected ReconTree to be unlocked after /skip-recon")
+	}
+
+	found := false
+	for _, b := range target.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "RECON phase unlocked") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'RECON phase unlocked' system block on target")
+	}
+}
+
+// ===========================================================================
+// Update() — spinner.TickMsg handling
+// ===========================================================================
+
+func TestUpdate_SpinnerTickMsg_WhileSpinning(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.spinning = true
+
+	result, cmd := m.Update(spinner.TickMsg{})
+	rm := result.(Model)
+
+	// viewportDirty should be reset
+	if rm.viewportDirty {
+		t.Error("expected viewportDirty=false after spinner tick")
+	}
+	// spinner.Update returns a Cmd to schedule the next tick
+	if cmd == nil {
+		t.Error("expected non-nil cmd from spinner tick while spinning")
+	}
+}
+
+func TestUpdate_SpinnerTickMsg_NotSpinning(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.spinning = false
+
+	_, cmd := m.Update(spinner.TickMsg{})
+
+	// Not spinning -> no cmd returned
+	if cmd != nil {
+		t.Error("expected nil cmd from spinner tick when not spinning")
+	}
+}
+
+// ===========================================================================
+// Update() — debounceMsg handling
+// ===========================================================================
+
+func TestUpdate_DebounceMsg_ViewportDirty(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.viewportDirty = true
+
+	result, cmd := m.Update(debounceMsg{})
+	rm := result.(Model)
+
+	if rm.viewportDirty {
+		t.Error("expected viewportDirty=false after debounceMsg flush")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd from debounceMsg")
+	}
+}
+
+func TestUpdate_DebounceMsg_NotDirty(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.viewportDirty = false
+
+	result, cmd := m.Update(debounceMsg{})
+	rm := result.(Model)
+
+	if rm.viewportDirty {
+		t.Error("viewportDirty should remain false")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd from debounceMsg when not dirty")
+	}
+}
+
+// ===========================================================================
+// Update() — AgentEventMsg handling
+// ===========================================================================
+
+func TestUpdate_AgentEventMsg_WithChannel(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	// agentEvents チャネルをセットして、次のイベント待ちコマンドが返ることを確認
+	ch := make(chan agent.Event, 1)
+	m.agentEvents = ch
+
+	result, cmd := m.Update(AgentEventMsg(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventLog,
+		Source:   agent.SourceSystem,
+		Message:  "test message",
+	}))
+	rm := result.(Model)
+	_ = rm
+
+	// cmd should be non-nil (batch of AgentEventCmd for next event)
+	if cmd == nil {
+		t.Error("expected non-nil cmd (AgentEventCmd) when agentEvents channel is set")
+	}
+
+	// Block should have been added
+	if len(t1.Blocks) == 0 {
+		t.Error("expected at least one block after AgentEventMsg")
+	}
+}
+
+func TestUpdate_AgentEventMsg_NilChannel(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.agentEvents = nil // no channel
+
+	_, cmd := m.Update(AgentEventMsg(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventLog,
+		Source:   agent.SourceSystem,
+		Message:  "no channel test",
+	}))
+
+	// With nil agentEvents, cmd may still be non-nil if spinnerCmd is returned,
+	// but AgentEventCmd should not be in the batch.
+	// Just ensure no panic.
+	_ = cmd
+}
+
+func TestUpdate_AgentEventMsg_WithSpinnerCmd(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	ch := make(chan agent.Event, 1)
+	m.agentEvents = ch
+
+	// ThinkStart event returns a spinner cmd
+	result, cmd := m.Update(AgentEventMsg(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventThinkStart,
+	}))
+	rm := result.(Model)
+
+	if !rm.spinning {
+		t.Error("expected spinning=true after ThinkStart via Update")
+	}
+	if cmd == nil {
+		t.Error("expected non-nil batch cmd (spinner tick + event cmd)")
+	}
+}
+
+// ===========================================================================
+// Update() — KeyMsg in select mode
+// ===========================================================================
+
+func TestUpdate_SelectMode_InterceptsKeys(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.inputMode = InputSelect
+	m.selectOptions = []SelectOption{
+		{Label: "Option A", Value: "a"},
+		{Label: "Option B", Value: "b"},
+	}
+	m.selectIndex = 0
+
+	// Down arrow should move selection
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	rm := result.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from select mode key")
+	}
+	if rm.selectIndex != 1 {
+		t.Errorf("expected selectIndex=1 after down arrow, got %d", rm.selectIndex)
+	}
+}
+
+func TestUpdate_SelectMode_Enter(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	callbackCalled := false
+	m.showSelect("Test:", []SelectOption{
+		{Label: "Option A", Value: "a"},
+	}, func(model *Model, value string) {
+		callbackCalled = true
+	})
+
+	// Enter to confirm selection
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := result.(Model)
+
+	if rm.inputMode != InputNormal {
+		t.Errorf("expected InputNormal after select confirm, got %d", rm.inputMode)
+	}
+	if !callbackCalled {
+		t.Error("expected callback to be called on Enter")
+	}
+}
+
+func TestUpdate_SelectMode_Escape(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.showSelect("Test:", []SelectOption{
+		{Label: "Option A", Value: "a"},
+	}, func(model *Model, value string) {
+		t.Error("callback should not be called on Escape")
+	})
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	rm := result.(Model)
+
+	if rm.inputMode != InputNormal {
+		t.Errorf("expected InputNormal after Escape, got %d", rm.inputMode)
+	}
+}
+
+// ===========================================================================
+// Update() — Ctrl+O toggles log folding
+// ===========================================================================
+
+func TestUpdate_CtrlO_TogglesLogFolding(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.logsExpanded = false
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	rm := result.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from Ctrl+O")
+	}
+	if !rm.logsExpanded {
+		t.Error("expected logsExpanded=true after Ctrl+O toggle")
+	}
+
+	// Toggle back
+	result2, _ := rm.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	rm2 := result2.(Model)
+	if rm2.logsExpanded {
+		t.Error("expected logsExpanded=false after second Ctrl+O toggle")
+	}
+}
+
+// ===========================================================================
+// Update() — Proposal approval keys (y/n/e)
+// ===========================================================================
+
+func TestUpdate_ProposalApprove_Y(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	approveCh := make(chan bool, 1)
+	m.agentApproveMap[t1.ID] = approveCh
+
+	t1.SetProposal(&agent.Proposal{
+		Description: "Run nmap scan",
+		Tool:        "nmap",
+		Args:        []string{"-sV", "10.0.0.1"},
+	})
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	rm := result.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from Y approval")
+	}
+	_ = rm
+
+	// Proposal should be cleared
+	if t1.GetProposal() != nil {
+		t.Error("expected proposal to be cleared after Y")
+	}
+
+	// Approve signal should be sent
+	select {
+	case approved := <-approveCh:
+		if !approved {
+			t.Error("expected true on approve channel")
+		}
+	default:
+		t.Error("expected a value on approve channel")
+	}
+}
+
+func TestUpdate_ProposalReject_N(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	approveCh := make(chan bool, 1)
+	m.agentApproveMap[t1.ID] = approveCh
+
+	t1.SetProposal(&agent.Proposal{
+		Description: "Run exploit",
+		Tool:        "msfconsole",
+		Args:        []string{"-x", "exploit"},
+	})
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	rm := result.(Model)
+	_ = rm
+
+	if cmd != nil {
+		t.Error("expected nil cmd from N rejection")
+	}
+
+	// Proposal should be cleared
+	if t1.GetProposal() != nil {
+		t.Error("expected proposal to be cleared after N")
+	}
+
+	// Reject signal should be sent
+	select {
+	case approved := <-approveCh:
+		if approved {
+			t.Error("expected false on approve channel")
+		}
+	default:
+		t.Error("expected a value on approve channel")
+	}
+}
+
+func TestUpdate_ProposalEdit_E(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.focus = FocusViewport // start from viewport focus
+
+	t1.SetProposal(&agent.Proposal{
+		Description: "Run scan",
+		Tool:        "nmap",
+		Args:        []string{"-sV", "target"},
+	})
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	rm := result.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from E edit")
+	}
+
+	// Focus should switch to input
+	if rm.focus != FocusInput {
+		t.Errorf("expected FocusInput after E, got %d", rm.focus)
+	}
+
+	// Input should be populated with the proposal command
+	inputVal := rm.input.Value()
+	if !strings.Contains(inputVal, "nmap") {
+		t.Errorf("expected input to contain 'nmap', got %q", inputVal)
+	}
+	if !strings.Contains(inputVal, "-sV") {
+		t.Errorf("expected input to contain '-sV', got %q", inputVal)
+	}
+}
+
+func TestUpdate_ProposalApprove_NoChannelInMap(t *testing.T) {
+	// Proposal approve when no channel in agentApproveMap — should not panic
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	// agentApproveMap has no entry for t1.ID
+
+	t1.SetProposal(&agent.Proposal{
+		Description: "Run test",
+		Tool:        "echo",
+		Args:        []string{"hello"},
+	})
+
+	// Should not panic
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	rm := result.(Model)
+	_ = rm
+
+	// Proposal should still be cleared
+	if t1.GetProposal() != nil {
+		t.Error("expected proposal to be cleared even without channel")
+	}
+}
+
+func TestUpdate_ProposalReject_NoChannelInMap(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	t1.SetProposal(&agent.Proposal{
+		Description: "Run test",
+		Tool:        "echo",
+		Args:        []string{"hello"},
+	})
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+	rm := result.(Model)
+	_ = rm
+
+	if t1.GetProposal() != nil {
+		t.Error("expected proposal to be cleared after N even without channel")
+	}
+}
+
+// ===========================================================================
+// Update() — FocusViewport key handling (viewport scrolling)
+// ===========================================================================
+
+func TestUpdate_ViewportFocus_PassesKeysToViewport(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.focus = FocusViewport
+
+	// Send an arrow key while viewport is focused — should not panic
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	rm := result.(Model)
+
+	if rm.focus != FocusViewport {
+		t.Errorf("expected FocusViewport to be maintained, got %d", rm.focus)
+	}
+}
+
+// ===========================================================================
+// Update() — FocusInput enter key calls submitInput
+// ===========================================================================
+
+func TestUpdate_FocusInput_EnterSubmits(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.focus = FocusInput
+	m.input.SetValue("test input text")
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	rm := result.(Model)
+
+	// Input should be cleared after submit
+	if rm.input.Value() != "" {
+		t.Errorf("expected input to be cleared after Enter, got %q", rm.input.Value())
+	}
+
+	// Block should be added
+	if len(t1.Blocks) == 0 {
+		t.Error("expected at least one block after Enter submit")
+	}
+}
+
+func TestUpdate_FocusInput_OtherKeys_PassToTextarea(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.focus = FocusInput
+
+	// Type a regular character
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	rm := result.(Model)
+
+	// The character should be appended to the input
+	if !strings.Contains(rm.input.Value(), "a") {
+		t.Errorf("expected input to contain 'a', got %q", rm.input.Value())
+	}
+}
+
+// ===========================================================================
+// Update() — WindowSizeMsg edge cases
+// ===========================================================================
+
+func TestUpdate_WindowSizeMsg_SmallTerminal(t *testing.T) {
+	m := NewWithTargets(nil)
+
+	// Very small terminal — handleResize should clamp to minimums
+	result, cmd := m.Update(tea.WindowSizeMsg{Width: 15, Height: 8})
+	rm := result.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from WindowSizeMsg")
+	}
+	if !rm.ready {
+		t.Error("expected ready=true")
+	}
+	if rm.width != 15 {
+		t.Errorf("expected width=15, got %d", rm.width)
+	}
+	if rm.height != 8 {
+		t.Errorf("expected height=8, got %d", rm.height)
+	}
+}
+
+func TestUpdate_WindowSizeMsg_AlreadyReady(t *testing.T) {
+	m := NewWithTargets(nil)
+	// First resize
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = result.(Model)
+
+	// Second resize — already ready, so viewport dimensions should be updated (not recreated)
+	result, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	rm := result.(Model)
+
+	if rm.width != 120 {
+		t.Errorf("expected width=120, got %d", rm.width)
+	}
+	if rm.height != 40 {
+		t.Errorf("expected height=40, got %d", rm.height)
+	}
+}
+
+// ===========================================================================
+// handleResize — edge cases for small sizes
+// ===========================================================================
+
+func TestHandleResize_VerySmallWidth(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(5, 30)
+
+	// vpW = 5 - 4 = 1, should be clamped to 10
+	if m.viewport.Width < 10 {
+		t.Errorf("expected viewport width >= 10 for very small terminal, got %d", m.viewport.Width)
+	}
+}
+
+func TestHandleResize_VerySmallHeight(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(80, 5)
+
+	// paneH should be clamped to minimum 4
+	// This ensures viewport doesn't get negative height
+	if m.viewport.Height < 2 {
+		t.Errorf("expected viewport height >= 2, got %d", m.viewport.Height)
+	}
+}
+
+// ===========================================================================
+// submitInput — slash command routing
+// ===========================================================================
+
+func TestSubmitInput_TargetsRouting(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	t2 := agent.NewTarget(2, "10.0.0.2")
+	m := NewWithTargets([]*agent.Target{t1, t2})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.input.SetValue("/targets")
+
+	m.submitInput()
+
+	if m.inputMode != InputSelect {
+		t.Errorf("expected InputSelect mode after /targets, got %d", m.inputMode)
+	}
+}
+
+func TestSubmitInput_ReconTreeRouting(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{target})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.input.SetValue("/recontree")
+
+	blocksBefore := len(target.Blocks)
+	m.submitInput()
+
+	// Should have logged "No recon tree available" since target has no ReconTree
+	if len(target.Blocks) <= blocksBefore {
+		t.Error("expected a system block for /recontree with no recon tree")
+	}
+}
+
+func TestSubmitInput_SkipReconRouting(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{target})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.input.SetValue("/skip-recon")
+
+	blocksBefore := len(target.Blocks)
+	m.submitInput()
+
+	// Should have logged "No recon tree available" since target has no ReconTree
+	if len(target.Blocks) <= blocksBefore {
+		t.Error("expected a system block for /skip-recon with no recon tree")
+	}
+}
+
+func TestSubmitInput_TargetCommand(t *testing.T) {
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+	m.input.SetValue("/target 10.0.0.5")
+
+	m.submitInput()
+
+	if len(m.targets) != 1 {
+		t.Fatalf("expected 1 target after /target command, got %d", len(m.targets))
+	}
+	if m.targets[0].Host != "10.0.0.5" {
+		t.Errorf("expected host '10.0.0.5', got %q", m.targets[0].Host)
+	}
+}
+
+func TestSubmitInput_BareIP_WithTeam(t *testing.T) {
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+	m.input.SetValue("10.0.0.99")
+
+	m.submitInput()
+
+	if len(m.targets) != 1 {
+		t.Fatalf("expected 1 target after bare IP, got %d", len(m.targets))
+	}
+	if m.targets[0].Host != "10.0.0.99" {
+		t.Errorf("expected host '10.0.0.99', got %q", m.targets[0].Host)
+	}
+}
+
+func TestSubmitInput_NaturalLanguageHost_WithTeam(t *testing.T) {
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+	m.input.SetValue("192.168.1.1をスキャンして")
+
+	m.submitInput()
+
+	// Should extract host and create target
+	if len(m.targets) != 1 {
+		t.Fatalf("expected 1 target from natural language, got %d", len(m.targets))
+	}
+	if m.targets[0].Host != "192.168.1.1" {
+		t.Errorf("expected host '192.168.1.1', got %q", m.targets[0].Host)
+	}
+}
+
+func TestSubmitInput_NaturalLanguageDomain_WithTeam(t *testing.T) {
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+	m.input.SetValue("eighteen.htbを攻撃して")
+
+	m.submitInput()
+
+	if len(m.targets) != 1 {
+		t.Fatalf("expected 1 target from domain extraction, got %d", len(m.targets))
+	}
+	if m.targets[0].Host != "eighteen.htb" {
+		t.Errorf("expected host 'eighteen.htb', got %q", m.targets[0].Host)
+	}
+}
+
+func TestSubmitInput_NaturalLanguageHost_WithRemainingMsg(t *testing.T) {
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+
+	// Set up user msg channel so we can verify message routing
+	// Note: addTarget will create the channel mapping when team is used
+	m.input.SetValue("scan 10.0.0.50 for open ports")
+
+	m.submitInput()
+
+	if len(m.targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(m.targets))
+	}
+	if m.targets[0].Host != "10.0.0.50" {
+		t.Errorf("expected host '10.0.0.50', got %q", m.targets[0].Host)
+	}
+
+	// Original full text should be logged as a user block
+	found := false
+	for _, b := range m.targets[0].Blocks {
+		if b.Type == agent.BlockUserInput && strings.Contains(b.UserText, "scan 10.0.0.50 for open ports") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected original full text to be logged as user block")
+	}
+}
+
+func TestSubmitInput_NaturalLanguageHost_ExistingTargets_NoExtract(t *testing.T) {
+	// When targets already exist, natural language extraction should NOT happen
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+	m.input.SetValue("scan 192.168.1.1 please")
+
+	targetsBefore := len(m.targets)
+	m.submitInput()
+
+	// Should NOT extract host because targets already exist
+	if len(m.targets) != targetsBefore {
+		t.Errorf("expected no new targets when targets already exist, got %d", len(m.targets))
+	}
+}
+
+func TestSubmitInput_SendsToAgentChannel(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	userMsgCh := make(chan string, 1)
+	m.agentUserMsgMap[t1.ID] = userMsgCh
+	m.input.SetValue("run nmap -sV")
+
+	m.submitInput()
+
+	// Message should be sent to agent channel
+	select {
+	case msg := <-userMsgCh:
+		if msg != "run nmap -sV" {
+			t.Errorf("expected 'run nmap -sV' on channel, got %q", msg)
+		}
+	default:
+		t.Error("expected message on userMsg channel")
+	}
+}
+
+func TestSubmitInput_NoActiveTarget_NoChannel(t *testing.T) {
+	// When no active target and no agent channel, should not panic
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.input.SetValue("some text without target")
+
+	// Should not panic — no target, no channel, just no-op
+	m.submitInput()
+}
+
+func TestSubmitInput_ApproveRouting_NoRunner(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.Runner = nil
+	m.input.SetValue("/approve")
+
+	blocksBefore := len(t1.Blocks)
+	m.submitInput()
+
+	// Without runner, should log "not available"
+	if len(t1.Blocks) <= blocksBefore {
+		t.Error("expected system block for /approve without runner")
+	}
+	found := false
+	for _, b := range t1.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "not available") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'not available' message for /approve without runner")
+	}
+}
+
+// ===========================================================================
+// switchModel — all branches
+// ===========================================================================
+
+func TestSwitchModel_NilBrainFactory(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.BrainFactory = nil
+
+	m.switchModel(brain.ProviderAnthropic, "claude-sonnet-4-6")
+
+	// Should log "not available" message
+	found := false
+	for _, b := range t1.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "not available") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'not available' message for nil BrainFactory")
+	}
+}
+
+func TestSwitchModel_FactoryError(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.BrainFactory = func(hint brain.ConfigHint) (brain.Brain, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	m.switchModel(brain.ProviderAnthropic, "claude-sonnet-4-6")
+
+	found := false
+	for _, b := range t1.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "Failed to switch model") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'Failed to switch model' message on factory error")
+	}
+}
+
+func TestSwitchModel_Success_WithTeam(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+	m.BrainFactory = func(hint brain.ConfigHint) (brain.Brain, error) {
+		return nil, nil // nil brain is ok for test
+	}
+
+	m.switchModel(brain.ProviderAnthropic, "claude-sonnet-4-6")
+
+	if m.CurrentProvider != "anthropic" {
+		t.Errorf("expected CurrentProvider 'anthropic', got %q", m.CurrentProvider)
+	}
+	if m.CurrentModel != "claude-sonnet-4-6" {
+		t.Errorf("expected CurrentModel 'claude-sonnet-4-6', got %q", m.CurrentModel)
+	}
+
+	found := false
+	for _, b := range t1.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "Switched to anthropic/claude-sonnet-4-6") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'Switched to' message with model name")
+	}
+}
+
+func TestSwitchModel_Success_NoModel(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.BrainFactory = func(hint brain.ConfigHint) (brain.Brain, error) {
+		return nil, nil
+	}
+
+	m.switchModel(brain.ProviderOllama, "")
+
+	if m.CurrentProvider != "ollama" {
+		t.Errorf("expected CurrentProvider 'ollama', got %q", m.CurrentProvider)
+	}
+	if m.CurrentModel != "" {
+		t.Errorf("expected empty CurrentModel, got %q", m.CurrentModel)
+	}
+
+	found := false
+	for _, b := range t1.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "Switched to ollama") && !strings.Contains(b.SystemMsg, "/") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'Switched to ollama' message without model suffix")
+	}
+}
+
+func TestSwitchModel_Success_NilTeam(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = nil
+	m.BrainFactory = func(hint brain.ConfigHint) (brain.Brain, error) {
+		return nil, nil
+	}
+
+	// Should not panic when team is nil
+	m.switchModel(brain.ProviderAnthropic, "claude-sonnet-4-6")
+
+	if m.CurrentProvider != "anthropic" {
+		t.Errorf("expected CurrentProvider 'anthropic', got %q", m.CurrentProvider)
+	}
+}
+
+// ===========================================================================
+// handleTargetsCommand — callback execution
+// ===========================================================================
+
+func TestHandleTargetsCommand_CallbackSelectsTarget(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	t2 := agent.NewTarget(2, "10.0.0.2")
+	m := NewWithTargets([]*agent.Target{t1, t2})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.selected = 0
+
+	m.handleTargetsCommand()
+
+	if m.inputMode != InputSelect {
+		t.Fatalf("expected InputSelect mode, got %d", m.inputMode)
+	}
+
+	// Simulate selecting the second target (index 1)
+	m.selectIndex = 1
+
+	// Invoke callback directly (simulating Enter press)
+	if m.selectCallback != nil {
+		cb := m.selectCallback
+		value := m.selectOptions[m.selectIndex].Value
+		m.inputMode = InputNormal
+		m.selectOptions = nil
+		m.selectCallback = nil
+		cb(&m, value)
+	}
+
+	if m.selected != 1 {
+		t.Errorf("expected selected=1, got %d", m.selected)
+	}
+}
+
+func TestHandleTargetsCommand_CallbackInvalidValue(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleTargetsCommand()
+
+	if m.selectCallback == nil {
+		t.Fatal("expected selectCallback to be set")
+	}
+
+	// Invoke callback with invalid (non-numeric) value
+	m.selectCallback(&m, "invalid")
+
+	// Should not change selection
+	if m.selected != 0 {
+		t.Errorf("expected selected=0 unchanged, got %d", m.selected)
+	}
+}
+
+func TestHandleTargetsCommand_CallbackOutOfRange(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleTargetsCommand()
+
+	if m.selectCallback == nil {
+		t.Fatal("expected selectCallback to be set")
+	}
+
+	// Invoke callback with out-of-range index
+	m.selectCallback(&m, "99")
+
+	// Should not change selection
+	if m.selected != 0 {
+		t.Errorf("expected selected=0 unchanged after out-of-range callback, got %d", m.selected)
+	}
+}
+
+// ===========================================================================
+// modelsForProvider — all providers
+// ===========================================================================
+
+func TestModelsForProvider_Anthropic(t *testing.T) {
+	models := modelsForProvider(brain.ProviderAnthropic)
+	if len(models) == 0 {
+		t.Fatal("expected models for Anthropic provider")
+	}
+	// Check that claude-sonnet-4-6 is in the list
+	found := false
+	for _, m := range models {
+		if strings.Contains(m.Value, "claude-sonnet-4-6") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected claude-sonnet-4-6 in Anthropic models")
+	}
+}
+
+func TestModelsForProvider_OpenAI(t *testing.T) {
+	models := modelsForProvider(brain.ProviderOpenAI)
+	if len(models) == 0 {
+		t.Fatal("expected models for OpenAI provider")
+	}
+	found := false
+	for _, m := range models {
+		if m.Value == "gpt-4o" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected gpt-4o in OpenAI models")
+	}
+}
+
+func TestModelsForProvider_Ollama(t *testing.T) {
+	models := modelsForProvider(brain.ProviderOllama)
+	if len(models) == 0 {
+		t.Fatal("expected models for Ollama provider")
+	}
+	found := false
+	for _, m := range models {
+		if m.Value == "llama3.2" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected llama3.2 in Ollama models")
+	}
+}
+
+func TestModelsForProvider_Unknown(t *testing.T) {
+	models := modelsForProvider(brain.Provider("unknown"))
+	if models != nil {
+		t.Errorf("expected nil for unknown provider, got %v", models)
+	}
+}
+
+// ===========================================================================
+// handleAgentEvent — EventLog with SourceTool and SourceUser
+// ===========================================================================
+
+func TestHandleAgentEvent_EventLog_SourceTool_NewBlock(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	blocksBefore := len(t1.Blocks)
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventLog,
+		Source:   agent.SourceTool,
+		Message:  "Starting nmap scan",
+	})
+
+	if len(t1.Blocks) != blocksBefore+1 {
+		t.Fatalf("expected 1 new block for tool log, got %d", len(t1.Blocks)-blocksBefore)
+	}
+	lastBlock := t1.Blocks[len(t1.Blocks)-1]
+	if lastBlock.Type != agent.BlockCommand {
+		t.Errorf("expected BlockCommand for tool log, got %d", lastBlock.Type)
+	}
+}
+
+func TestHandleAgentEvent_EventLog_SourceTool_AppendToExisting(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	// Add an incomplete command block
+	t1.AddBlock(agent.NewCommandBlock("nmap"))
+
+	blocksBefore := len(t1.Blocks)
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventLog,
+		Source:   agent.SourceTool,
+		Message:  "80/tcp open http",
+	})
+
+	// Should append to existing block, not create a new one
+	if len(t1.Blocks) != blocksBefore {
+		t.Errorf("expected no new block (append to existing), got %d new", len(t1.Blocks)-blocksBefore)
+	}
+	lastBlock := t1.LastBlock()
+	if len(lastBlock.Output) != 1 || lastBlock.Output[0] != "80/tcp open http" {
+		t.Errorf("expected output to be appended, got %v", lastBlock.Output)
+	}
+}
+
+func TestHandleAgentEvent_EventLog_SourceUser(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	blocksBefore := len(t1.Blocks)
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventLog,
+		Source:   agent.SourceUser,
+		Message:  "User input message",
+	})
+
+	if len(t1.Blocks) != blocksBefore+1 {
+		t.Fatalf("expected 1 new block, got %d", len(t1.Blocks)-blocksBefore)
+	}
+	lastBlock := t1.Blocks[len(t1.Blocks)-1]
+	if lastBlock.Type != agent.BlockUserInput {
+		t.Errorf("expected BlockUserInput, got %d", lastBlock.Type)
+	}
+	if lastBlock.UserText != "User input message" {
+		t.Errorf("expected 'User input message', got %q", lastBlock.UserText)
+	}
+}
+
+// ===========================================================================
+// handleAgentEvent — EventSubTaskLog
+// ===========================================================================
+
+func TestHandleAgentEvent_EventSubTaskLog(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	blocksBefore := len(t1.Blocks)
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventSubTaskLog,
+		TaskID:   "task-1",
+		Message:  "subtask internal log",
+	})
+
+	// EventSubTaskLog should NOT add any blocks
+	if len(t1.Blocks) != blocksBefore {
+		t.Errorf("expected no new blocks for SubTaskLog, got %d new", len(t1.Blocks)-blocksBefore)
+	}
+}
+
+// ===========================================================================
+// handleAgentEvent — EventCmdOutput debounce behavior
+// ===========================================================================
+
+func TestHandleAgentEvent_EventCmdOutput_Debounce_NotSpinning(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.spinning = false
+
+	t1.AddBlock(agent.NewCommandBlock("echo test"))
+
+	cmd := m.handleAgentEvent(agent.Event{
+		TargetID:   1,
+		Type:       agent.EventCmdOutput,
+		OutputLine: "output line",
+	})
+
+	if !m.viewportDirty {
+		t.Error("expected viewportDirty=true after CmdOutput")
+	}
+	// When not spinning, debounce timer should be returned
+	if cmd == nil {
+		t.Error("expected non-nil debounce cmd when not spinning")
+	}
+}
+
+func TestHandleAgentEvent_EventCmdOutput_Debounce_WhileSpinning(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.spinning = true
+
+	t1.AddBlock(agent.NewCommandBlock("echo test"))
+
+	cmd := m.handleAgentEvent(agent.Event{
+		TargetID:   1,
+		Type:       agent.EventCmdOutput,
+		OutputLine: "output while spinning",
+	})
+
+	if !m.viewportDirty {
+		t.Error("expected viewportDirty=true after CmdOutput")
+	}
+	// When spinning, next spinner tick will flush — no debounce cmd needed
+	if cmd != nil {
+		t.Error("expected nil cmd (debounce deferred to spinner tick) when spinning")
+	}
+}
+
+// ===========================================================================
+// handleAgentEvent — EventAddTarget with empty host
+// ===========================================================================
+
+func TestHandleAgentEvent_EventAddTarget_EmptyHost(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+
+	targetsBefore := len(m.targets)
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventAddTarget,
+		NewHost:  "", // empty host
+	})
+
+	if len(m.targets) != targetsBefore {
+		t.Errorf("expected no new target for empty host, got %d", len(m.targets))
+	}
+}
+
+// ===========================================================================
+// handleAgentEvent — non-active target event (no viewport update)
+// ===========================================================================
+
+func TestHandleAgentEvent_NonActiveTarget_NoViewportUpdate(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	t2 := agent.NewTarget(2, "10.0.0.2")
+	m := NewWithTargets([]*agent.Target{t1, t2})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.selected = 0 // t1 is active
+
+	// Event for t2 — needsViewportUpdate is false
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID:   2,
+		Type:       agent.EventCmdOutput,
+		OutputLine: "output for t2",
+	})
+
+	// viewportDirty should NOT be set for non-active target's CmdOutput
+	if m.viewportDirty {
+		t.Error("expected viewportDirty=false for non-active target event")
+	}
+}
+
+// ===========================================================================
+// renderStatusBar — model info branches
+// ===========================================================================
+
+func TestRenderStatusBar_ProviderOnly(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.CurrentProvider = "anthropic"
+	m.CurrentModel = "" // empty model
+
+	bar := m.renderStatusBar()
+	if !strings.Contains(bar, "Model: anthropic") {
+		t.Error("expected 'Model: anthropic' in status bar when only provider is set")
+	}
+}
+
+func TestRenderStatusBar_ProviderAndModel(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.CurrentProvider = "anthropic"
+	m.CurrentModel = "claude-sonnet-4-6"
+
+	bar := m.renderStatusBar()
+	if !strings.Contains(bar, "Model: anthropic/claude-sonnet-4-6") {
+		t.Error("expected 'Model: anthropic/claude-sonnet-4-6' in status bar")
+	}
+}
+
+func TestRenderStatusBar_NoProvider(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.CurrentProvider = ""
+	m.CurrentModel = ""
+
+	bar := m.renderStatusBar()
+	if strings.Contains(bar, "Model:") {
+		t.Error("expected no 'Model:' in status bar when provider is empty")
+	}
+}
+
+func TestRenderStatusBar_NoTarget_ShowsMessage(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+
+	bar := m.renderStatusBar()
+	if !strings.Contains(bar, "No target selected") {
+		t.Error("expected 'No target selected' in status bar when no targets")
+	}
+}
+
+// ===========================================================================
+// handleModelCommand — no providers detected
+// ===========================================================================
+
+func TestHandleModelCommand_NoProviders_ViaSubmit(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("OLLAMA_BASE_URL", "")
+
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.input.SetValue("/model")
+
+	m.submitInput()
+
+	// Should log "No providers detected"
+	found := false
+	for _, b := range t1.Blocks {
+		if b.Type == agent.BlockSystem && strings.Contains(b.SystemMsg, "No providers detected") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'No providers detected' message")
+	}
+}
+
+func TestHandleModelCommand_WithProvider_ShowsSelect(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("OLLAMA_BASE_URL", "")
+
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleModelCommand("")
+
+	if m.inputMode != InputSelect {
+		t.Errorf("expected InputSelect after /model, got %d", m.inputMode)
+	}
+	if len(m.selectOptions) == 0 {
+		t.Error("expected at least one select option")
+	}
+}
+
+func TestHandleModelCommand_ProviderCallback_ShowsModelSelect(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("OLLAMA_BASE_URL", "")
+
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.handleModelCommand("")
+
+	// Execute the provider selection callback (select "anthropic")
+	if m.selectCallback != nil {
+		m.selectCallback(&m, "anthropic")
+	}
+
+	// Should now show model selection
+	if m.inputMode != InputSelect {
+		t.Errorf("expected InputSelect for model selection, got %d", m.inputMode)
+	}
+	if len(m.selectOptions) == 0 {
+		t.Error("expected model options for anthropic")
+	}
+}
+
+func TestHandleModelCommand_ProviderCallback_UnknownProvider(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("OLLAMA_BASE_URL", "")
+
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.BrainFactory = func(hint brain.ConfigHint) (brain.Brain, error) {
+		return nil, nil
+	}
+
+	m.handleModelCommand("")
+
+	// Execute the provider selection callback with an unknown provider
+	// (modelsForProvider returns nil → switchModel is called directly)
+	if m.selectCallback != nil {
+		m.selectCallback(&m, "unknown_provider")
+	}
+
+	// Should have called switchModel with empty model (no model list for unknown provider)
+	// CurrentProvider should be set if BrainFactory succeeded
+	if m.CurrentProvider != "unknown_provider" {
+		t.Errorf("expected CurrentProvider 'unknown_provider', got %q", m.CurrentProvider)
+	}
+}
+
+// ===========================================================================
+// handleApproveCommand — callback execution
+// ===========================================================================
+
+func TestHandleApproveCommand_CallbackOn(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	runner := tools.NewCommandRunner(tools.NewRegistry(), tools.NewBlacklist(nil), tools.NewLogStore())
+	m.Runner = runner
+
+	m.handleApproveCommand("/approve")
+
+	if m.inputMode != InputSelect {
+		t.Fatalf("expected InputSelect, got %d", m.inputMode)
+	}
+
+	// Execute callback with "on"
+	if m.selectCallback != nil {
+		m.selectCallback(&m, "on")
+	}
+
+	if !runner.AutoApprove() {
+		t.Error("expected AutoApprove=true after selecting ON")
+	}
+}
+
+func TestHandleApproveCommand_CallbackOff(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	runner := tools.NewCommandRunner(tools.NewRegistry(), tools.NewBlacklist(nil), tools.NewLogStore())
+	runner.SetAutoApprove(true)
+	m.Runner = runner
+
+	m.handleApproveCommand("/approve")
+
+	// Execute callback with "off"
+	if m.selectCallback != nil {
+		m.selectCallback(&m, "off")
+	}
+
+	if runner.AutoApprove() {
+		t.Error("expected AutoApprove=false after selecting OFF")
+	}
+}
+
+func TestHandleApproveCommand_CallbackNilRunner(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	runner := tools.NewCommandRunner(tools.NewRegistry(), tools.NewBlacklist(nil), tools.NewLogStore())
+	m.Runner = runner
+
+	m.handleApproveCommand("/approve")
+
+	// Set Runner to nil before callback (edge case)
+	m.Runner = nil
+	if m.selectCallback != nil {
+		// Should not panic
+		m.selectCallback(&m, "on")
+	}
+}
+
+// ===========================================================================
+// logSystem — with and without active target
+// ===========================================================================
+
+func TestLogSystem_NoActiveTarget(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+
+	m.logSystem("test global log")
+
+	if len(m.globalLogs) != 1 {
+		t.Fatalf("expected 1 global log, got %d", len(m.globalLogs))
+	}
+	if m.globalLogs[0] != "test global log" {
+		t.Errorf("expected 'test global log', got %q", m.globalLogs[0])
+	}
+}
+
+func TestLogSystem_WithActiveTarget(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	blocksBefore := len(t1.Blocks)
+	m.logSystem("target log message")
+
+	if len(t1.Blocks) != blocksBefore+1 {
+		t.Fatalf("expected 1 new block, got %d", len(t1.Blocks)-blocksBefore)
+	}
+	lastBlock := t1.Blocks[len(t1.Blocks)-1]
+	if lastBlock.Type != agent.BlockSystem {
+		t.Errorf("expected BlockSystem, got %d", lastBlock.Type)
+	}
+	if lastBlock.SystemMsg != "target log message" {
+		t.Errorf("expected 'target log message', got %q", lastBlock.SystemMsg)
+	}
+}
+
+// ===========================================================================
+// AgentEventCmd — basic functionality
+// ===========================================================================
+
+func TestAgentEventCmd_ReturnsCmd(t *testing.T) {
+	ch := make(chan agent.Event, 1)
+	cmd := AgentEventCmd(ch)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from AgentEventCmd")
+	}
+
+	// Push an event to the channel so the cmd can resolve
+	ch <- agent.Event{
+		TargetID: 1,
+		Type:     agent.EventLog,
+		Source:   agent.SourceSystem,
+		Message:  "test",
+	}
+
+	// Execute the cmd and verify it returns an AgentEventMsg
+	msg := cmd()
+	eventMsg, ok := msg.(AgentEventMsg)
+	if !ok {
+		t.Fatalf("expected AgentEventMsg, got %T", msg)
+	}
+	if agent.Event(eventMsg).Message != "test" {
+		t.Errorf("expected message 'test', got %q", agent.Event(eventMsg).Message)
+	}
+}
+
+// ===========================================================================
+// Update() — unknown message type (default case)
+// ===========================================================================
+
+func TestUpdate_UnknownMsgType(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+
+	// Send a custom message type that is not handled
+	type customMsg struct{}
+	result, cmd := m.Update(customMsg{})
+	rm := result.(Model)
+	_ = rm
+
+	// Should not panic, cmd should be tea.Batch of empty cmds
+	if cmd != nil {
+		// tea.Batch(nil...) may return non-nil, but it should be safe
+		_ = cmd
+	}
+}
+
+// ===========================================================================
+// handleSelectKey — up/down boundary checks
+// ===========================================================================
+
+func TestHandleSelectKey_UpAtTop(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.showSelect("Test:", []SelectOption{
+		{Label: "A", Value: "a"},
+		{Label: "B", Value: "b"},
+	}, nil)
+	m.selectIndex = 0
+
+	m.handleSelectKey(tea.KeyMsg{Type: tea.KeyUp})
+
+	if m.selectIndex != 0 {
+		t.Errorf("expected selectIndex=0 at top boundary, got %d", m.selectIndex)
+	}
+}
+
+func TestHandleSelectKey_DownAtBottom(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.showSelect("Test:", []SelectOption{
+		{Label: "A", Value: "a"},
+		{Label: "B", Value: "b"},
+	}, nil)
+	m.selectIndex = 1
+
+	m.handleSelectKey(tea.KeyMsg{Type: tea.KeyDown})
+
+	if m.selectIndex != 1 {
+		t.Errorf("expected selectIndex=1 at bottom boundary, got %d", m.selectIndex)
+	}
+}
+
+// ===========================================================================
+// ConfirmQuit — uppercase N
+// ===========================================================================
+
+func TestConfirmQuit_UpperN_Cancels(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.inputMode = InputConfirmQuit
+
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+	rm := result.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd on uppercase N")
+	}
+	if rm.inputMode != InputNormal {
+		t.Errorf("expected InputNormal after uppercase N, got %d", rm.inputMode)
+	}
+}
+
+// ===========================================================================
+// Update() — WindowSizeMsg with very tiny values
+// ===========================================================================
+
+func TestUpdate_WindowSizeMsg_TinyDimensions(t *testing.T) {
+	m := NewWithTargets(nil)
+
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 1, Height: 1})
+	rm := result.(Model)
+
+	if !rm.ready {
+		t.Error("expected ready=true even with tiny dimensions")
+	}
+}
+
+// ===========================================================================
+// handleAgentEvent — EventSubTaskComplete matching by TaskID
+// ===========================================================================
+
+func TestHandleAgentEvent_SubTaskComplete_MatchesTaskID(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+
+	// Add two subtask blocks
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventSubTaskStart,
+		TaskID:   "task-A",
+		Message:  "Task A",
+	})
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventSubTaskStart,
+		TaskID:   "task-B",
+		Message:  "Task B",
+	})
+
+	// Complete task-A (first one) — should match by TaskID
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventSubTaskComplete,
+		TaskID:   "task-A",
+	})
+
+	// Find the task-A block and verify it's done
+	foundA := false
+	foundBNotDone := false
+	for _, b := range t1.Blocks {
+		if b.Type == agent.BlockSubTask && b.TaskID == "task-A" && b.TaskDone {
+			foundA = true
+		}
+		if b.Type == agent.BlockSubTask && b.TaskID == "task-B" && !b.TaskDone {
+			foundBNotDone = true
+		}
+	}
+	if !foundA {
+		t.Error("expected task-A to be marked done")
+	}
+	if !foundBNotDone {
+		t.Error("expected task-B to still be pending")
+	}
+}
+
+// ===========================================================================
+// handleAgentEvent — EventAddTarget with team (success case)
+// ===========================================================================
+
+func TestHandleAgentEvent_EventAddTarget_WithTeam(t *testing.T) {
+	t1 := agent.NewTarget(1, "10.0.0.1")
+	cfg := agent.TeamConfig{
+		Events: make(chan agent.Event, 10),
+		Brain:  nil,
+		Runner: nil,
+	}
+	team := agent.NewTeam(cfg)
+
+	m := NewWithTargets([]*agent.Target{t1})
+	m.handleResize(120, 40)
+	m.ready = true
+	m.team = team
+
+	_ = m.handleAgentEvent(agent.Event{
+		TargetID: 1,
+		Type:     agent.EventAddTarget,
+		NewHost:  "10.0.0.2",
+	})
+
+	if len(m.targets) != 2 {
+		t.Fatalf("expected 2 targets after EventAddTarget, got %d", len(m.targets))
+	}
+	if m.targets[1].Host != "10.0.0.2" {
+		t.Errorf("expected new target host '10.0.0.2', got %q", m.targets[1].Host)
+	}
+}
+
+// ===========================================================================
+// View() — basic rendering tests
+// ===========================================================================
+
+func TestView_NotReady_ShowsStartup(t *testing.T) {
+	m := NewWithTargets(nil)
+	// ready is false by default
+
+	view := m.View()
+	if !strings.Contains(view, "Starting Pentecter") {
+		t.Error("expected 'Starting Pentecter' when not ready")
+	}
+}
+
+func TestView_Ready_NoTarget_ShowsHeader(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+
+	view := m.View()
+	if !strings.Contains(view, "PENTECTER") {
+		t.Error("expected 'PENTECTER' in rendered view")
+	}
+}
+
+func TestView_SelectMode(t *testing.T) {
+	m := NewWithTargets(nil)
+	m.handleResize(120, 40)
+	m.ready = true
+	m.showSelect("Pick one:", []SelectOption{
+		{Label: "Alpha", Value: "a"},
+		{Label: "Beta", Value: "b"},
+	}, nil)
+
+	view := m.View()
+	if !strings.Contains(view, "Alpha") {
+		t.Error("expected 'Alpha' in select mode view")
 	}
 }


### PR DESCRIPTION
## Summary
- Comprehensive test coverage improvements across 9 packages (+6370 lines of tests)
- brain: 84.6% → 94.4%, tui: 81.9% → 97.3%, mcp: 61.7% → 73.6%, tools: 86.1% → 88.0%, agent: 86.6% → 88.1%
- Fix ActionWait timeout bug in loop_tasks_test.go (drainCompletedTasks consumed doneCh before handleWait)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/...` all green
- [x] `golangci-lint run` 0 issues

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)