### PR TITLE
feat: phase gate — block MainAI during active recon

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -194,6 +194,17 @@ func (l *Loop) Run(ctx context.Context) {
 			l.target.SetStatusSafe(StatusScanning)
 		}
 
+		// Phase gate: Recon SubAgent 実行中は Brain.Think() を呼ばず完了を待つ。
+		// ユーザー入力は常に受け付ける。完了タスクの drain も定期的に行う。
+		if l.shouldGateForRecon(userMsg) {
+			l.emit(Event{Type: EventLog, Source: SourceSystem,
+				Message: "Phase gate: waiting for HTTPAgent to complete recon..."})
+			userMsg = l.waitForReconGate(ctx)
+			if userMsg == "" && ctx.Err() != nil {
+				return // context cancelled
+			}
+		}
+
 		l.emit(Event{Type: EventTurnStart, TurnNumber: l.turnCount})
 
 		// 完了済みサブタスクの結果を自動注入（Push モデル）
@@ -823,6 +834,44 @@ func (l *Loop) buildReconQueue() string {
 		return ""
 	}
 	return l.attackData.RenderIntel()
+}
+
+// shouldGateForRecon は Phase gate を有効にすべきかを判定する。
+// AttackDataTree が存在し、かつ Recon SubAgent が実行中（Active > 0）で、
+// ユーザーメッセージが無い場合にゲートを有効にする。
+func (l *Loop) shouldGateForRecon(userMsg string) bool {
+	return l.attackData != nil && l.attackData.Active() > 0 && userMsg == ""
+}
+
+// waitForReconGate は Recon 完了またはユーザー入力を待つブロッキング関数。
+// 2秒ごとに Recon 状態と完了タスクをチェックする。
+// 戻り値はユーザーメッセージ（なければ空文字）。
+func (l *Loop) waitForReconGate(ctx context.Context) string {
+	for {
+		// 完了タスクを drain（CompleteAllPortTasks が呼ばれ Active が減る可能性がある）
+		if completedOutput := l.drainCompletedTasks(); completedOutput != "" {
+			l.lastToolOutput = completedOutput
+			return ""
+		}
+
+		// Recon が完了したらゲート解除
+		if l.attackData.Active() <= 0 {
+			return ""
+		}
+
+		// ユーザー入力 or コンテキストキャンセル or タイムアウトを待つ
+		select {
+		case <-ctx.Done():
+			return ""
+		case msg := <-l.userMsg:
+			if l.skillsReg != nil {
+				msg = l.skillsReg.Expand(msg)
+			}
+			return msg
+		case <-time.After(2 * time.Second):
+			// 定期チェック: 次のループで Active() を再確認
+		}
+	}
 }
 
 func (l *Loop) buildSnapshot() string {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2082,3 +2082,196 @@ func TestTeam_AddTarget_Duplicate_AfterStart(t *testing.T) {
 		t.Errorf("Loops() count after duplicate: got %d, want 1", len(team.Loops()))
 	}
 }
+
+// =============================================================================
+// Phase Gate Tests
+// =============================================================================
+
+// TestLoop_PhaseGate_BlocksDuringRecon tests that Brain.Think() is NOT called
+// while recon SubAgents are active.
+func TestLoop_PhaseGate_BlocksDuringRecon(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+
+	thinkCalled := make(chan struct{}, 10)
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "done", Action: schema.ActionComplete},
+		},
+		onThink: func(_ int) {
+			thinkCalled <- struct{}{}
+		},
+	}
+
+	loop, events, _, _ := newTestLoop(target, mb)
+
+	// Set up AttackDataTree with active recon (Active=1)
+	tree := agent.NewAttackDataTree("10.0.0.1", 2)
+	tree.AddPort(80, "http", "Apache")
+	// Simulate an active SubAgent by starting port recon
+	tree.StartPortRecon(tree.Ports[0])
+	loop.WithAttackData(tree)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+
+	// Drain events to avoid blocking
+	go func() {
+		for range events {
+		}
+	}()
+
+	// Brain.Think() should NOT be called while recon is active
+	select {
+	case <-thinkCalled:
+		t.Fatal("Brain.Think() was called while recon is active — phase gate should block it")
+	case <-time.After(2 * time.Second):
+		// Good — Think was not called
+	}
+	cancel()
+}
+
+// TestLoop_PhaseGate_UnblocksOnUserMsg tests that user message unblocks the gate.
+func TestLoop_PhaseGate_UnblocksOnUserMsg(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+
+	thinkCalled := make(chan struct{}, 10)
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "responding to user", Action: schema.ActionComplete},
+		},
+		onThink: func(_ int) {
+			thinkCalled <- struct{}{}
+		},
+	}
+
+	loop, events, _, userMsg := newTestLoop(target, mb)
+
+	// Set up AttackDataTree with active recon
+	tree := agent.NewAttackDataTree("10.0.0.1", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.StartPortRecon(tree.Ports[0])
+	loop.WithAttackData(tree)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+
+	// Wait a bit, then send user message
+	time.Sleep(500 * time.Millisecond)
+	userMsg <- "what is the status?"
+
+	// Brain.Think() should be called after user message unblocks the gate
+	select {
+	case <-thinkCalled:
+		// Good — user message unblocked the gate
+		// Verify the user message was passed to Brain
+		if len(mb.inputs) > 0 {
+			lastInput := mb.inputs[len(mb.inputs)-1]
+			if lastInput.UserMessage == "" {
+				t.Error("UserMessage should be non-empty after gate unblock")
+			}
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("Brain.Think() was never called — user message should unblock the phase gate")
+	}
+
+	// Wait for completion
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestLoop_PhaseGate_UnblocksWhenReconCompletes tests that the gate unblocks
+// when all recon SubAgents finish (Active goes to 0).
+func TestLoop_PhaseGate_UnblocksWhenReconCompletes(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+
+	thinkCalled := make(chan struct{}, 10)
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "recon done, analyzing", Action: schema.ActionComplete},
+		},
+		onThink: func(_ int) {
+			thinkCalled <- struct{}{}
+		},
+	}
+
+	loop, events, _, _ := newTestLoop(target, mb)
+
+	// Set up AttackDataTree with active recon
+	tree := agent.NewAttackDataTree("10.0.0.1", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.StartPortRecon(tree.Ports[0])
+	loop.WithAttackData(tree)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+
+	// Wait a bit, then simulate recon completion
+	time.Sleep(500 * time.Millisecond)
+	tree.CompleteAllPortTasks(80)
+
+	// Brain.Think() should be called after recon completes
+	select {
+	case <-thinkCalled:
+		// Good — recon completion unblocked the gate
+	case <-time.After(4 * time.Second):
+		t.Fatal("Brain.Think() was never called — recon completion should unblock the phase gate")
+	}
+
+	// Wait for completion
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}
+
+// TestLoop_PhaseGate_NoGateWithoutAttackData tests that the gate does NOT
+// activate when AttackDataTree is nil.
+func TestLoop_PhaseGate_NoGateWithoutAttackData(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "no recon tree", Action: schema.ActionComplete},
+		},
+	}
+
+	loop, events, _, _ := newTestLoop(target, mb)
+	// Do NOT set AttackData — no gate should activate
+	_ = loop // suppress unused warning
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+
+	// Should complete normally without blocking
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout — loop should complete normally without AttackData")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- MainLoop に Phase Gate を追加: HTTPReconAgent 実行中は `Brain.Think()` をブロック
- `shouldGateForRecon()`: AttackDataTree.Active() > 0 かつユーザー入力なし → ゲート有効
- `waitForReconGate()`: 2秒ごとに Recon 状態を確認、完了タスクも定期 drain
- ユーザー入力は常に受け付け、ゲートを即座に解除
- MainAI の早期攻撃開始（問題1-C）を解決

## 実装詳細
- `loop.go`: フェーズゲートロジック（`shouldGateForRecon` + `waitForReconGate`）
- `loop_test.go`: 4つのテストケース
  - `BlocksDuringRecon` — Active中にThinkが呼ばれないことを確認
  - `UnblocksOnUserMsg` — ユーザー入力でゲート解除
  - `UnblocksWhenReconCompletes` — Recon完了でゲート解除
  - `NoGateWithoutAttackData` — AttackData無しでは通常動作

Closes #98

## Test plan
- [x] `go build ./...` 成功
- [x] `go vet ./...` 成功
- [x] `go test ./internal/...` 全グリーン（27s）
- [x] `golangci-lint run` — 0 issues
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)