### PR TITLE
feat: JSON backup for AttackDataTree + raw output JSON化

### DIFF
--- a/internal/agent/attack_data_backup.go
+++ b/internal/agent/attack_data_backup.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const attackTreeFileName = "attack_tree.json"
+const attackTreeBackupDir = "attack_tree_backup"
+
+// BackupManager は AttackDataTree のバックアップを管理する。
+type BackupManager struct {
+	baseDir string
+	host    string
+	tree    *AttackDataTree
+}
+
+// NewBackupManager は BackupManager を作成する。
+func NewBackupManager(baseDir, host string, tree *AttackDataTree) *BackupManager {
+	return &BackupManager{
+		baseDir: baseDir,
+		host:    host,
+		tree:    tree,
+	}
+}
+
+// Save は AttackDataTree の最新状態を attack_tree.json に保存する。
+// tmpfile + rename で atomic write を行う。
+func (b *BackupManager) Save() error {
+	snap := b.tree.Snapshot()
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot: %w", err)
+	}
+
+	dir := filepath.Join(b.baseDir, b.host)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	targetPath := filepath.Join(dir, attackTreeFileName)
+
+	// Atomic write: write to temp file, then rename
+	tmpPath := targetPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		// Cleanup tmp on rename failure (best-effort)
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// SaveBackup は attack_tree_backup/<timestamp>.json にバックアップをコピーする。
+func (b *BackupManager) SaveBackup() error {
+	snap := b.tree.Snapshot()
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot: %w", err)
+	}
+
+	backupDir := filepath.Join(b.baseDir, b.host, attackTreeBackupDir)
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		return fmt.Errorf("create backup dir: %w", err)
+	}
+
+	timestamp := time.Now().Format("20060102-150405")
+	filename := fmt.Sprintf("%s.json", timestamp)
+	filePath := filepath.Join(backupDir, filename)
+
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
+		return fmt.Errorf("write backup: %w", err)
+	}
+	return nil
+}
+
+// LoadAttackDataTree は attack_tree.json から AttackDataTree を復元する。
+// ファイルが存在しない場合は nil, nil を返す。
+func LoadAttackDataTree(baseDir, host string) (*AttackDataTree, error) {
+	filePath := filepath.Join(baseDir, host, attackTreeFileName)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read attack tree: %w", err)
+	}
+
+	var snap AttackDataSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("unmarshal attack tree: %w", err)
+	}
+
+	return RestoreAttackDataTree(snap), nil
+}

--- a/internal/agent/attack_data_backup_test.go
+++ b/internal/agent/attack_data_backup_test.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBackupManager_Save(t *testing.T) {
+	dir := t.TempDir()
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache 2.4.49")
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+
+	mgr := NewBackupManager(dir, "10.10.11.100", tree)
+	if err := mgr.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// ファイルが作成されているか
+	filePath := filepath.Join(dir, "10.10.11.100", attackTreeFileName)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// JSON として有効か
+	var snap AttackDataSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if snap.Host != "10.10.11.100" {
+		t.Errorf("Host = %q, want 10.10.11.100", snap.Host)
+	}
+	if len(snap.Ports) != 2 {
+		t.Errorf("Ports = %d, want 2", len(snap.Ports))
+	}
+}
+
+func TestBackupManager_Save_Overwrite(t *testing.T) {
+	dir := t.TempDir()
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	mgr := NewBackupManager(dir, "10.10.11.100", tree)
+	if err := mgr.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add more data and save again
+	tree.AddPort(443, "https", "nginx")
+	if err := mgr.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load and verify updated data
+	filePath := filepath.Join(dir, "10.10.11.100", attackTreeFileName)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap AttackDataSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Ports) != 2 {
+		t.Errorf("Ports = %d, want 2 after overwrite", len(snap.Ports))
+	}
+}
+
+func TestBackupManager_SaveBackup(t *testing.T) {
+	dir := t.TempDir()
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+
+	mgr := NewBackupManager(dir, "10.10.11.100", tree)
+	if err := mgr.SaveBackup(); err != nil {
+		t.Fatal(err)
+	}
+
+	// バックアップディレクトリにファイルが作成されているか
+	backupDir := filepath.Join(dir, "10.10.11.100", attackTreeBackupDir)
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 backup file, got %d", len(entries))
+	}
+
+	// ファイル名が .json で終わるか
+	name := entries[0].Name()
+	if filepath.Ext(name) != ".json" {
+		t.Errorf("backup file should be .json, got: %s", name)
+	}
+}
+
+func TestLoadAttackDataTree(t *testing.T) {
+	dir := t.TempDir()
+	tree := NewAttackDataTree("10.10.11.100", 3)
+	tree.AddPort(80, "http", "Apache 2.4.49")
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+
+	// Save
+	mgr := NewBackupManager(dir, "10.10.11.100", tree)
+	if err := mgr.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load
+	loaded, err := LoadAttackDataTree(dir, "10.10.11.100")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil {
+		t.Fatal("loaded should not be nil")
+	}
+
+	// Verify
+	if loaded.Host != "10.10.11.100" {
+		t.Errorf("Host = %q", loaded.Host)
+	}
+	if loaded.MaxParallel != 3 {
+		t.Errorf("MaxParallel = %d, want 3", loaded.MaxParallel)
+	}
+	if len(loaded.Ports) != 2 {
+		t.Fatalf("Ports = %d, want 2", len(loaded.Ports))
+	}
+	// Port 80 EndpointEnum should be Complete
+	if loaded.Ports[0].EndpointEnum != StatusComplete {
+		t.Errorf("EndpointEnum = %d, want Complete", loaded.Ports[0].EndpointEnum)
+	}
+	// Children preserved
+	if len(loaded.Ports[0].Children) != 1 {
+		t.Fatalf("children = %d, want 1", len(loaded.Ports[0].Children))
+	}
+}
+
+func TestLoadAttackDataTree_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	loaded, err := LoadAttackDataTree(dir, "nonexistent")
+	if err != nil {
+		t.Fatalf("should not error on missing file, got: %v", err)
+	}
+	if loaded != nil {
+		t.Error("should return nil for missing file")
+	}
+}

--- a/internal/agent/attack_data_tree.go
+++ b/internal/agent/attack_data_tree.go
@@ -47,10 +47,10 @@ func (t ReconTaskType) String() string {
 
 // Finding はバリューファジングで発見された脆弱性の疑い
 type Finding struct {
-	Param    string // パラメーター名 (e.g. "id")
-	Category string // ファジングカテゴリ (e.g. "sqli")
-	Evidence string // 証拠 (e.g. "500 + MySQL syntax error on single quote")
-	Severity string // 深刻度: "high", "medium", "low", "info"
+	Param    string `json:"param"`    // パラメーター名 (e.g. "id")
+	Category string `json:"category"` // ファジングカテゴリ (e.g. "sqli")
+	Evidence string `json:"evidence"` // 証拠 (e.g. "500 + MySQL syntax error on single quote")
+	Severity string `json:"severity"` // 深刻度: "high", "medium", "low", "info"
 }
 
 // TaskProgress は特定タスクタイプの進捗
@@ -1056,4 +1056,120 @@ func collectAllChildren(nodes *[]*AttackDataNode, node *AttackDataNode) {
 		*nodes = append(*nodes, child)
 		collectAllChildren(nodes, child)
 	}
+}
+
+// AttackDataSnapshot は AttackDataTree の JSON シリアライズ用構造体
+type AttackDataSnapshot struct {
+	Host        string              `json:"host"`
+	MaxParallel int                 `json:"max_parallel"`
+	Locked      bool                `json:"locked"`
+	Ports       []AttackDataNodeDTO `json:"ports"`
+	Vhosts      []AttackDataNodeDTO `json:"vhosts"`
+}
+
+// AttackDataNodeDTO はノードの JSON 表現
+type AttackDataNodeDTO struct {
+	Host         string              `json:"host"`
+	Port         int                 `json:"port"`
+	Service      string              `json:"service"`
+	Banner       string              `json:"banner"`
+	Path         string              `json:"path"`
+	EndpointEnum AttackDataStatus    `json:"endpoint_enum"`
+	ParamFuzz    AttackDataStatus    `json:"param_fuzz"`
+	Profiling    AttackDataStatus    `json:"profiling"`
+	VhostDiscov  AttackDataStatus    `json:"vhost_discovery"`
+	Findings     []Finding           `json:"findings,omitempty"`
+	Checklist    *ServiceChecklist   `json:"checklist,omitempty"`
+	Children     []AttackDataNodeDTO `json:"children,omitempty"`
+}
+
+// Snapshot は現在のツリー状態のスナップショットを返す（スレッドセーフ）。
+func (t *AttackDataTree) Snapshot() AttackDataSnapshot {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	snap := AttackDataSnapshot{
+		Host:        t.Host,
+		MaxParallel: t.MaxParallel,
+		Locked:      t.locked,
+	}
+	for _, node := range t.Ports {
+		snap.Ports = append(snap.Ports, nodeToDTO(node))
+	}
+	for _, node := range t.Vhosts {
+		snap.Vhosts = append(snap.Vhosts, nodeToDTO(node))
+	}
+	return snap
+}
+
+// RestoreAttackDataTree はスナップショットから AttackDataTree を復元する。
+// InProgress のタスクは Pending にリセットされる（SubAgent は再起動が必要なため）。
+// active カウンタは 0 にリセットされる。
+func RestoreAttackDataTree(snap AttackDataSnapshot) *AttackDataTree {
+	tree := &AttackDataTree{
+		Host:        snap.Host,
+		MaxParallel: snap.MaxParallel,
+		locked:      snap.Locked,
+		active:      0, // SubAgent は別途再 spawn
+	}
+	if tree.MaxParallel <= 0 {
+		tree.MaxParallel = 2
+	}
+	for _, dto := range snap.Ports {
+		tree.Ports = append(tree.Ports, dtoToNode(dto))
+	}
+	for _, dto := range snap.Vhosts {
+		tree.Vhosts = append(tree.Vhosts, dtoToNode(dto))
+	}
+	return tree
+}
+
+// nodeToDTO は AttackDataNode を DTO に変換する。
+func nodeToDTO(node *AttackDataNode) AttackDataNodeDTO {
+	dto := AttackDataNodeDTO{
+		Host:         node.Host,
+		Port:         node.Port,
+		Service:      node.Service,
+		Banner:       node.Banner,
+		Path:         node.Path,
+		EndpointEnum: node.EndpointEnum,
+		ParamFuzz:    node.ParamFuzz,
+		Profiling:    node.Profiling,
+		VhostDiscov:  node.VhostDiscov,
+		Findings:     node.Findings,
+		Checklist:    node.Checklist,
+	}
+	for _, child := range node.Children {
+		dto.Children = append(dto.Children, nodeToDTO(child))
+	}
+	return dto
+}
+
+// dtoToNode は DTO から AttackDataNode を復元する。
+// InProgress のタスクは Pending にリセットする。
+func dtoToNode(dto AttackDataNodeDTO) *AttackDataNode {
+	node := &AttackDataNode{
+		Host:         dto.Host,
+		Port:         dto.Port,
+		Service:      dto.Service,
+		Banner:       dto.Banner,
+		Path:         dto.Path,
+		EndpointEnum: resetInProgress(dto.EndpointEnum),
+		ParamFuzz:    resetInProgress(dto.ParamFuzz),
+		Profiling:    resetInProgress(dto.Profiling),
+		VhostDiscov:  resetInProgress(dto.VhostDiscov),
+		Findings:     dto.Findings,
+		Checklist:    dto.Checklist,
+	}
+	for _, childDTO := range dto.Children {
+		node.Children = append(node.Children, dtoToNode(childDTO))
+	}
+	return node
+}
+
+// resetInProgress は InProgress を Pending にリセットする。
+func resetInProgress(s AttackDataStatus) AttackDataStatus {
+	if s == StatusInProgress {
+		return StatusPending
+	}
+	return s
 }

--- a/internal/agent/attack_data_tree_test.go
+++ b/internal/agent/attack_data_tree_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -1370,4 +1371,175 @@ func TestRenderIntel_NoReconProgressForNonHTTPOnly(t *testing.T) {
 	if strings.Contains(output, "RECON PROGRESS") {
 		t.Errorf("should NOT show RECON PROGRESS when no HTTP ports\noutput:\n%s", output)
 	}
+}
+
+func TestSnapshot_Roundtrip(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 3)
+	tree.AddPort(80, "http", "Apache 2.4.49")
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddEndpoint("10.10.11.100", 80, "/api", "/api/v1")
+	tree.AddVhost("10.10.11.100", 80, "dev.example.com")
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+
+	snap1 := tree.Snapshot()
+
+	// JSON marshal/unmarshal roundtrip
+	data, err := json.Marshal(snap1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap2 AttackDataSnapshot
+	if err := json.Unmarshal(data, &snap2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore from snapshot
+	restored := RestoreAttackDataTree(snap2)
+
+	// Verify
+	if restored.Host != tree.Host {
+		t.Errorf("Host = %q, want %q", restored.Host, tree.Host)
+	}
+	if restored.MaxParallel != tree.MaxParallel {
+		t.Errorf("MaxParallel = %d, want %d", restored.MaxParallel, tree.MaxParallel)
+	}
+	if len(restored.Ports) != len(tree.Ports) {
+		t.Fatalf("Ports count = %d, want %d", len(restored.Ports), len(tree.Ports))
+	}
+	if len(restored.Vhosts) != len(tree.Vhosts) {
+		t.Fatalf("Vhosts count = %d, want %d", len(restored.Vhosts), len(tree.Vhosts))
+	}
+
+	// Port 80 should have EndpointEnum=Complete (not reset since it was Complete)
+	port80 := restored.Ports[0]
+	if port80.EndpointEnum != StatusComplete {
+		t.Errorf("port 80 EndpointEnum = %d, want Complete", port80.EndpointEnum)
+	}
+
+	// Children preserved
+	if len(port80.Children) != 1 {
+		t.Fatalf("port 80 children = %d, want 2", len(port80.Children))
+	}
+	if port80.Children[0].Path != "/api" {
+		t.Errorf("child[0].Path = %q, want /api", port80.Children[0].Path)
+	}
+	// Nested children
+	if len(port80.Children[0].Children) != 1 {
+		t.Fatalf("/api children = %d, want 1", len(port80.Children[0].Children))
+	}
+	if port80.Children[0].Children[0].Path != "/api/v1" {
+		t.Errorf("nested child path = %q, want /api/v1", port80.Children[0].Children[0].Path)
+	}
+}
+
+func TestSnapshot_WithChecklist(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(22, "ssh", "OpenSSH 8.2")
+	cl := GenerateChecklist("ssh", "OpenSSH 8.2", false)
+	tree.SetChecklist(22, cl)
+	// Mark one item done
+	tree.Ports[0].Checklist.Items[0].Done = true
+
+	snap := tree.Snapshot()
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap2 AttackDataSnapshot
+	if err := json.Unmarshal(data, &snap2); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := RestoreAttackDataTree(snap2)
+	sshNode := restored.Ports[0]
+	if sshNode.Checklist == nil {
+		t.Fatal("Checklist should be preserved")
+	}
+	if len(sshNode.Checklist.Items) != len(cl.Items) {
+		t.Errorf("Checklist items = %d, want %d", len(sshNode.Checklist.Items), len(cl.Items))
+	}
+	if !sshNode.Checklist.Items[0].Done {
+		t.Error("first checklist item should still be Done")
+	}
+}
+
+func TestSnapshot_WithFindings(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	tree.AddFinding("10.10.11.100", 80, "/api", Finding{
+		Param: "id", Category: "sqli", Evidence: "500 + MySQL syntax error", Severity: "high",
+	})
+	tree.AddFinding("10.10.11.100", 80, "/api", Finding{
+		Param: "name", Category: "xss", Evidence: "reflected <script>", Severity: "medium",
+	})
+
+	snap := tree.Snapshot()
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap2 AttackDataSnapshot
+	if err := json.Unmarshal(data, &snap2); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := RestoreAttackDataTree(snap2)
+	port80 := restored.Ports[0]
+	if len(port80.Children) != 1 {
+		t.Fatalf("children count = %d, want 1", len(port80.Children))
+	}
+	apiNode := port80.Children[0]
+	if len(apiNode.Findings) != 2 {
+		t.Fatalf("findings count = %d, want 2", len(apiNode.Findings))
+	}
+	if apiNode.Findings[0].Param != "id" || apiNode.Findings[0].Category != "sqli" {
+		t.Errorf("finding[0] = %+v", apiNode.Findings[0])
+	}
+	if apiNode.Findings[1].Param != "name" || apiNode.Findings[1].Category != "xss" {
+		t.Errorf("finding[1] = %+v", apiNode.Findings[1])
+	}
+}
+
+func TestSnapshot_InProgressResetToPending(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.10.11.100", 80, "/", "/api")
+	// Set tasks to InProgress
+	batch := tree.NextBatch()
+	for _, task := range batch {
+		tree.StartTask(task)
+	}
+	// Verify InProgress
+	port80 := tree.Ports[0]
+	if port80.EndpointEnum != StatusInProgress {
+		t.Fatalf("should be InProgress, got %d", port80.EndpointEnum)
+	}
+
+	snap := tree.Snapshot()
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap2 AttackDataSnapshot
+	if err := json.Unmarshal(data, &snap2); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := RestoreAttackDataTree(snap2)
+	// InProgress should be reset to Pending
+	restoredPort := restored.Ports[0]
+	if restoredPort.EndpointEnum != StatusPending {
+		t.Errorf("EndpointEnum should be reset to Pending, got %d", restoredPort.EndpointEnum)
+	}
+	if restoredPort.VhostDiscov != StatusPending {
+		t.Errorf("VhostDiscov should be reset to Pending, got %d", restoredPort.VhostDiscov)
+	}
+	// Active should be 0
+	if restored.Active() != 0 {
+		t.Errorf("Active = %d, want 0", restored.Active())
+	}
+	// Completed tasks should stay Complete
+	// (none in this test, but verify StatusNone stays None)
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -54,6 +54,7 @@ type Loop struct {
 	knowledgeStore *knowledge.Store // ナレッジベース検索（nil = 無効）
 	attackData   *AttackDataTree    // 構造的偵察制御（nil = 無効）
 	reconRunner  *ReconRunner // リアクティブ偵察オーケストレーター（nil = 無効）
+	backupMgr    *BackupManager   // AttackDataTree バックアップ（nil = 無効）
 
 	// TUI との通信チャネル
 	events  chan<- Event  // Agent → TUI
@@ -146,6 +147,19 @@ func (l *Loop) Run(ctx context.Context) {
 	l.emit(Event{Type: EventLog, Source: SourceSystem,
 		Message: fmt.Sprintf("Agent started: %s", l.target.Host)})
 	l.target.SetStatusSafe(StatusScanning)
+
+	// AttackDataTree バックアップからの復元
+	if l.attackData != nil && l.memoryStore != nil {
+		if restored, err := LoadAttackDataTree(l.memoryStore.BaseDir(), l.target.Host); err != nil {
+			l.emit(Event{Type: EventLog, Source: SourceSystem,
+				Message: fmt.Sprintf("AttackDataTree restore warning: %v", err)})
+		} else if restored != nil {
+			l.attackData = restored
+			l.emit(Event{Type: EventLog, Source: SourceSystem,
+				Message: "AttackDataTree restored from backup"})
+		}
+		l.backupMgr = NewBackupManager(l.memoryStore.BaseDir(), l.target.Host, l.attackData)
+	}
 
 	// ReconRunner 初期化（リアクティブモデル: evaluateResult から自動 spawn）
 	if l.attackData != nil {
@@ -570,7 +584,7 @@ func (l *Loop) evaluateResult(ctx context.Context) {
 
 	// Raw output saving: コマンド出力をファイルに保存
 	if l.lastCommand != "" && l.memoryStore != nil {
-		if _, err := SaveRawOutput(l.memoryStore.BaseDir(), l.target.Host, l.lastCommand, l.lastToolOutput); err != nil {
+		if _, err := SaveRawOutput(l.memoryStore.BaseDir(), l.target.Host, l.lastCommand, l.lastToolOutput, l.lastExitCode); err != nil {
 			l.emit(Event{Type: EventLog, Source: SourceSystem,
 				Message: fmt.Sprintf("Raw output save warning: %v", err)})
 		}
@@ -616,6 +630,14 @@ func (l *Loop) evaluateResult(ctx context.Context) {
 
 		// Target にも反映（TUI から参照可能にする）
 		l.target.SetAttackData(l.attackData)
+
+		// AttackDataTree バックアップ保存
+		if l.backupMgr != nil {
+			if err := l.backupMgr.Save(); err != nil {
+				l.emit(Event{Type: EventLog, Source: SourceSystem,
+					Message: fmt.Sprintf("AttackDataTree backup warning: %v", err)})
+			}
+		}
 
 		// Recon 完了検出: 全タスク + チェックリスト完了時に一度だけイベントを emit
 		if !l.reconCompleteEmitted && l.attackData.IsReconComplete() {

--- a/internal/agent/raw_output.go
+++ b/internal/agent/raw_output.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,9 +10,29 @@ import (
 	"time"
 )
 
-// SaveRawOutput はコマンドの生出力をファイルに保存する。
-// baseDir/<host>/raw/<timestamp>_<tool>.txt に保存し、ファイルパスを返す。
-func SaveRawOutput(baseDir, host, command, output string) (string, error) {
+// RawOutputEntry は構造化された raw output の1エントリ
+type RawOutputEntry struct {
+	ID        string `json:"id"`        // UUID
+	Command   string `json:"command"`   // 実行コマンド
+	Output    string `json:"output"`    // コマンド出力
+	Timestamp string `json:"timestamp"` // RFC3339
+	Tool      string `json:"tool"`      // extractToolName の結果
+	ExitCode  int    `json:"exit_code"` // コマンドの exit code
+}
+
+// generateUUID は crypto/rand を使って UUID v4 を生成する。
+func generateUUID() string {
+	var buf [16]byte
+	_, _ = rand.Read(buf[:])
+	buf[6] = (buf[6] & 0x0f) | 0x40 // version 4
+	buf[8] = (buf[8] & 0x3f) | 0x80 // variant
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
+}
+
+// SaveRawOutput はコマンドの生出力を JSON ファイルに保存する。
+// baseDir/<host>/raw/<timestamp>_<tool>.json に保存し、ファイルパスを返す。
+func SaveRawOutput(baseDir, host, command, output string, exitCode int) (string, error) {
 	rawDir := filepath.Join(baseDir, host, "raw")
 	if err := os.MkdirAll(rawDir, 0o755); err != nil {
 		return "", fmt.Errorf("create raw dir: %w", err)
@@ -18,19 +40,24 @@ func SaveRawOutput(baseDir, host, command, output string) (string, error) {
 
 	toolName := extractToolName(command)
 	timestamp := time.Now().Format("20060102-150405")
-	filename := fmt.Sprintf("%s_%s.txt", timestamp, toolName)
+	filename := fmt.Sprintf("%s_%s.json", timestamp, toolName)
 	filePath := filepath.Join(rawDir, filename)
 
-	// ヘッダー付きで保存
-	var sb strings.Builder
-	sb.WriteString("# Command: ")
-	sb.WriteString(command)
-	sb.WriteString("\n# Timestamp: ")
-	sb.WriteString(time.Now().Format(time.RFC3339))
-	sb.WriteString("\n# ---\n")
-	sb.WriteString(output)
+	entry := RawOutputEntry{
+		ID:        generateUUID(),
+		Command:   command,
+		Output:    output,
+		Timestamp: time.Now().Format(time.RFC3339),
+		Tool:      toolName,
+		ExitCode:  exitCode,
+	}
 
-	if err := os.WriteFile(filePath, []byte(sb.String()), 0o644); err != nil {
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal raw output: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
 		return "", fmt.Errorf("write raw output: %w", err)
 	}
 

--- a/internal/agent/raw_output_test.go
+++ b/internal/agent/raw_output_test.go
@@ -1,15 +1,18 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSaveRawOutput_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
-	path, err := SaveRawOutput(dir, "10.10.11.100", "nmap -sV 10.10.11.100", "PORT   STATE SERVICE\n22/tcp open  ssh\n80/tcp open  http\n")
+	path, err := SaveRawOutput(dir, "10.10.11.100", "nmap -sV 10.10.11.100", "PORT   STATE SERVICE\n22/tcp open  ssh\n80/tcp open  http\n", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,20 +26,25 @@ func TestSaveRawOutput_CreatesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	content := string(data)
-	// コマンドがヘッダーに含まれる
-	if !strings.Contains(content, "nmap -sV 10.10.11.100") {
-		t.Errorf("file should contain command, got:\n%s", content)
+	// JSON としてパースできるか
+	var entry RawOutputEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("file should be valid JSON: %v", err)
+	}
+
+	// コマンドが含まれる
+	if entry.Command != "nmap -sV 10.10.11.100" {
+		t.Errorf("command mismatch: got %q", entry.Command)
 	}
 	// 出力が含まれる
-	if !strings.Contains(content, "22/tcp open  ssh") {
-		t.Errorf("file should contain output, got:\n%s", content)
+	if !strings.Contains(entry.Output, "22/tcp open  ssh") {
+		t.Errorf("output should contain scan results, got: %q", entry.Output)
 	}
 }
 
 func TestSaveRawOutput_CreatesSubdirectory(t *testing.T) {
 	dir := t.TempDir()
-	_, err := SaveRawOutput(dir, "10.10.11.100", "nmap -sV", "output")
+	_, err := SaveRawOutput(dir, "10.10.11.100", "nmap -sV", "output", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +62,7 @@ func TestSaveRawOutput_CreatesSubdirectory(t *testing.T) {
 
 func TestSaveRawOutput_FilenameContainsTool(t *testing.T) {
 	dir := t.TempDir()
-	path, err := SaveRawOutput(dir, "10.10.11.100", "ffuf -w /usr/share/wordlists -u http://target/FUZZ", "results")
+	path, err := SaveRawOutput(dir, "10.10.11.100", "ffuf -w /usr/share/wordlists -u http://target/FUZZ", "results", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,14 +70,14 @@ func TestSaveRawOutput_FilenameContainsTool(t *testing.T) {
 	if !strings.Contains(base, "ffuf") {
 		t.Errorf("filename should contain tool name, got: %s", base)
 	}
-	if !strings.HasSuffix(base, ".txt") {
-		t.Errorf("filename should end with .txt, got: %s", base)
+	if !strings.HasSuffix(base, ".json") {
+		t.Errorf("filename should end with .json, got: %s", base)
 	}
 }
 
 func TestSaveRawOutput_EmptyOutput(t *testing.T) {
 	dir := t.TempDir()
-	path, err := SaveRawOutput(dir, "10.10.11.100", "echo hello", "")
+	path, err := SaveRawOutput(dir, "10.10.11.100", "echo hello", "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,13 +90,88 @@ func TestSaveRawOutput_EmptyOutput(t *testing.T) {
 func TestSaveRawOutput_SpecialCharsInHost(t *testing.T) {
 	dir := t.TempDir()
 	// ドメイン名をホストとして使用
-	path, err := SaveRawOutput(dir, "dev.example.com", "curl http://dev.example.com", "HTTP/1.1 200 OK")
+	path, err := SaveRawOutput(dir, "dev.example.com", "curl http://dev.example.com", "HTTP/1.1 200 OK", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// ドメインディレクトリが作成されるか
 	if !strings.Contains(path, "dev.example.com") {
 		t.Errorf("path should contain host, got: %s", path)
+	}
+}
+
+func TestSaveRawOutput_JSONStructure(t *testing.T) {
+	dir := t.TempDir()
+	command := "nmap -sV -p- 10.10.11.100"
+	output := "PORT   STATE SERVICE\n22/tcp open  ssh"
+	exitCode := 1
+
+	path, err := SaveRawOutput(dir, "10.10.11.100", command, output, exitCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var entry RawOutputEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("should be valid JSON: %v", err)
+	}
+
+	// ID が空でない
+	if entry.ID == "" {
+		t.Error("ID should not be empty")
+	}
+
+	// Command が一致
+	if entry.Command != command {
+		t.Errorf("Command = %q, want %q", entry.Command, command)
+	}
+
+	// Output が一致
+	if entry.Output != output {
+		t.Errorf("Output = %q, want %q", entry.Output, output)
+	}
+
+	// ExitCode が一致
+	if entry.ExitCode != exitCode {
+		t.Errorf("ExitCode = %d, want %d", entry.ExitCode, exitCode)
+	}
+
+	// Timestamp が RFC3339 形式
+	if _, err := time.Parse(time.RFC3339, entry.Timestamp); err != nil {
+		t.Errorf("Timestamp %q is not valid RFC3339: %v", entry.Timestamp, err)
+	}
+
+	// Tool が extractToolName の結果と一致
+	expectedTool := extractToolName(command)
+	if entry.Tool != expectedTool {
+		t.Errorf("Tool = %q, want %q", entry.Tool, expectedTool)
+	}
+}
+
+func TestSaveRawOutput_FilePermission(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission check not reliable on Windows")
+	}
+
+	dir := t.TempDir()
+	path, err := SaveRawOutput(dir, "10.10.11.100", "nmap -sV", "output", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm != 0o600 {
+		t.Errorf("file permission = %o, want 0600", perm)
 	}
 }
 

--- a/internal/agent/recon_checklist.go
+++ b/internal/agent/recon_checklist.go
@@ -7,15 +7,15 @@ import (
 
 // ChecklistItem represents a single recon task for a service.
 type ChecklistItem struct {
-	ID          string   // e.g. "searchsploit", "anon-check"
-	Description string   // Prompt display text
-	Keywords    []string // AND-match against command history
-	Done        bool     // additive-only: once true, never goes back
+	ID          string   `json:"id"`          // e.g. "searchsploit", "anon-check"
+	Description string   `json:"description"` // Prompt display text
+	Keywords    []string `json:"keywords"`    // AND-match against command history
+	Done        bool     `json:"done"`        // additive-only: once true, never goes back
 }
 
 // ServiceChecklist holds the recon checklist for a specific service.
 type ServiceChecklist struct {
-	Items []ChecklistItem
+	Items []ChecklistItem `json:"items"`
 }
 
 // serviceAliases maps nmap service names to canonical names.


### PR DESCRIPTION
## Summary
- Raw output を plaintext `.txt` から構造化 `.json` (`RawOutputEntry`) に変更
- AttackDataTree の Snapshot/Restore による JSON シリアライズ（DTO パターン）
- BackupManager による atomic write（tmpfile + rename）でセッション永続化
- Agent loop 統合: evaluateResult 後に自動保存、起動時に既存バックアップから復元

## Changes
| File | Change |
|------|--------|
| `raw_output.go` | `RawOutputEntry` struct, JSON output, `0o600` perm, exit code param |
| `attack_data_tree.go` | `AttackDataSnapshot`/`AttackDataNodeDTO`, `Snapshot()`, `RestoreAttackDataTree()` |
| `attack_data_backup.go` | **New**: `BackupManager` (Save/SaveBackup/Load) |
| `recon_checklist.go` | JSON tags on `ChecklistItem`/`ServiceChecklist` |
| `loop.go` | `backupMgr` field, restore on startup, save after evaluateResult |

## Design decisions
- InProgress → Pending on restore (SubAgents need re-spawn)
- active counter reset to 0 on restore
- Atomic write via tmpfile + rename (safe on Windows same-directory)
- UUID v4 via `crypto/rand` (no external deps)

## Test plan
- [x] `TestSaveRawOutput_JSONStructure` — JSON parse + field verification
- [x] `TestSnapshot_Roundtrip` — full marshal/unmarshal/restore cycle
- [x] `TestSnapshot_InProgressResetToPending` — InProgress → Pending on restore
- [x] `TestBackupManager_Save` / `TestLoadAttackDataTree` — save/load roundtrip
- [x] `TestLoadAttackDataTree_FileNotFound` — graceful nil return
- [x] `go build ./...` / `go vet ./...` / `golangci-lint run` all pass

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)