### PR TITLE
Add re-spawn count limit for HTTPReconAgent

### DIFF
--- a/internal/agent/attack_data_tree.go
+++ b/internal/agent/attack_data_tree.go
@@ -19,6 +19,8 @@ const (
 	StatusInProgress
 	// StatusComplete は完了
 	StatusComplete
+	// StatusSkipped はリスポーン制限等で意図的にスキップされた
+	StatusSkipped
 )
 
 // ReconTaskType は偵察タスクの種類
@@ -90,6 +92,7 @@ type AttackDataNode struct {
 
 	Findings []Finding
 	Checklist *ServiceChecklist
+	SpawnCount int // SubAgent がこのポートに対して spawn された回数
 
 	Children []*AttackDataNode
 }
@@ -145,6 +148,8 @@ func (n *AttackDataNode) countTasks() (pending, complete, total int) {
 			total++
 		case StatusComplete:
 			complete++
+			total++
+		case StatusSkipped:
 			total++
 		}
 	}
@@ -590,6 +595,31 @@ func nodeHasPendingChildren(node *AttackDataNode) bool {
 }
 
 // FindPortNode は指定ポート番号のノードを返す。見つからなければ nil。
+// SkipAllPendingChildren は指定ポートのノードとその子孫で Pending なタスクを StatusSkipped に変更する。
+// MaxRespawns に達した場合に呼ばれ、残りのタスクを意図的にスキップする。
+func (t *AttackDataTree) SkipAllPendingChildren(port int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, node := range t.Ports {
+		if node.Port == port {
+			skipPendingRecursive(node)
+			return
+		}
+	}
+}
+
+// skipPendingRecursive はノードとその子孫で Pending なタスクを StatusSkipped に変更する。
+func skipPendingRecursive(node *AttackDataNode) {
+	for _, tt := range []ReconTaskType{TaskEndpointEnum, TaskParamFuzz, TaskValueFuzz, TaskProfiling, TaskVhostDiscov} {
+		if node.getAttackDataStatus(tt) == StatusPending {
+			node.setAttackDataStatus(tt, StatusSkipped)
+		}
+	}
+	for _, child := range node.Children {
+		skipPendingRecursive(child)
+	}
+}
+
 func (t *AttackDataTree) FindPortNode(port int) *AttackDataNode {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -658,6 +688,8 @@ func statusIcon(s AttackDataStatus) string {
 		return "[>]"
 	case StatusPending:
 		return "[ ]"
+	case StatusSkipped:
+		return "[-]"
 	default:
 		return ""
 	}
@@ -672,6 +704,8 @@ func statusLabel(s AttackDataStatus) string {
 		return "running"
 	case StatusPending:
 		return "pending"
+	case StatusSkipped:
+		return "skipped"
 	default:
 		return ""
 	}
@@ -959,7 +993,7 @@ func accumTaskProgressWithPath(tp *TaskProgress, status AttackDataStatus, path s
 		return
 	}
 	tp.Total++
-	if status == StatusComplete {
+	if status == StatusComplete || status == StatusSkipped {
 		tp.Done++
 	}
 	if status == StatusPending && len(tp.PendingPaths) < maxPendingPaths {
@@ -1255,6 +1289,7 @@ func (t *AttackDataTree) StartPortRecon(port *AttackDataNode) bool {
 			port.setAttackDataStatus(tt, StatusInProgress)
 		}
 	}
+	port.SpawnCount++
 	t.active++
 	return true
 }
@@ -1297,6 +1332,7 @@ type AttackDataNodeDTO struct {
 	VhostDiscov  AttackDataStatus    `json:"vhost_discovery"`
 	Findings     []Finding           `json:"findings,omitempty"`
 	Checklist    *ServiceChecklist   `json:"checklist,omitempty"`
+	SpawnCount   int                 `json:"spawn_count"`
 	Children     []AttackDataNodeDTO `json:"children,omitempty"`
 }
 
@@ -1360,6 +1396,7 @@ func nodeToDTO(node *AttackDataNode) AttackDataNodeDTO {
 		VhostDiscov:  node.VhostDiscov,
 		Findings:     node.Findings,
 		Checklist:    node.Checklist,
+		SpawnCount:   node.SpawnCount,
 	}
 	for _, child := range node.Children {
 		dto.Children = append(dto.Children, nodeToDTO(child))
@@ -1383,6 +1420,7 @@ func dtoToNode(dto AttackDataNodeDTO) *AttackDataNode {
 		VhostDiscov:  resetInProgress(dto.VhostDiscov),
 		Findings:     dto.Findings,
 		Checklist:    dto.Checklist,
+		SpawnCount:   dto.SpawnCount,
 	}
 	for _, childDTO := range dto.Children {
 		node.Children = append(node.Children, dtoToNode(childDTO))

--- a/internal/agent/attack_data_tree_test.go
+++ b/internal/agent/attack_data_tree_test.go
@@ -2302,3 +2302,199 @@ func TestFindPortNode_NotFound(t *testing.T) {
 		t.Errorf("FindPortNode(8080) = %v, want nil", node)
 	}
 }
+
+// === Re-spawn limit tests ===
+
+func TestAttackDataNode_SpawnCount_Increment(t *testing.T) {
+	// StartPortRecon should increment SpawnCount each time it succeeds
+	tree := NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	node := tree.Ports[0]
+
+	// First spawn
+	ok := tree.StartPortRecon(node)
+	if !ok {
+		t.Fatal("StartPortRecon should succeed on first call")
+	}
+	if node.SpawnCount != 1 {
+		t.Errorf("SpawnCount = %d after first StartPortRecon, want 1", node.SpawnCount)
+	}
+
+	// Complete the port so active goes down
+	tree.CompleteAllPortTasks(80)
+
+	// Re-add pending tasks to simulate new tasks discovered
+	node.SetAttackDataStatusForTest(TaskEndpointEnum, StatusPending)
+
+	// Second spawn
+	ok = tree.StartPortRecon(node)
+	if !ok {
+		t.Fatal("StartPortRecon should succeed on second call")
+	}
+	if node.SpawnCount != 2 {
+		t.Errorf("SpawnCount = %d after second StartPortRecon, want 2", node.SpawnCount)
+	}
+}
+
+func TestAttackDataTree_SkipAllPendingChildren(t *testing.T) {
+	tree := NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	node := tree.Ports[0]
+
+	// Add some endpoints with pending tasks
+	tree.AddEndpoint("10.0.0.1", 80, "/", "/api")
+	tree.AddEndpoint("10.0.0.1", 80, "/", "/admin")
+
+	// Set some tasks to various statuses
+	apiNode := node.Children[0]
+	apiNode.SetAttackDataStatusForTest(TaskEndpointEnum, StatusComplete)
+	apiNode.SetAttackDataStatusForTest(TaskParamFuzz, StatusPending)
+
+	adminNode := node.Children[1]
+	adminNode.SetAttackDataStatusForTest(TaskEndpointEnum, StatusPending)
+	adminNode.SetAttackDataStatusForTest(TaskParamFuzz, StatusPending)
+
+	// Port-level tasks: set endpoint_enum to Complete, vhost to Pending
+	node.SetAttackDataStatusForTest(TaskEndpointEnum, StatusComplete)
+	node.SetAttackDataStatusForTest(TaskVhostDiscov, StatusPending)
+
+	// Skip all pending children
+	tree.SkipAllPendingChildren(80)
+
+	// Port-level pending tasks should be skipped
+	if node.VhostDiscov != StatusSkipped {
+		t.Errorf("port VhostDiscov = %d, want StatusSkipped(%d)", node.VhostDiscov, StatusSkipped)
+	}
+	// Port-level complete tasks should remain complete
+	if node.EndpointEnum != StatusComplete {
+		t.Errorf("port EndpointEnum = %d, want StatusComplete(%d)", node.EndpointEnum, StatusComplete)
+	}
+
+	// Child pending tasks should be skipped
+	if apiNode.ParamFuzz != StatusSkipped {
+		t.Errorf("api ParamFuzz = %d, want StatusSkipped(%d)", apiNode.ParamFuzz, StatusSkipped)
+	}
+	// Child complete tasks should remain complete
+	if apiNode.EndpointEnum != StatusComplete {
+		t.Errorf("api EndpointEnum = %d, want StatusComplete(%d)", apiNode.EndpointEnum, StatusComplete)
+	}
+
+	if adminNode.EndpointEnum != StatusSkipped {
+		t.Errorf("admin EndpointEnum = %d, want StatusSkipped(%d)", adminNode.EndpointEnum, StatusSkipped)
+	}
+	if adminNode.ParamFuzz != StatusSkipped {
+		t.Errorf("admin ParamFuzz = %d, want StatusSkipped(%d)", adminNode.ParamFuzz, StatusSkipped)
+	}
+}
+
+func TestAttackDataTree_SkipAllPendingChildren_DeepNesting(t *testing.T) {
+	tree := NewAttackDataTree("10.0.0.1", 2, 5)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.0.0.1", 80, "/", "/api")
+	tree.AddEndpoint("10.0.0.1", 80, "/api", "/api/v1")
+	tree.AddEndpoint("10.0.0.1", 80, "/api/v1", "/api/v1/users")
+
+	// All children should have pending tasks
+	tree.SkipAllPendingChildren(80)
+
+	// Walk and verify all pending became skipped
+	var walk func(n *AttackDataNode)
+	walk = func(n *AttackDataNode) {
+		for _, st := range []AttackDataStatus{n.EndpointEnum, n.ParamFuzz, n.ValueFuzz, n.Profiling, n.VhostDiscov} {
+			if st == StatusPending {
+				t.Errorf("found StatusPending in node path=%s port=%d after SkipAllPendingChildren", n.Path, n.Port)
+			}
+		}
+		for _, child := range n.Children {
+			walk(child)
+		}
+	}
+	node := tree.Ports[0]
+	walk(node)
+}
+
+func TestStatusSkipped_Icon_And_Label(t *testing.T) {
+	// statusIcon should return "[-]" for Skipped
+	icon := statusIcon(StatusSkipped)
+	if icon != "[-]" {
+		t.Errorf("statusIcon(StatusSkipped) = %q, want %q", icon, "[-]")
+	}
+
+	// statusLabel should return "skipped"
+	label := statusLabel(StatusSkipped)
+	if label != "skipped" {
+		t.Errorf("statusLabel(StatusSkipped) = %q, want %q", label, "skipped")
+	}
+}
+
+func TestStatusSkipped_CountTasks(t *testing.T) {
+	// Skipped tasks should count as total but not pending or complete
+	tree := NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	node := tree.Ports[0]
+
+	node.SetAttackDataStatusForTest(TaskEndpointEnum, StatusSkipped)
+	node.SetAttackDataStatusForTest(TaskVhostDiscov, StatusComplete)
+
+	pending, complete, total := node.countTasks()
+	if pending != 0 {
+		t.Errorf("pending = %d, want 0", pending)
+	}
+	if complete != 1 {
+		t.Errorf("complete = %d, want 1", complete)
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2 (skipped + complete)", total)
+	}
+}
+
+func TestSpawnCount_JSON_RoundTrip(t *testing.T) {
+	tree := NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	node := tree.Ports[0]
+
+	// Simulate 2 spawns
+	tree.StartPortRecon(node)
+	tree.CompleteAllPortTasks(80)
+	node.SetAttackDataStatusForTest(TaskEndpointEnum, StatusPending)
+	tree.StartPortRecon(node)
+	tree.CompleteAllPortTasks(80)
+
+	if node.SpawnCount != 2 {
+		t.Fatalf("SpawnCount = %d before snapshot, want 2", node.SpawnCount)
+	}
+
+	// Snapshot → Restore → check SpawnCount preserved
+	snap := tree.Snapshot()
+	snapJSON, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var restored AttackDataSnapshot
+	if err := json.Unmarshal(snapJSON, &restored); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	tree2 := RestoreAttackDataTree(restored)
+	if len(tree2.Ports) != 1 {
+		t.Fatalf("restored ports = %d, want 1", len(tree2.Ports))
+	}
+	if tree2.Ports[0].SpawnCount != 2 {
+		t.Errorf("restored SpawnCount = %d, want 2", tree2.Ports[0].SpawnCount)
+	}
+}
+
+func TestStatusSkipped_NotCountedAsPending_InPortHasPendingChildren(t *testing.T) {
+	tree := NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.0.0.1", 80, "/", "/api")
+
+	// Set all children tasks to skipped
+	tree.SkipAllPendingChildren(80)
+
+	// PortHasPendingChildren should return false (skipped != pending)
+	if tree.PortHasPendingChildren(80) {
+		t.Error("PortHasPendingChildren should return false when all pending are skipped")
+	}
+}

--- a/internal/agent/loop_tasks.go
+++ b/internal/agent/loop_tasks.go
@@ -31,7 +31,18 @@ func (l *Loop) drainCompletedTasks(ctx context.Context) string {
 			task.Metadata.Phase == "web_recon" && task.Metadata.Port > 0 {
 			if l.attackData.PortHasPendingChildren(task.Metadata.Port) {
 				if portNode := l.attackData.FindPortNode(task.Metadata.Port); portNode != nil {
-					l.reconRunner.SpawnWebReconForPort(ctx, portNode)
+					if portNode.SpawnCount >= MaxRespawns {
+						// リスポーン上限到達 — 残タスクをスキップ
+						l.attackData.SkipAllPendingChildren(task.Metadata.Port)
+						l.emit(Event{
+							Type:     EventLog,
+							Source:   SourceSystem,
+							Message:  fmt.Sprintf("[RECON] Max re-spawns reached for port %d — skipping remaining tasks", task.Metadata.Port),
+							TargetID: l.target.ID,
+						})
+					} else {
+						l.reconRunner.SpawnWebReconForPort(ctx, portNode)
+					}
 				}
 			}
 		}

--- a/internal/agent/loop_tasks_test.go
+++ b/internal/agent/loop_tasks_test.go
@@ -500,3 +500,86 @@ func TestBuildTaskResult_WebReconUpdatesAttackDataTree(t *testing.T) {
 		}
 	}
 }
+
+// TestDrainCompletedTasks_RespawnLimit verifies that after MaxRespawns, no more
+// re-spawns happen and remaining tasks are skipped.
+func TestDrainCompletedTasks_RespawnLimit(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+
+	// mockBrain: first Think() sees drained output, second completes
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			{Thought: "checking recon results", Action: schema.ActionThink},
+		},
+	}
+
+	loop, taskMgr, events, _, _ := newTestLoopWithTaskManager(target, mb)
+
+	// Set up AttackDataTree with HTTP port and pending children
+	tree := agent.NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpoint("10.0.0.1", 80, "/", "/api")
+	loop.WithAttackData(tree)
+
+	// Simulate that SpawnCount has already reached MaxRespawns
+	portNode := tree.FindPortNode(80)
+	// Spawn + Complete 3 times to reach MaxRespawns
+	for i := 0; i < agent.MaxRespawns; i++ {
+		tree.StartPortRecon(portNode)
+		tree.CompleteAllPortTasks(80)
+		// Re-set pending to simulate new tasks discovered
+		portNode.SetAttackDataStatusForTest(agent.TaskEndpointEnum, agent.StatusPending)
+	}
+
+	// Verify SpawnCount == MaxRespawns
+	if portNode.SpawnCount != agent.MaxRespawns {
+		t.Fatalf("SpawnCount = %d, want %d", portNode.SpawnCount, agent.MaxRespawns)
+	}
+
+	// Add pending tasks on child node
+	apiChild := tree.Ports[0].Children[0]
+	apiChild.SetAttackDataStatusForTest(agent.TaskParamFuzz, agent.StatusPending)
+
+	// Inject a completed web_recon task for port 80
+	task := agent.NewSubTask("task-respawn-limit", agent.TaskKindSmart, "web recon :80")
+	task.Metadata = agent.TaskMetadata{
+		Port:    80,
+		Service: "http",
+		Phase:   "web_recon",
+	}
+	task.Status = agent.TaskStatusCompleted
+	task.Complete()
+	taskMgr.InjectTask("task-respawn-limit", task)
+	taskMgr.InjectDone("task-respawn-limit")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+
+	// Wait for completion and check events
+	gotSkipLog := false
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventLog &&
+				strings.Contains(e.Message, "Max re-spawns reached for port 80") {
+				gotSkipLog = true
+			}
+			if e.Type == agent.EventComplete {
+				if !gotSkipLog {
+					t.Error("expected '[RECON] Max re-spawns reached for port 80' log event")
+				}
+
+				// All pending tasks should now be skipped
+				if tree.PortHasPendingChildren(80) {
+					t.Error("PortHasPendingChildren should be false after max respawns (all skipped)")
+				}
+
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for EventComplete")
+		}
+	}
+}

--- a/internal/agent/recon_runner.go
+++ b/internal/agent/recon_runner.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// MaxRespawns はポートあたりの SubAgent 最大リスポーン回数。
+const MaxRespawns = 3
+
 // ReconRunnerConfig は ReconRunner の構築パラメーター。
 type ReconRunnerConfig struct {
 	Tree       *AttackDataTree


### PR DESCRIPTION
## Summary
- ポートごとの SubAgent 再 spawn 回数に上限（MaxRespawns=3）を追加
- 上限到達時は残りの Pending タスクを StatusSkipped にして終了
- Metasploitable2 等の大量エンドポイントターゲットで無限ループしなくなる
- MaxTurns=50 × MaxRespawns=3 = 最大 150 ターン/ポートで確実に終了

## Test plan
- [x] `go test ./internal/agent/...` — 全テスト通過（8テスト追加）
- [x] `go build ./...` / `go vet ./...` / `golangci-lint run` — 通過

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)