### PR TITLE
feat: RECON PROGRESS section and completion tracking

### DIFF
--- a/internal/agent/attack_data_tree.go
+++ b/internal/agent/attack_data_tree.go
@@ -53,6 +53,21 @@ type Finding struct {
 	Severity string // 深刻度: "high", "medium", "low", "info"
 }
 
+// TaskProgress は特定タスクタイプの進捗
+type TaskProgress struct {
+	Done  int
+	Total int
+}
+
+// ReconProgress は HTTP 偵察の全体進捗
+type ReconProgress struct {
+	EndpointEnum TaskProgress
+	ParamFuzz    TaskProgress
+	Profiling    TaskProgress
+	VhostDiscov  TaskProgress
+	PendingPaths []string // EndpointEnum == Pending のパス一覧（最大10件）
+}
+
 // AttackDataNode はツリーの各ノード
 type AttackDataNode struct {
 	Host    string // "10.10.11.100" or "dev.example.com" (vhost)
@@ -696,6 +711,98 @@ func (t *AttackDataTree) allChecklistsDoneLocked() bool {
 	return true
 }
 
+
+const maxPendingPaths = 10
+
+// ComputeReconProgress は HTTP 偵察のタスクタイプ別進捗を計算する。
+func (t *AttackDataTree) ComputeReconProgress() ReconProgress {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.computeReconProgressLocked()
+}
+
+func (t *AttackDataTree) computeReconProgressLocked() ReconProgress {
+	var prog ReconProgress
+	for _, node := range t.Ports {
+		if node.isHTTP() {
+			t.accumulateProgress(&prog, node)
+		}
+	}
+	for _, node := range t.Vhosts {
+		t.accumulateProgress(&prog, node)
+	}
+	return prog
+}
+
+func (t *AttackDataTree) accumulateProgress(prog *ReconProgress, node *AttackDataNode) {
+	// Count tasks for this node
+	accumTaskProgress(&prog.EndpointEnum, node.EndpointEnum)
+	accumTaskProgress(&prog.ParamFuzz, node.ParamFuzz)
+	accumTaskProgress(&prog.Profiling, node.Profiling)
+	accumTaskProgress(&prog.VhostDiscov, node.VhostDiscov)
+
+	// Collect pending paths
+	if node.EndpointEnum == StatusPending && len(prog.PendingPaths) < maxPendingPaths {
+		path := node.Path
+		if path == "" {
+			path = "/"
+		}
+		prog.PendingPaths = append(prog.PendingPaths, path)
+	}
+
+	// Recurse into children
+	for _, child := range node.Children {
+		t.accumulateProgress(prog, child)
+	}
+}
+
+func accumTaskProgress(tp *TaskProgress, status AttackDataStatus) {
+	if status == StatusNone {
+		return
+	}
+	tp.Total++
+	if status == StatusComplete {
+		tp.Done++
+	}
+}
+
+// IsReconComplete は全 Recon が完了したかを判定する。
+// HTTP タスク（CountPending==0）+ 非 HTTP チェックリスト（AllChecklistsDone）の両方が完了で true。
+// タスクが1つもない場合は false（まだ nmap していない）。
+func (t *AttackDataTree) IsReconComplete() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	total := t.countTotalLocked()
+	hasChecklist := false
+	for _, node := range t.Ports {
+		if node.Checklist != nil {
+			hasChecklist = true
+			break
+		}
+	}
+	// At least some work must exist
+	if total == 0 && !hasChecklist {
+		return false
+	}
+	// All HTTP tasks complete
+	if t.countPendingLocked() > 0 {
+		return false
+	}
+	// All non-HTTP checklists complete
+	if !t.allChecklistsDoneLocked() {
+		return false
+	}
+	return true
+}
+
+func renderTaskProgress(sb *strings.Builder, name string, tp TaskProgress) {
+	if tp.Total == 0 {
+		return
+	}
+	pct := tp.Done * 100 / tp.Total
+	fmt.Fprintf(sb, "  %s: %d/%d (%d%%)\n", name, tp.Done, tp.Total, pct)
+}
+
 // RenderIntel は RECON INTEL をプロンプト注入用に返す。
 // ポートがない場合は空文字列を返す。
 func (t *AttackDataTree) RenderIntel() string {
@@ -725,6 +832,30 @@ func (t *AttackDataTree) RenderIntel() string {
 			strings.Join(activePorts, ", "))
 	}
 
+
+
+	// [RECON PROGRESS]: HTTP タスクタイプ別進捗
+	prog := t.computeReconProgressLocked()
+	httpTotal := prog.EndpointEnum.Total + prog.ParamFuzz.Total + prog.Profiling.Total + prog.VhostDiscov.Total
+	if httpTotal > 0 {
+		sb.WriteString("[RECON PROGRESS]\n")
+		sb.WriteString("HTTP Recon:\n")
+		renderTaskProgress(&sb, "endpoint_enum", prog.EndpointEnum)
+		renderTaskProgress(&sb, "param_fuzz", prog.ParamFuzz)
+		renderTaskProgress(&sb, "profiling", prog.Profiling)
+		renderTaskProgress(&sb, "vhost_discovery", prog.VhostDiscov)
+		if len(prog.PendingPaths) > 0 {
+			fmt.Fprintf(&sb, "  Pending: %s\n", strings.Join(prog.PendingPaths, ", "))
+		}
+		httpDone := prog.EndpointEnum.Done + prog.ParamFuzz.Done + prog.Profiling.Done + prog.VhostDiscov.Done
+		if httpDone == httpTotal {
+			sb.WriteString("Overall: COMPLETE — ready for exploitation phase\n")
+		} else {
+			pct := httpDone * 100 / httpTotal
+			fmt.Fprintf(&sb, "Overall: %d/%d tasks (%d%%)\n", httpDone, httpTotal, pct)
+		}
+		sb.WriteString("\n")
+	}
 
 	// [RECON CHECKLIST]: 非HTTPポートのチェックリスト
 	hasChecklist := false
@@ -785,11 +916,11 @@ func (t *AttackDataTree) RenderIntel() string {
 				}
 			}
 			if status == "not tested" {
-				anyTask, allComplete := nodeTreeTaskStatus(node)
-				if anyTask && allComplete {
-					status = "recon complete"
-				} else if anyTask {
-					status = "recon pending"
+				_, complete, total := node.countTasks()
+				if total > 0 && complete == total {
+					status = fmt.Sprintf("recon complete (%d/%d)", complete, total)
+				} else if total > 0 {
+					status = fmt.Sprintf("recon: %d/%d tasks", complete, total)
 				}
 			}
 		} else if node.Checklist != nil {
@@ -814,32 +945,6 @@ func (t *AttackDataTree) RenderIntel() string {
 	}
 
 	return sb.String()
-}
-
-// nodeTreeTaskStatus はノードとその子を再帰的に走査し、
-// タスクが1つでもあるか (anyTask) と、すべて完了か (allComplete) を返す。
-func nodeTreeTaskStatus(node *AttackDataNode) (anyTask, allComplete bool) {
-	allComplete = true
-	taskTypes := []ReconTaskType{TaskEndpointEnum, TaskParamFuzz, TaskProfiling, TaskVhostDiscov}
-	for _, tt := range taskTypes {
-		st := node.getAttackDataStatus(tt)
-		if st != StatusNone {
-			anyTask = true
-			if st != StatusComplete {
-				allComplete = false
-			}
-		}
-	}
-	for _, child := range node.Children {
-		childAny, childAll := nodeTreeTaskStatus(child)
-		if childAny {
-			anyTask = true
-			if !childAll {
-				allComplete = false
-			}
-		}
-	}
-	return
 }
 
 // renderNodeFindings はノードとその子の findings を再帰的にレンダリングする。

--- a/internal/agent/attack_data_tree_test.go
+++ b/internal/agent/attack_data_tree_test.go
@@ -947,8 +947,9 @@ func TestRenderIntel_ChildPendingPreventsReconComplete(t *testing.T) {
 	if strings.Contains(output, "recon complete") {
 		t.Errorf("should NOT show 'recon complete' when child has pending tasks\noutput:\n%s", output)
 	}
-	if !strings.Contains(output, "recon pending") {
-		t.Errorf("should show 'recon pending' when child has pending tasks\noutput:\n%s", output)
+	// New format: "recon: N/M tasks" instead of "recon pending"
+	if !strings.Contains(output, "tasks") {
+		t.Errorf("should show task count when child has pending tasks\noutput:\n%s", output)
 	}
 }
 
@@ -1174,5 +1175,199 @@ func TestRenderIntel_AttackSurface_ChecklistProgress(t *testing.T) {
 	expectedProgress := fmt.Sprintf("recon: 1/%d", totalItems)
 	if !strings.Contains(output, expectedProgress) {
 		t.Errorf("ATTACK SURFACE should show checklist progress %q\noutput:\n%s", expectedProgress, output)
+	}
+}
+
+func TestComputeReconProgress_Basic(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/login")
+
+	// Complete some tasks
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "/api", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "/api", TaskParamFuzz)
+
+	prog := tree.ComputeReconProgress()
+
+	// EndpointEnum: port root(complete) + /api(complete) + /login(pending) = 2/3
+	if prog.EndpointEnum.Done != 2 || prog.EndpointEnum.Total != 3 {
+		t.Errorf("EndpointEnum = %d/%d, want 2/3", prog.EndpointEnum.Done, prog.EndpointEnum.Total)
+	}
+	// ParamFuzz: /api(complete) + /login(pending) = 1/2 (port root has no ParamFuzz)
+	if prog.ParamFuzz.Done != 1 || prog.ParamFuzz.Total != 2 {
+		t.Errorf("ParamFuzz = %d/%d, want 1/2", prog.ParamFuzz.Done, prog.ParamFuzz.Total)
+	}
+	// VhostDiscov: port root has 1 pending = 0/1
+	if prog.VhostDiscov.Done != 0 || prog.VhostDiscov.Total != 1 {
+		t.Errorf("VhostDiscov = %d/%d, want 0/1", prog.VhostDiscov.Done, prog.VhostDiscov.Total)
+	}
+}
+
+func TestComputeReconProgress_Empty(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	prog := tree.ComputeReconProgress()
+
+	if prog.EndpointEnum.Total != 0 {
+		t.Errorf("empty tree EndpointEnum.Total = %d, want 0", prog.EndpointEnum.Total)
+	}
+	if len(prog.PendingPaths) != 0 {
+		t.Errorf("empty tree PendingPaths = %v, want empty", prog.PendingPaths)
+	}
+}
+
+func TestComputeReconProgress_PendingPaths(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/login")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/admin")
+
+	// Complete /api endpoint enum
+	tree.CompleteTask("10.10.11.100", 80, "/api", TaskEndpointEnum)
+
+	prog := tree.ComputeReconProgress()
+
+	// Pending paths: / (port root), /login, /admin (but NOT /api since it's complete)
+	// Port root path "" should show as "/"
+	if len(prog.PendingPaths) != 3 {
+		t.Errorf("PendingPaths = %v, want 3 items", prog.PendingPaths)
+	}
+}
+
+func TestComputeReconProgress_MaxPendingPaths(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	// Add 15 endpoints — all pending
+	for i := 0; i < 15; i++ {
+		path := fmt.Sprintf("/path%d", i)
+		tree.AddEndpoint("10.10.11.100", 80, "/", path)
+	}
+
+	prog := tree.ComputeReconProgress()
+
+	// Should cap at 10
+	if len(prog.PendingPaths) > 10 {
+		t.Errorf("PendingPaths should be capped at 10, got %d", len(prog.PendingPaths))
+	}
+}
+
+func TestIsReconComplete(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+
+	// Empty tree: no tasks = not complete (need at least 1 task)
+	if tree.IsReconComplete() {
+		t.Error("empty tree should not be complete")
+	}
+
+	tree.AddPort(80, "http", "Apache")
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	// Set checklist for non-HTTP
+	tree.SetChecklist(22, GenerateChecklist("ssh", "OpenSSH 8.2", false))
+
+	// Not complete yet
+	if tree.IsReconComplete() {
+		t.Error("should not be complete with pending tasks")
+	}
+
+	// Complete all HTTP tasks
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "", TaskVhostDiscov)
+
+	// Still not complete — checklist not done
+	if tree.IsReconComplete() {
+		t.Error("should not be complete with checklist incomplete")
+	}
+
+	// Complete all checklist items
+	sshNode := tree.Ports[1]
+	for i := range sshNode.Checklist.Items {
+		sshNode.Checklist.Items[i].Done = true
+	}
+
+	// Now complete
+	if !tree.IsReconComplete() {
+		t.Error("should be complete when all HTTP tasks and checklists are done")
+	}
+}
+
+func TestIsReconComplete_ChecklistIncomplete(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.SetChecklist(22, GenerateChecklist("ssh", "OpenSSH 8.2", false))
+
+	// Checklist incomplete → not complete
+	if tree.IsReconComplete() {
+		t.Error("should not be complete with incomplete checklist")
+	}
+}
+
+func TestRenderIntel_ReconProgress(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+
+	// Complete port-level endpoint enum
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+
+	output := tree.RenderIntel()
+
+	checks := []string{
+		"RECON PROGRESS",
+		"endpoint_enum:",
+		"param_fuzz:",
+		"vhost_discovery:",
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderIntel missing %q\noutput:\n%s", check, output)
+		}
+	}
+}
+
+func TestRenderIntel_ReconProgressComplete(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	// Complete all port-level tasks
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "", TaskVhostDiscov)
+
+	output := tree.RenderIntel()
+
+	if !strings.Contains(output, "COMPLETE") {
+		t.Errorf("should show COMPLETE when all HTTP tasks are done\noutput:\n%s", output)
+	}
+}
+
+func TestRenderIntel_AttackSurface_HTTPTaskCount(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+
+	// Complete 2 of 5 tasks
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "/api", TaskEndpointEnum)
+
+	output := tree.RenderIntel()
+
+	// Should show task count like "recon: 2/5 tasks" instead of generic "recon pending"
+	if !strings.Contains(output, "2/5") {
+		t.Errorf("ATTACK SURFACE should show task count\noutput:\n%s", output)
+	}
+}
+
+func TestRenderIntel_NoReconProgressForNonHTTPOnly(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+
+	output := tree.RenderIntel()
+
+	// No HTTP ports = no RECON PROGRESS section
+	if strings.Contains(output, "RECON PROGRESS") {
+		t.Errorf("should NOT show RECON PROGRESS when no HTTP ports\noutput:\n%s", output)
 	}
 }

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -39,6 +39,8 @@ const (
 	EventCmdDone EventType = "cmd_done"
 	// EventSubTaskStart はサブタスク開始を示す（スピナー表示）。
 	EventSubTaskStart EventType = "subtask_start"
+	// EventReconComplete は全 Recon（HTTP タスク + 非 HTTP チェックリスト）が完了したとき。
+	EventReconComplete EventType = "recon_complete"
 )
 
 // Event は Agent ループから TUI へ送るメッセージ。

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -75,6 +75,8 @@ type Loop struct {
 	// コマンド実行時間計測用
 	cmdStartTime time.Time
 
+	// Recon 完了イベントの重複 emit 防止
+	reconCompleteEmitted bool
 }
 
 // NewLoop は Loop を構築する。
@@ -614,6 +616,13 @@ func (l *Loop) evaluateResult(ctx context.Context) {
 
 		// Target にも反映（TUI から参照可能にする）
 		l.target.SetAttackData(l.attackData)
+
+		// Recon 完了検出: 全タスク + チェックリスト完了時に一度だけイベントを emit
+		if !l.reconCompleteEmitted && l.attackData.IsReconComplete() {
+			l.reconCompleteEmitted = true
+			l.emit(Event{Type: EventReconComplete,
+				Message: "Recon phase complete — all tasks finished"})
+		}
 	}
 }
 

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -82,6 +82,10 @@ func (a *App) handleAgentEvent(e agent.Event) {
 		t.AddBlock(agent.NewSystemBlock("Type a message to give the agent new direction."))
 		displayChanged = true
 
+	case agent.EventReconComplete:
+		t.AddBlock(agent.NewSystemBlock("✓ " + e.Message))
+		displayChanged = true
+
 	case agent.EventTurnStart:
 		// no-op
 


### PR DESCRIPTION
## Summary
- RenderIntel に `[RECON PROGRESS]` セクション追加: HTTP 偵察のタスクタイプ別進捗（%表示）+ pending パス一覧
- `IsReconComplete()` で HTTP タスク + 非 HTTP チェックリスト両方の完了判定
- `EventReconComplete` イベントで TUI に Recon 完了を通知
- `[ATTACK SURFACE]` の HTTP ポート表示をタスクカウントベースに強化

## RenderIntel 出力例

```
=== RECON INTEL ===
[BACKGROUND] HTTPAgent active on ports: 80

[RECON PROGRESS]
HTTP Recon:
  endpoint_enum: 3/5 (60%)
  param_fuzz: 2/4 (50%)
  profiling: 1/3 (33%)
  vhost_discovery: 5/5 (100%)
  Pending: /api/v2/, /admin/config/, /uploads/
Overall: 11/17 tasks (64%)

[RECON CHECKLIST]
Port 22/ssh (OpenSSH 8.2):
  [x] searchsploit ssh OpenSSH 8.2
  [ ] Enumerate SSH auth methods

[ATTACK SURFACE]
  22/ssh OpenSSH 8.2 — recon: 1/3
  80/http Apache — recon: 3/5 tasks
```

## Changes
- **`internal/agent/attack_data_tree.go`**: `TaskProgress`/`ReconProgress` 型、`ComputeReconProgress`/`IsReconComplete` メソッド、`[RECON PROGRESS]` セクション、`[ATTACK SURFACE]` タスクカウント表示、未使用の `nodeTreeTaskStatus` 削除
- **`internal/agent/attack_data_tree_test.go`**: 10 テスト追加
- **`internal/agent/event.go`**: `EventReconComplete` 定義
- **`internal/agent/loop.go`**: `reconCompleteEmitted` フラグ + 完了検出
- **`internal/tui/events.go`**: `EventReconComplete` ログ表示

## Test plan
- [x] `go test ./internal/agent/... -run "ReconProgress|IsReconComplete"` — 9 tests PASS
- [x] `go test ./internal/...` — all packages PASS
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)