### PR TITLE
feat: Recon Checklist — service-specific recon guidance for MainAI

### DIFF
--- a/internal/agent/attack_data_tree.go
+++ b/internal/agent/attack_data_tree.go
@@ -68,6 +68,7 @@ type AttackDataNode struct {
 	VhostDiscov  AttackDataStatus
 
 	Findings []Finding
+	Checklist *ServiceChecklist
 
 	Children []*AttackDataNode
 }
@@ -649,6 +650,52 @@ func renderEndpointNode(sb *strings.Builder, node *AttackDataNode, prefix, child
 	}
 }
 
+
+// SetChecklist sets the recon checklist for a non-HTTP port.
+// No-op if the port already has a checklist or if the port is HTTP.
+func (t *AttackDataTree) SetChecklist(port int, checklist *ServiceChecklist) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, node := range t.Ports {
+		if node.Port == port {
+			if node.isHTTP() || node.Checklist != nil {
+				return
+			}
+			node.Checklist = checklist
+			return
+		}
+	}
+}
+
+// UpdateAllChecklists updates completion state of all port checklists based on command history.
+func (t *AttackDataTree) UpdateAllChecklists(commands []string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, node := range t.Ports {
+		if node.Checklist != nil {
+			UpdateChecklistCompletion(node.Checklist, commands)
+		}
+	}
+}
+
+// AllChecklistsDone returns true if all non-HTTP ports' checklists are fully complete.
+// Returns true if no checklists exist (vacuously true).
+func (t *AttackDataTree) AllChecklistsDone() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.allChecklistsDoneLocked()
+}
+
+// allChecklistsDoneLocked is a lock-free helper for use within methods that already hold the lock.
+func (t *AttackDataTree) allChecklistsDoneLocked() bool {
+	for _, node := range t.Ports {
+		if node.Checklist != nil && !ChecklistAllDone(node.Checklist) {
+			return false
+		}
+	}
+	return true
+}
+
 // RenderIntel は RECON INTEL をプロンプト注入用に返す。
 // ポートがない場合は空文字列を返す。
 func (t *AttackDataTree) RenderIntel() string {
@@ -677,6 +724,41 @@ func (t *AttackDataTree) RenderIntel() string {
 		fmt.Fprintf(&sb, "[BACKGROUND] HTTPAgent active on ports: %s — do NOT run ffuf/dirb yourself\n\n",
 			strings.Join(activePorts, ", "))
 	}
+
+
+	// [RECON CHECKLIST]: 非HTTPポートのチェックリスト
+	hasChecklist := false
+	for _, node := range t.Ports {
+		if node.Checklist == nil {
+			continue
+		}
+		if !hasChecklist {
+			sb.WriteString("[RECON CHECKLIST]\n")
+			hasChecklist = true
+		}
+		banner := node.Banner
+		if banner != "" {
+			banner = " (" + banner + ")"
+		}
+		fmt.Fprintf(&sb, "Port %d/%s%s:\n", node.Port, node.Service, banner)
+		for _, item := range node.Checklist.Items {
+			check := "[ ]"
+			if item.Done {
+				check = "[x]"
+			}
+			fmt.Fprintf(&sb, "  %s %s\n", check, item.Description)
+		}
+		if ChecklistAllDone(node.Checklist) {
+			sb.WriteString("  ** ALL ITEMS COMPLETE **\n")
+		}
+	}
+	if hasChecklist && t.allChecklistsDoneLocked() {
+		sb.WriteString("ALL NON-HTTP RECON COMPLETE. Use \"wait\" action or proceed to ANALYZE.\n")
+	}
+	if hasChecklist {
+		sb.WriteString("\n")
+	}
+
 
 	// [FINDINGS]: 全ノードの findings を表示
 	hasFindings := false
@@ -709,6 +791,19 @@ func (t *AttackDataTree) RenderIntel() string {
 				} else if anyTask {
 					status = "recon pending"
 				}
+			}
+		} else if node.Checklist != nil {
+			done := 0
+			for _, item := range node.Checklist.Items {
+				if item.Done {
+					done++
+				}
+			}
+			total := len(node.Checklist.Items)
+			if done == total {
+				status = fmt.Sprintf("recon complete (%d/%d)", done, total)
+			} else {
+				status = fmt.Sprintf("recon: %d/%d", done, total)
 			}
 		}
 		banner := node.Banner
@@ -808,6 +903,19 @@ func (t *AttackDataTree) PendingHTTPPorts() []*AttackDataNode {
 	var result []*AttackDataNode
 	for _, port := range t.Ports {
 		if port.isHTTP() && port.EndpointEnum == StatusPending {
+			result = append(result, port)
+		}
+	}
+	return result
+}
+
+// NonHTTPPortsWithoutChecklist はチェックリスト未設定の非 HTTP ポートを返す。
+func (t *AttackDataTree) NonHTTPPortsWithoutChecklist() []*AttackDataNode {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var result []*AttackDataNode
+	for _, port := range t.Ports {
+		if !port.isHTTP() && port.Checklist == nil {
 			result = append(result, port)
 		}
 	}

--- a/internal/agent/attack_data_tree_test.go
+++ b/internal/agent/attack_data_tree_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -948,5 +949,230 @@ func TestRenderIntel_ChildPendingPreventsReconComplete(t *testing.T) {
 	}
 	if !strings.Contains(output, "recon pending") {
 		t.Errorf("should show 'recon pending' when child has pending tasks\noutput:\n%s", output)
+	}
+}
+
+func TestSetChecklist(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", false)
+	tree.SetChecklist(22, cl)
+
+	// Checklist should be set
+	node := tree.Ports[0]
+	if node.Checklist == nil {
+		t.Fatal("Checklist should be set on port 22")
+	}
+	if len(node.Checklist.Items) == 0 {
+		t.Error("Checklist should have items")
+	}
+}
+
+func TestSetChecklist_NoOpIfAlreadySet(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	cl1 := GenerateChecklist("ssh", "OpenSSH 8.2", false)
+	tree.SetChecklist(22, cl1)
+
+	cl2 := GenerateChecklist("ssh", "OpenSSH 8.2", true) // different checklist
+	tree.SetChecklist(22, cl2)
+
+	// Should still have the first checklist (no-op on second set)
+	node := tree.Ports[0]
+	// cl1 has no search-knowledge, cl2 does. If no-op, should NOT have search-knowledge.
+	hasKnowledge := false
+	for _, item := range node.Checklist.Items {
+		if item.ID == "search-knowledge" {
+			hasKnowledge = true
+		}
+	}
+	if hasKnowledge {
+		t.Error("SetChecklist should be no-op if already set")
+	}
+}
+
+func TestSetChecklist_SkipsHTTPPorts(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	cl := GenerateChecklist("http", "", false)
+	tree.SetChecklist(80, cl)
+
+	// HTTP ports should not get a checklist
+	node := tree.Ports[0]
+	if node.Checklist != nil {
+		t.Error("HTTP port should not get a checklist")
+	}
+}
+
+func TestSetChecklist_PortNotFound(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", false)
+	// Port 443 doesn't exist - should not panic
+	tree.SetChecklist(443, cl)
+}
+
+func TestUpdateAllChecklists(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddPort(21, "ftp", "vsftpd 2.3.4")
+
+	tree.SetChecklist(22, GenerateChecklist("ssh", "OpenSSH 8.2", false))
+	tree.SetChecklist(21, GenerateChecklist("ftp", "vsftpd 2.3.4", false))
+
+	commands := []string{
+		"searchsploit ssh OpenSSH 8.2",
+		"nmap --script ssh-auth-methods -p22 10.10.11.100",
+	}
+	tree.UpdateAllChecklists(commands)
+
+	// SSH checklist should have searchsploit and ssh-auth-methods done
+	sshNode := tree.Ports[0]
+	for _, item := range sshNode.Checklist.Items {
+		if item.ID == "searchsploit" && !item.Done {
+			t.Error("searchsploit should be done for ssh")
+		}
+		if item.ID == "ssh-auth-methods" && !item.Done {
+			t.Error("ssh-auth-methods should be done")
+		}
+	}
+
+	// FTP checklist should not be affected (different keywords)
+	ftpNode := tree.Ports[1]
+	for _, item := range ftpNode.Checklist.Items {
+		if item.ID == "searchsploit" && item.Done {
+			t.Error("searchsploit should NOT be done for ftp (commands mention ssh, not ftp)")
+		}
+	}
+}
+
+func TestAllChecklistsDone(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddPort(80, "http", "Apache") // HTTP port - no checklist
+
+	tree.SetChecklist(22, GenerateChecklist("ssh", "OpenSSH 8.2", false))
+
+	// Not all done yet
+	if tree.AllChecklistsDone() {
+		t.Error("should not be all done yet")
+	}
+
+	// Mark all items done manually
+	sshNode := tree.Ports[0]
+	for i := range sshNode.Checklist.Items {
+		sshNode.Checklist.Items[i].Done = true
+	}
+
+	if !tree.AllChecklistsDone() {
+		t.Error("should be all done now")
+	}
+}
+
+func TestAllChecklistsDone_NoChecklists(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache") // HTTP only - no checklists
+
+	// No checklists at all - should return true (vacuously)
+	if !tree.AllChecklistsDone() {
+		t.Error("no checklists = all done (vacuously true)")
+	}
+}
+
+func TestRenderIntel_WithChecklist(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddPort(80, "http", "Apache")
+
+	tree.SetChecklist(22, GenerateChecklist("ssh", "OpenSSH 8.2", false))
+
+	// Mark searchsploit as done
+	commands := []string{"searchsploit ssh OpenSSH 8.2"}
+	tree.UpdateAllChecklists(commands)
+
+	output := tree.RenderIntel()
+
+	checks := []string{
+		"RECON CHECKLIST",
+		"Port 22/ssh",
+		"[x] searchsploit",
+		"[ ] ", // at least one incomplete item
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderIntel missing %q\noutput:\n%s", check, output)
+		}
+	}
+
+	// ATTACK SURFACE should show recon progress
+	if !strings.Contains(output, "22/ssh") {
+		t.Errorf("ATTACK SURFACE should list ssh port\noutput:\n%s", output)
+	}
+}
+
+func TestRenderIntel_ChecklistAllComplete(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	tree.SetChecklist(22, GenerateChecklist("ssh", "OpenSSH 8.2", false))
+
+	// Mark all items done
+	sshNode := tree.Ports[0]
+	for i := range sshNode.Checklist.Items {
+		sshNode.Checklist.Items[i].Done = true
+	}
+
+	output := tree.RenderIntel()
+
+	if !strings.Contains(output, "ALL ITEMS COMPLETE") {
+		t.Errorf("should show ALL ITEMS COMPLETE when all checklist items are done\noutput:\n%s", output)
+	}
+}
+
+func TestRenderIntel_AllNonHTTPReconComplete(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddPort(21, "ftp", "vsftpd 2.3.4")
+
+	tree.SetChecklist(22, GenerateChecklist("ssh", "OpenSSH 8.2", false))
+	tree.SetChecklist(21, GenerateChecklist("ftp", "vsftpd 2.3.4", false))
+
+	// Mark all items done
+	for _, port := range tree.Ports {
+		if port.Checklist != nil {
+			for i := range port.Checklist.Items {
+				port.Checklist.Items[i].Done = true
+			}
+		}
+	}
+
+	output := tree.RenderIntel()
+
+	if !strings.Contains(output, "ALL NON-HTTP RECON COMPLETE") {
+		t.Errorf("should show ALL NON-HTTP RECON COMPLETE\noutput:\n%s", output)
+	}
+}
+
+func TestRenderIntel_AttackSurface_ChecklistProgress(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", false)
+	tree.SetChecklist(22, cl)
+
+	// Mark 1 item done
+	tree.Ports[0].Checklist.Items[0].Done = true
+
+	output := tree.RenderIntel()
+
+	// Should show progress like "recon: 1/3" or "recon: 1/N"
+	totalItems := len(tree.Ports[0].Checklist.Items)
+	expectedProgress := fmt.Sprintf("recon: 1/%d", totalItems)
+	if !strings.Contains(output, expectedProgress) {
+		t.Errorf("ATTACK SURFACE should show checklist progress %q\noutput:\n%s", expectedProgress, output)
 	}
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -597,6 +597,13 @@ func (l *Loop) evaluateResult(ctx context.Context) {
 				Message: fmt.Sprintf("AttackDataTree parse warning: %v", err)})
 		}
 
+		// 新規非 HTTP ポートにチェックリストを自動生成
+		hasKnowledge := l.knowledgeStore != nil
+		for _, port := range l.attackData.NonHTTPPortsWithoutChecklist() {
+			cl := GenerateChecklist(port.Service, port.Banner, hasKnowledge)
+			l.attackData.SetChecklist(port.Port, cl)
+		}
+
 		// リアクティブ spawn: Pending な HTTP ポートがあれば SubAgent を自動起動
 		// 新規追加ポートと非HTTP→HTTP 更新ポートの両方を検出する
 		if l.reconRunner != nil {
@@ -828,11 +835,22 @@ func (l *Loop) buildMemory() string {
 	return l.memoryStore.Read(l.target.Host)
 }
 
+// extractCommandStrings は履歴からコマンド文字列のスライスを返す。
+func (l *Loop) extractCommandStrings() []string {
+	cmds := make([]string, len(l.history))
+	for i, e := range l.history {
+		cmds[i] = e.Command
+	}
+	return cmds
+}
+
 // buildReconQueue は RECON QUEUE のプロンプト注入テキストを返す。
+// チェックリストの完了状態をコマンド履歴で更新してからレンダリングする。
 func (l *Loop) buildReconQueue() string {
 	if l.attackData == nil {
 		return ""
 	}
+	l.attackData.UpdateAllChecklists(l.extractCommandStrings())
 	return l.attackData.RenderIntel()
 }
 

--- a/internal/agent/recon_checklist.go
+++ b/internal/agent/recon_checklist.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ChecklistItem represents a single recon task for a service.
+type ChecklistItem struct {
+	ID          string   // e.g. "searchsploit", "anon-check"
+	Description string   // Prompt display text
+	Keywords    []string // AND-match against command history
+	Done        bool     // additive-only: once true, never goes back
+}
+
+// ServiceChecklist holds the recon checklist for a specific service.
+type ServiceChecklist struct {
+	Items []ChecklistItem
+}
+
+// serviceAliases maps nmap service names to canonical names.
+var serviceAliases = map[string]string{
+	"microsoft-ds": "smb",
+	"netbios-ssn":  "smb",
+	"ms-sql-s":     "mssql",
+	"ms-sql":       "mssql",
+	"ms-wbt-server": "rdp",
+	"domain":       "dns",
+	"pop3s":        "pop3",
+	"imaps":        "imap",
+	"smtps":        "smtp",
+	"submission":   "smtp",
+}
+
+// normalizeServiceName maps nmap service aliases to canonical names.
+func normalizeServiceName(service string) string {
+	if canonical, ok := serviceAliases[service]; ok {
+		return canonical
+	}
+	return service
+}
+
+// GenerateChecklist creates a deterministic recon checklist for the given service.
+func GenerateChecklist(service, version string, hasKnowledge bool) *ServiceChecklist {
+	svc := normalizeServiceName(service)
+	items := []ChecklistItem{}
+
+	// Common: searchsploit
+	searchDesc := fmt.Sprintf("searchsploit %s", svc)
+	searchKeywords := []string{"searchsploit", svc}
+	if version != "" {
+		searchDesc = fmt.Sprintf("searchsploit %s %s", svc, version)
+	}
+	items = append(items, ChecklistItem{ID: "searchsploit", Description: searchDesc, Keywords: searchKeywords})
+
+	if hasKnowledge {
+		items = append(items, ChecklistItem{
+			ID: "search-knowledge", Description: fmt.Sprintf("search_knowledge %s", svc),
+			Keywords: []string{"search_knowledge", svc},
+		})
+	}
+
+	switch svc {
+	case "ftp":
+		items = append(items,
+			ChecklistItem{ID: "anon-check", Description: "Check FTP anonymous login", Keywords: []string{"ftp", "anonymous"}},
+			ChecklistItem{ID: "ftp-bounce", Description: "Check FTP bounce attack", Keywords: []string{"ftp-bounce"}},
+		)
+	case "ssh":
+		items = append(items,
+			ChecklistItem{ID: "ssh-auth-methods", Description: "Enumerate SSH auth methods", Keywords: []string{"ssh-auth-methods"}},
+			ChecklistItem{ID: "banner-grab", Description: "SSH banner grab", Keywords: []string{"ssh", "banner"}},
+		)
+	case "smb":
+		items = append(items,
+			ChecklistItem{ID: "enum4linux", Description: "Run enum4linux for SMB enumeration", Keywords: []string{"enum4linux"}},
+			ChecklistItem{ID: "smbclient", Description: "List SMB shares with smbclient", Keywords: []string{"smbclient"}},
+			ChecklistItem{ID: "smb-vuln", Description: "Run nmap smb-vuln scripts", Keywords: []string{"smb-vuln"}},
+		)
+	case "mysql":
+		items = append(items,
+			ChecklistItem{ID: "mysql-info", Description: "Run nmap mysql-info script", Keywords: []string{"mysql-info"}},
+			ChecklistItem{ID: "default-creds", Description: "Try MySQL default credentials", Keywords: []string{"mysql", "-u"}},
+		)
+	case "mssql":
+		items = append(items,
+			ChecklistItem{ID: "mssqlclient", Description: "Try impacket-mssqlclient connection", Keywords: []string{"mssqlclient"}},
+			ChecklistItem{ID: "default-creds", Description: "Try MSSQL default credentials (sa account)", Keywords: []string{"mssql", "sa"}},
+		)
+	case "postgresql":
+		items = append(items,
+			ChecklistItem{ID: "pg-ready", Description: "Check PostgreSQL availability with pg_isready", Keywords: []string{"pg_isready"}},
+			ChecklistItem{ID: "default-creds", Description: "Try PostgreSQL default credentials with psql", Keywords: []string{"psql", "-u"}},
+		)
+	case "rdp":
+		items = append(items,
+			ChecklistItem{ID: "rdp-enum", Description: "Enumerate RDP encryption (nmap rdp-enum-encryption)", Keywords: []string{"rdp-enum-encryption"}},
+		)
+	case "telnet":
+		items = append(items,
+			ChecklistItem{ID: "banner-grab", Description: "Telnet banner grab", Keywords: []string{"telnet", "banner"}},
+		)
+	case "snmp":
+		items = append(items,
+			ChecklistItem{ID: "snmpwalk", Description: "SNMP walk with community strings", Keywords: []string{"snmpwalk"}},
+		)
+	case "ldap":
+		items = append(items,
+			ChecklistItem{ID: "ldapsearch", Description: "LDAP search for base information", Keywords: []string{"ldapsearch"}},
+			ChecklistItem{ID: "ldap-rootdse", Description: "Enumerate LDAP rootDSE", Keywords: []string{"ldap-rootdse"}},
+		)
+	case "dns":
+		items = append(items,
+			ChecklistItem{ID: "zone-transfer", Description: "Attempt DNS zone transfer (dig axfr)", Keywords: []string{"dig", "axfr"}},
+			ChecklistItem{ID: "dns-enum", Description: "DNS enumeration (dnsenum or dnsrecon)", Keywords: []string{"dnsenum"}},
+		)
+	case "smtp":
+		items = append(items,
+			ChecklistItem{ID: "smtp-user-enum", Description: "SMTP user enumeration", Keywords: []string{"smtp-user-enum"}},
+			ChecklistItem{ID: "vrfy", Description: "SMTP VRFY command check", Keywords: []string{"smtp", "vrfy"}},
+		)
+	case "pop3":
+		items = append(items,
+			ChecklistItem{ID: "banner-grab", Description: "POP3 banner grab", Keywords: []string{"pop3"}},
+		)
+	case "imap":
+		items = append(items,
+			ChecklistItem{ID: "banner-grab", Description: "IMAP banner grab", Keywords: []string{"imap"}},
+		)
+	case "nfs":
+		items = append(items,
+			ChecklistItem{ID: "showmount", Description: "List NFS exports (showmount)", Keywords: []string{"showmount"}},
+		)
+	case "redis":
+		items = append(items,
+			ChecklistItem{ID: "redis-cli", Description: "Redis server info (redis-cli info)", Keywords: []string{"redis-cli"}},
+		)
+	case "mongodb":
+		items = append(items,
+			ChecklistItem{ID: "mongo-connect", Description: "Try MongoDB unauthenticated connection", Keywords: []string{"mongo"}},
+		)
+	case "vnc":
+		items = append(items,
+			ChecklistItem{ID: "vnc-info", Description: "VNC server info (nmap vnc-info)", Keywords: []string{"vnc-info"}},
+		)
+	}
+
+	return &ServiceChecklist{Items: items}
+}
+
+// UpdateChecklistCompletion checks commands against checklist items.
+// For each item, if ALL keywords are found (case-insensitive substring match)
+// in ANY single command, mark Done=true. Once Done=true, it never reverts to false.
+func UpdateChecklistCompletion(checklist *ServiceChecklist, commands []string) {
+	for i := range checklist.Items {
+		if checklist.Items[i].Done {
+			continue // additive-only: skip already done items
+		}
+		for _, cmd := range commands {
+			if matchesAllKeywords(cmd, checklist.Items[i].Keywords) {
+				checklist.Items[i].Done = true
+				break
+			}
+		}
+	}
+}
+
+// matchesAllKeywords returns true if all keywords are found as case-insensitive substrings.
+func matchesAllKeywords(cmd string, keywords []string) bool {
+	lower := strings.ToLower(cmd)
+	for _, kw := range keywords {
+		if !strings.Contains(lower, kw) {
+			return false
+		}
+	}
+	return true
+}
+
+// ChecklistAllDone returns true if all items are Done (empty = true).
+func ChecklistAllDone(checklist *ServiceChecklist) bool {
+	for _, item := range checklist.Items {
+		if !item.Done {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/recon_checklist_test.go
+++ b/internal/agent/recon_checklist_test.go
@@ -1,0 +1,356 @@
+package agent
+
+import (
+	"testing"
+)
+
+func Test_normalizeServiceName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"microsoft-ds", "smb"},
+		{"netbios-ssn", "smb"},
+		{"ms-sql-s", "mssql"},
+		{"ms-sql", "mssql"},
+		{"ms-wbt-server", "rdp"},
+		{"domain", "dns"},
+		{"pop3s", "pop3"},
+		{"imaps", "imap"},
+		{"smtps", "smtp"},
+		{"submission", "smtp"},
+		{"ssh", "ssh"},
+		{"ftp", "ftp"},
+		{"smb", "smb"},
+		{"mysql", "mysql"},
+		{"mssql", "mssql"},
+		{"rdp", "rdp"},
+		{"telnet", "telnet"},
+		{"snmp", "snmp"},
+		{"ldap", "ldap"},
+		{"dns", "dns"},
+		{"smtp", "smtp"},
+		{"pop3", "pop3"},
+		{"imap", "imap"},
+		{"nfs", "nfs"},
+		{"redis", "redis"},
+		{"mongodb", "mongodb"},
+		{"vnc", "vnc"},
+		{"custom-svc", "custom-svc"},
+		{"some-unknown-thing", "some-unknown-thing"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input+"_to_"+tt.want, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeServiceName(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeServiceName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GenerateChecklist_SSH(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", true)
+	if cl == nil { t.Fatal("GenerateChecklist returned nil") }
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "ssh-auth-methods", "ssh-auth-methods")
+	assertHasItem(t, cl, "banner-grab", "banner")
+}
+
+func Test_GenerateChecklist_FTP(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ftp", "vsftpd 3.0.3", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "anon-check", "anonymous")
+	assertHasItem(t, cl, "ftp-bounce", "ftp-bounce")
+}
+
+func Test_GenerateChecklist_SMB(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("microsoft-ds", "Samba 4.9", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "enum4linux", "enum4linux")
+	assertHasItem(t, cl, "smbclient", "smbclient")
+	assertHasItem(t, cl, "smb-vuln", "smb-vuln")
+}
+
+func Test_GenerateChecklist_MySQL(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("mysql", "MySQL 5.7", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "mysql-info", "mysql-info")
+	assertHasItem(t, cl, "default-creds", "default")
+}
+
+func Test_GenerateChecklist_MSSQL(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ms-sql-s", "Microsoft SQL Server 2019", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "mssqlclient", "mssqlclient")
+	assertHasItem(t, cl, "default-creds", "sa")
+}
+
+func Test_GenerateChecklist_PostgreSQL(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("postgresql", "PostgreSQL 13", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "pg-ready", "pg_isready")
+	assertHasItem(t, cl, "default-creds", "psql")
+}
+
+func Test_GenerateChecklist_RDP(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ms-wbt-server", "Microsoft Terminal Services", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "rdp-enum", "rdp-enum-encryption")
+}
+
+func Test_GenerateChecklist_Telnet(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("telnet", "", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "banner-grab", "telnet")
+}
+
+func Test_GenerateChecklist_SNMP(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("snmp", "SNMPv2", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "snmpwalk", "snmpwalk")
+}
+
+func Test_GenerateChecklist_LDAP(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ldap", "OpenLDAP 2.4", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "ldapsearch", "ldapsearch")
+	assertHasItem(t, cl, "ldap-rootdse", "ldap-rootdse")
+}
+
+func Test_GenerateChecklist_DNS(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("domain", "BIND 9.11", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "zone-transfer", "axfr")
+	assertHasItem(t, cl, "dns-enum", "dnsenum")
+}
+
+func Test_GenerateChecklist_SMTP(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("smtp", "Postfix", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "smtp-user-enum", "smtp-user-enum")
+	assertHasItem(t, cl, "vrfy", "vrfy")
+}
+
+func Test_GenerateChecklist_POP3(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("pop3", "Dovecot", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "banner-grab", "pop3")
+}
+
+func Test_GenerateChecklist_IMAP(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("imap", "Dovecot", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "banner-grab", "imap")
+}
+
+func Test_GenerateChecklist_NFS(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("nfs", "", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "showmount", "showmount")
+}
+
+func Test_GenerateChecklist_Redis(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("redis", "Redis 6.0", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "redis-cli", "redis-cli")
+}
+
+func Test_GenerateChecklist_MongoDB(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("mongodb", "MongoDB 4.4", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "mongo-connect", "mongo")
+}
+
+func Test_GenerateChecklist_VNC(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("vnc", "RealVNC 5", true)
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "vnc-info", "vnc-info")
+}
+
+func Test_GenerateChecklist_NoKnowledge(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", false)
+	for _, item := range cl.Items {
+		if item.ID == "search-knowledge" {
+			t.Error("search-knowledge should NOT be present when hasKnowledge=false")
+		}
+	}
+}
+
+func Test_GenerateChecklist_WithKnowledge(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", true)
+	assertHasItem(t, cl, "search-knowledge", "search_knowledge")
+}
+
+func Test_GenerateChecklist_UnknownService(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("custom-weird-svc", "1.0", true)
+	if len(cl.Items) != 2 {
+		t.Errorf("unknown service should have 2 items, got %d", len(cl.Items))
+	}
+	assertHasItem(t, cl, "searchsploit", "searchsploit")
+	assertHasItem(t, cl, "search-knowledge", "search_knowledge")
+}
+
+func Test_GenerateChecklist_EmptyVersion(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "", true)
+	if cl == nil { t.Fatal("returned nil for empty version") }
+	if len(cl.Items) == 0 { t.Error("checklist should not be empty") }
+	for _, item := range cl.Items {
+		if item.ID == "searchsploit" {
+			last := item.Description[len(item.Description)-1]
+			if last == ' ' {
+				t.Errorf("searchsploit description has trailing space: %q", item.Description)
+			}
+		}
+	}
+}
+
+func Test_UpdateChecklistCompletion_Match(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", true)
+	UpdateChecklistCompletion(cl, []string{"searchsploit ssh OpenSSH 8.2"})
+	item := findItem(cl, "searchsploit")
+	if item == nil { t.Fatal("searchsploit item not found") }
+	if !item.Done { t.Error("searchsploit should be Done") }
+}
+
+func Test_UpdateChecklistCompletion_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", true)
+	UpdateChecklistCompletion(cl, []string{"SEARCHSPLOIT SSH OpenSSH 8.2"})
+	item := findItem(cl, "searchsploit")
+	if item == nil { t.Fatal("not found") }
+	if !item.Done { t.Error("case-insensitive match should mark Done") }
+}
+
+func Test_UpdateChecklistCompletion_MultipleMatch(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", true)
+	UpdateChecklistCompletion(cl, []string{
+		"searchsploit ssh OpenSSH 8.2",
+		"nmap --script ssh-auth-methods -p 22 target",
+	})
+	si := findItem(cl, "searchsploit")
+	if si == nil || !si.Done { t.Error("searchsploit should be Done") }
+	ai := findItem(cl, "ssh-auth-methods")
+	if ai == nil || !ai.Done { t.Error("ssh-auth-methods should be Done") }
+}
+
+func Test_UpdateChecklistCompletion_NoMatch(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", true)
+	UpdateChecklistCompletion(cl, []string{"ls -la /tmp", "cat /etc/passwd"})
+	for _, item := range cl.Items {
+		if item.Done { t.Errorf("item %q should not be Done", item.ID) }
+	}
+}
+
+func Test_UpdateChecklistCompletion_AdditiveOnly(t *testing.T) {
+	t.Parallel()
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", true)
+	UpdateChecklistCompletion(cl, []string{"searchsploit ssh OpenSSH 8.2"})
+	item := findItem(cl, "searchsploit")
+	if item == nil || !item.Done { t.Fatal("should be Done") }
+	UpdateChecklistCompletion(cl, []string{})
+	item = findItem(cl, "searchsploit")
+	if !item.Done { t.Error("Done should never go back to false") }
+}
+
+func Test_ChecklistAllDone_AllDone(t *testing.T) {
+	t.Parallel()
+	cl := &ServiceChecklist{Items: []ChecklistItem{
+		{ID: "a", Done: true}, {ID: "b", Done: true}, {ID: "c", Done: true},
+	}}
+	if !ChecklistAllDone(cl) { t.Error("expected AllDone=true") }
+}
+
+func Test_ChecklistAllDone_NotAllDone(t *testing.T) {
+	t.Parallel()
+	cl := &ServiceChecklist{Items: []ChecklistItem{
+		{ID: "a", Done: true}, {ID: "b", Done: false}, {ID: "c", Done: true},
+	}}
+	if ChecklistAllDone(cl) { t.Error("expected AllDone=false") }
+}
+
+func Test_ChecklistAllDone_EmptyList(t *testing.T) {
+	t.Parallel()
+	cl := &ServiceChecklist{Items: []ChecklistItem{}}
+	if !ChecklistAllDone(cl) { t.Error("expected AllDone=true for empty list") }
+}
+
+// Test helpers
+
+func assertHasItem(t *testing.T, cl *ServiceChecklist, id, keywordSubstr string) {
+	t.Helper()
+	if cl == nil { t.Fatalf("checklist is nil, expected item %q", id); return }
+	for _, item := range cl.Items {
+		if item.ID == id {
+			for _, kw := range item.Keywords {
+				if testContainsLower(kw, keywordSubstr) { return }
+			}
+			if testContainsLower(item.Description, keywordSubstr) { return }
+			t.Errorf("item %q: no keyword/desc contains %q (kw=%v, desc=%q)",
+				id, keywordSubstr, item.Keywords, item.Description)
+			return
+		}
+	}
+	t.Errorf("item %q not found in checklist (have %v)", id, itemIDs(cl))
+}
+
+func findItem(cl *ServiceChecklist, id string) *ChecklistItem {
+	for i := range cl.Items {
+		if cl.Items[i].ID == id { return &cl.Items[i] }
+	}
+	return nil
+}
+
+func itemIDs(cl *ServiceChecklist) []string {
+	ids := make([]string, 0, len(cl.Items))
+	for _, item := range cl.Items { ids = append(ids, item.ID) }
+	return ids
+}
+
+func testContainsLower(s, substr string) bool {
+	if len(s) == 0 || len(substr) == 0 { return false }
+	sl := testToLower(s)
+	subl := testToLower(substr)
+	for i := 0; i <= len(sl)-len(subl); i++ {
+		if sl[i:i+len(subl)] == subl { return true }
+	}
+	return false
+}
+
+func testToLower(s string) string {
+	b := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' { c += 'a' - 'A' }
+		b[i] = c
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary
- nmap 結果から**非 HTTP サービス別 Recon チェックリスト**を自動生成し、MainAI プロンプトに注入
- MainAI が nmap 無限ループや早期攻撃に陥ることを防止する有限タスクリスト
- 18 サービステンプレート（ftp, ssh, smb, mysql, mssql, postgresql, rdp, telnet, snmp, ldap, dns, smtp, pop3, imap, nfs, redis, mongodb, vnc）+ unknown default

## Changes
- **`internal/agent/recon_checklist.go`** (新規): `ChecklistItem`/`ServiceChecklist` 型、`normalizeServiceName` (10 aliases)、`GenerateChecklist` (18 services)、`UpdateChecklistCompletion` (keyword AND-match)、`ChecklistAllDone`
- **`internal/agent/recon_checklist_test.go`** (新規): 31 テスト（normalizeServiceName 30 subtests、GenerateChecklist 22 tests、UpdateChecklistCompletion 5 tests、ChecklistAllDone 3 tests）
- **`internal/agent/attack_data_tree.go`**: `Checklist` フィールド追加、`SetChecklist`/`UpdateAllChecklists`/`AllChecklistsDone`/`NonHTTPPortsWithoutChecklist` メソッド、`RenderIntel` に `[RECON CHECKLIST]` セクション + `[ATTACK SURFACE]` 進捗表示
- **`internal/agent/attack_data_tree_test.go`**: 11 統合テスト追加
- **`internal/agent/loop.go`**: `extractCommandStrings`、`buildReconQueue` でチェックリスト更新、`evaluateResult` で非 HTTP ポートにチェックリスト自動生成

## Design Decisions
- Done は **additive-only**（一度 true → false に戻らない。履歴 rotate しても安全）
- チェックリスト生成は **1回限り**（`SetChecklist` は既設なら no-op）
- Phase gate (#98) とは **独立動作**（チェックリスト = MainAI ガイダンス、Phase gate = HTTPAgent 実行中ブロック）
- **スレッドセーフ**: `SetChecklist`/`UpdateAllChecklists` は Write lock、`AllChecklistsDone`/`RenderIntel` は Read lock

## Test plan
- [x] `go test ./internal/agent/... -v -run "Checklist|normalizeService"` — 42 tests PASS
- [x] `go test ./internal/agent/...` — all agent tests PASS
- [x] `go build ./...` — build clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)