### PR TITLE
fix: remove 18 golangci-lint warnings in TUI package

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -77,7 +77,6 @@ type App struct {
 	mu               sync.Mutex
 	spinnerActive    atomic.Bool
 	spinnerIdx       atomic.Int32
-	inputProcessing  atomic.Bool
 	interruptPending atomic.Bool
 	drawTimerPending atomic.Bool
 
@@ -1195,9 +1194,8 @@ func drawLine(s tcell.Screen, y int, text string, style tcell.Style, width int) 
 	if y < 0 {
 		return
 	}
-	runes := []rune(text)
 	x := 0
-	for _, r := range runes {
+	for _, r := range text {
 		rw := runewidth.RuneWidth(r)
 		if rw <= 0 {
 			rw = 1
@@ -1211,21 +1209,6 @@ func drawLine(s tcell.Screen, y int, text string, style tcell.Style, width int) 
 	for ; x < width; x++ {
 		s.SetContent(x, y, ' ', nil, style)
 	}
-}
-
-func wrapLines(lines []string, width int) []string {
-	if width <= 0 {
-		return append([]string(nil), lines...)
-	}
-
-	out := make([]string, 0, len(lines))
-	for _, l := range lines {
-		out = append(out, wrapLine(l, width)...)
-	}
-	if len(out) == 0 {
-		return []string{""}
-	}
-	return out
 }
 
 func wrapOutputLines(lines []outputLine, width int) []outputLine {
@@ -1286,41 +1269,6 @@ func wrapLine(line string, width int) []string {
 		out = append(out, "")
 	}
 	return out
-}
-
-func tailLines(lines []string, n int) []string {
-	if n <= 0 {
-		return nil
-	}
-	if len(lines) <= n {
-		return lines
-	}
-	return lines[len(lines)-n:]
-}
-
-func windowLines(lines []string, n int, scroll int) []string {
-	if n <= 0 {
-		return nil
-	}
-	if scroll < 0 {
-		scroll = 0
-	}
-	if len(lines) <= n {
-		return lines
-	}
-
-	end := len(lines) - scroll
-	if end < 0 {
-		end = 0
-	}
-	start := end - n
-	if start < 0 {
-		start = 0
-	}
-	if end < start {
-		end = start
-	}
-	return lines[start:end]
 }
 
 func windowOutputLines(lines []outputLine, n int, scroll int) []outputLine {
@@ -1516,11 +1464,6 @@ func (a *App) getTerminalSize() (int, int) {
 		h = defaultHeight
 	}
 	return w, h
-}
-
-// pollResize is a compatibility no-op (tcell emits EventResize).
-func (a *App) pollResize(ctx context.Context) {
-	<-ctx.Done()
 }
 
 // writer returns a test writer if configured; otherwise discard.

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/0x6d61/pentecter/internal/agent"
 )
@@ -201,8 +200,4 @@ func (a *App) hasActiveBlocksLocked() bool {
 		}
 	}
 	return false
-}
-
-func (a *App) debugEventString(e agent.Event) string {
-	return fmt.Sprintf("event=%s target=%d", e.Type, e.TargetID)
 }

--- a/internal/tui/output.go
+++ b/internal/tui/output.go
@@ -27,38 +27,6 @@ func (a *App) runSpinner(ctx context.Context) {
 	}
 }
 
-// overwriteOutputLine is a compatibility no-op; full redraw is handled by tcell.
-func (a *App) overwriteOutputLine(string) {}
-
-// isThinkingLocked checks if the most recent active block is a Thinking block.
-// Must be called with a.mu held.
-func (a *App) isThinkingLocked() bool {
-	t := a.activeTargetLocked()
-	if t == nil {
-		return false
-	}
-	for i := len(t.Blocks) - 1; i >= 0; i-- {
-		b := t.Blocks[i]
-		if b.Type == agent.BlockThinking && !b.ThinkingDone {
-			return true
-		}
-		if (b.Type == agent.BlockCommand && !b.Completed) ||
-			(b.Type == agent.BlockSubTask && !b.TaskDone) {
-			return false
-		}
-	}
-	return false
-}
-
-// nextSpinnerFrame returns the current spinner animation frame.
-func (a *App) nextSpinnerFrame() string {
-	if len(a.spinnerFrames) == 0 {
-		return "."
-	}
-	idx := a.spinnerIdx.Load()
-	return a.spinnerFrames[int(idx)%len(a.spinnerFrames)]
-}
-
 // printCmdOutputLine emits textual output only in tests.
 func (a *App) printCmdOutputLine(line string, outputLen int) {
 	if a.testWriter == nil {
@@ -80,7 +48,7 @@ func (a *App) printCmdOutputLine(line string, outputLen int) {
 	}
 
 	remaining := outputLen - previewLines
-	_, _ = fmt.Fprintln(a.testWriter, fmt.Sprintf("     ... +%d lines (ctrl+o)", remaining))
+	_, _ = fmt.Fprintf(a.testWriter, "     ... +%d lines (ctrl+o)\n", remaining)
 }
 
 // toggleFold toggles log folding.
@@ -107,19 +75,6 @@ func (a *App) clearAndReprint() {
 	lines := a.buildOutputLinesLocked(width)
 	a.mu.Unlock()
 
-	for _, l := range lines {
-		_, _ = fmt.Fprintln(a.testWriter, l)
-	}
-}
-
-// printProposal emits proposal text only in tests.
-func (a *App) printProposal(p *agent.Proposal) {
-	if a.testWriter == nil {
-		return
-	}
-	a.mu.Lock()
-	lines := a.proposalLinesLocked(p)
-	a.mu.Unlock()
 	for _, l := range lines {
 		_, _ = fmt.Fprintln(a.testWriter, l)
 	}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,24 +8,8 @@ var (
 	colorSecondary    = lipgloss.Color("#AF87FF") // purple — AI source label
 	colorSuccess      = lipgloss.Color("#87FF5F") // green — PWNED / USER
 	colorWarning      = lipgloss.Color("#FFD700") // yellow — PAUSED / proposal
-	colorDanger       = lipgloss.Color("#FF5555") // red — FAILED
 	colorMuted = lipgloss.Color("#555577") // dim gray — timestamps / hints
 )
-
-// Output style for command output lines
-var outputStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#AAAAAA"))
-
-// Status bar (top)
-var statusBarStyle = lipgloss.NewStyle().
-	Background(lipgloss.Color("#0D0D1A")).
-	Foreground(colorPrimary).
-	Padding(0, 1)
-
-// Proposal box (rendered inside viewport)
-var proposalBoxStyle = lipgloss.NewStyle().
-	Border(lipgloss.RoundedBorder()).
-	BorderForeground(colorWarning).
-	Padding(0, 1)
 
 // foldIndicatorStyle は折りたたみ行の「⋯ +N Lines (Ctrl+O)」スタイル。
 var foldIndicatorStyle = lipgloss.NewStyle().Foreground(colorMuted).Italic(true)
@@ -37,14 +21,3 @@ var userInputBlockStyle = lipgloss.NewStyle().
 	Bold(true).
 	Padding(0, 1)
 
-// Select box style — Proposal と同パターンの角丸ボーダー
-var selectBoxStyle = lipgloss.NewStyle().
-	Border(lipgloss.RoundedBorder()).
-	BorderForeground(colorPrimary).
-	Padding(0, 1)
-
-// Recon tree box style — 偵察ツリー表示用
-var reconBoxStyle = lipgloss.NewStyle().
-	Border(lipgloss.RoundedBorder()).
-	BorderForeground(colorPrimary).
-	Padding(0, 1)


### PR DESCRIPTION
## Summary
- SA6003: range over string directly instead of `[]rune(string)` in `drawLine`
- S1038: use `fmt.Fprintf` instead of `fmt.Fprintln(fmt.Sprintf(...))`
- Remove 16 unused functions/fields/variables: `inputProcessing`, `wrapLines`, `tailLines`, `windowLines`, `pollResize`, `debugEventString`, `overwriteOutputLine`, `isThinkingLocked`, `nextSpinnerFrame`, `printProposal`, `colorDanger`, `outputStyle`, `statusBarStyle`, `proposalBoxStyle`, `selectBoxStyle`, `reconBoxStyle`

`golangci-lint run` → 0 issues

Closes #107

## Test plan
- [x] `go build ./...` 成功
- [x] `go vet ./...` 成功
- [x] `go test ./internal/tui/...` グリーン
- [x] `golangci-lint run` — 0 issues
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)