### PR TITLE
fix: AttackDataTree recording bugs + webfuzz streaming wordlist

### DIFF
--- a/internal/agent/attack_data_tree.go
+++ b/internal/agent/attack_data_tree.go
@@ -59,6 +59,12 @@ type Finding struct {
 	Severity string `json:"severity"` // 深刻度: "high", "medium", "low", "info"
 }
 
+// Parameter はファジングで発見されたパラメーター
+type Parameter struct {
+	Name string `json:"name"` // パラメーター名 (e.g. "id", "username")
+	Type string `json:"type"` // query, form, header, cookie, path
+}
+
 // TaskProgress は特定タスクタイプの進捗
 type TaskProgress struct {
 	Done         int
@@ -90,8 +96,9 @@ type AttackDataNode struct {
 	Profiling    AttackDataStatus
 	VhostDiscov  AttackDataStatus
 
-	Findings []Finding
-	Checklist *ServiceChecklist
+	Findings   []Finding
+	Parameters []Parameter
+	Checklist  *ServiceChecklist
 	SpawnCount int // SubAgent がこのポートに対して spawn された回数
 
 	Children []*AttackDataNode
@@ -720,6 +727,25 @@ func taskStatusLine(name string, s AttackDataStatus) string {
 	return fmt.Sprintf("%s: %s", name, label)
 }
 
+// AddParameter はエンドポイントノードにパラメーターを追加する。
+// 同名パラメーターが既に存在する場合はスキップする。
+// ノードが見つからない場合は何もしない。
+func (t *AttackDataTree) AddParameter(host string, port int, path string, name string, paramType string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	node := t.findNode(host, port, path)
+	if node == nil {
+		return
+	}
+	// 重複チェック
+	for _, p := range node.Parameters {
+		if p.Name == name {
+			return
+		}
+	}
+	node.Parameters = append(node.Parameters, Parameter{Name: name, Type: paramType})
+}
+
 // AddFinding はエンドポイントノードに finding を追加する。
 // ノードが見つからない場合は何もしない。
 func (t *AttackDataTree) AddFinding(host string, port int, path string, finding Finding) {
@@ -795,31 +821,38 @@ func renderNode(sb *strings.Builder, node *AttackDataNode, prefix, childPrefix s
 		}
 
 		if node.isHTTP() {
-			// vhost + endpoint ステータス表示
 			sb.WriteString("\n")
-			hasChildren := len(node.Children) > 0
-			vhostPrefix := childPrefix + "|-- "
-			if !hasChildren {
-				vhostPrefix = childPrefix + "+-- "
-			}
-			fmt.Fprintf(sb, "%svhost %s\n", vhostPrefix, statusIcon(node.VhostDiscov))
-
-			// endpoint ノードのステータス（ルートレベル）— 新形式で表示
 			hasRootTasks := node.EndpointEnum != StatusNone
-			if hasRootTasks {
+			hasChildren := len(node.Children) > 0
+			hasVhost := node.VhostDiscov != StatusNone
+
+			// vhost_discovery タスクステータス（他タスクと同形式）
+			if hasVhost {
+				vhostIsLast := !hasRootTasks && !hasChildren
+				vhostPrefix := childPrefix + "|-- "
+				if vhostIsLast {
+					vhostPrefix = childPrefix + "+-- "
+				}
+				fmt.Fprintf(sb, "%s%s\n", vhostPrefix, taskStatusLine("vhost_discovery", node.VhostDiscov))
+			}
+
+			// ルート "/" ノード（ポートノードのタスク・パラメータ・ファインディングを表示）
+			hasRootData := hasRootTasks || len(node.Parameters) > 0 || len(node.Findings) > 0
+			if hasRootData {
 				rootPrefix := childPrefix + "|-- "
 				rootChildPrefix := childPrefix + "|   "
 				if !hasChildren {
 					rootPrefix = childPrefix + "+-- "
 					rootChildPrefix = childPrefix + "    "
 				}
-				// ルートを仮の endpoint ノードとしてレンダリング
 				rootNode := &AttackDataNode{
 					Path:         "/",
 					EndpointEnum: node.EndpointEnum,
 					ParamFuzz:    node.ParamFuzz,
 					ValueFuzz:    node.ValueFuzz,
 					Profiling:    node.Profiling,
+					Parameters:   node.Parameters,
+					Findings:     node.Findings,
 				}
 				renderEndpointNode(sb, rootNode, rootPrefix, rootChildPrefix)
 			}
@@ -863,8 +896,8 @@ func renderEndpointNode(sb *strings.Builder, node *AttackDataNode, prefix, child
 		}
 	}
 
-	// findings + children + taskLines の合計で最終要素を判定
-	totalItems := len(taskLines) + len(node.Findings) + len(node.Children)
+	// parameters + findings + children + taskLines の合計で最終要素を判定
+	totalItems := len(taskLines) + len(node.Parameters) + len(node.Findings) + len(node.Children)
 	itemIdx := 0
 
 	for _, line := range taskLines {
@@ -875,6 +908,16 @@ func renderEndpointNode(sb *strings.Builder, node *AttackDataNode, prefix, child
 			tp = childPrefix + "+-- "
 		}
 		fmt.Fprintf(sb, "%s%s\n", tp, line)
+	}
+
+	for _, p := range node.Parameters {
+		itemIdx++
+		isLast := itemIdx == totalItems
+		pp := childPrefix + "|-- "
+		if isLast {
+			pp = childPrefix + "+-- "
+		}
+		fmt.Fprintf(sb, "%sparam: %s (%s)\n", pp, p.Name, p.Type)
 	}
 
 	for _, f := range node.Findings {
@@ -1331,6 +1374,7 @@ type AttackDataNodeDTO struct {
 	Profiling    AttackDataStatus    `json:"profiling"`
 	VhostDiscov  AttackDataStatus    `json:"vhost_discovery"`
 	Findings     []Finding           `json:"findings,omitempty"`
+	Parameters   []Parameter         `json:"parameters,omitempty"`
 	Checklist    *ServiceChecklist   `json:"checklist,omitempty"`
 	SpawnCount   int                 `json:"spawn_count"`
 	Children     []AttackDataNodeDTO `json:"children,omitempty"`
@@ -1395,6 +1439,7 @@ func nodeToDTO(node *AttackDataNode) AttackDataNodeDTO {
 		Profiling:    node.Profiling,
 		VhostDiscov:  node.VhostDiscov,
 		Findings:     node.Findings,
+		Parameters:   node.Parameters,
 		Checklist:    node.Checklist,
 		SpawnCount:   node.SpawnCount,
 	}
@@ -1419,6 +1464,7 @@ func dtoToNode(dto AttackDataNodeDTO) *AttackDataNode {
 		Profiling:    resetInProgress(dto.Profiling),
 		VhostDiscov:  resetInProgress(dto.VhostDiscov),
 		Findings:     dto.Findings,
+		Parameters:   dto.Parameters,
 		Checklist:    dto.Checklist,
 		SpawnCount:   dto.SpawnCount,
 	}

--- a/internal/agent/attack_data_tree_test.go
+++ b/internal/agent/attack_data_tree_test.go
@@ -544,6 +544,142 @@ func TestRenderTree_WithFindings(t *testing.T) {
 	}
 }
 
+func TestRenderTree_WithParameters(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2, 0)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/login", 200)
+
+	tree.AddParameter("10.10.11.100", 80, "/login", "username", "query")
+	tree.AddParameter("10.10.11.100", 80, "/login", "password", "query")
+
+	output := tree.RenderTree()
+
+	checks := []string{
+		"/login",
+		"param: username (query)",
+		"param: password (query)",
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderTree missing %q\noutput:\n%s", check, output)
+		}
+	}
+}
+
+func TestRenderTree_WithParametersAndFindings(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2, 0)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/api", 200)
+
+	tree.AddParameter("10.10.11.100", 80, "/api", "id", "query")
+	tree.AddFinding("10.10.11.100", 80, "/api", Finding{
+		Param:    "id",
+		Category: "sqli",
+		Evidence: "500 + MySQL syntax error",
+		Severity: "high",
+	})
+
+	output := tree.RenderTree()
+
+	checks := []string{
+		"param: id (query)",
+		`finding: param "id"`,
+		"sqli",
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderTree missing %q\noutput:\n%s", check, output)
+		}
+	}
+
+	// param が finding より前に表示されること
+	paramIdx := strings.Index(output, "param: id")
+	findingIdx := strings.Index(output, "finding:")
+	if paramIdx >= findingIdx {
+		t.Errorf("param should appear before finding\noutput:\n%s", output)
+	}
+}
+
+func TestRenderTree_RootParamsAndFindings(t *testing.T) {
+	// ポートノードの "/" にパラメータと Finding があるとき
+	// renderNode の virtual "/" ノードに正しく渡されること
+	tree := NewAttackDataTree("10.10.11.100", 2, 0)
+	tree.AddPort(80, "http", "Apache")
+
+	// "/" にパラメータを追加（ポートノード = path ""）
+	tree.AddParameter("10.10.11.100", 80, "", "q", "query")
+	tree.AddFinding("10.10.11.100", 80, "", Finding{
+		Param:    "q",
+		Category: "sqli",
+		Evidence: "syntax error",
+		Severity: "high",
+	})
+
+	output := tree.RenderTree()
+	t.Logf("RenderTree output:\n%s", output)
+
+	checks := []string{
+		"/",
+		"param: q (query)",
+		`finding: param "q"`,
+		"sqli",
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderTree missing %q\noutput:\n%s", check, output)
+		}
+	}
+}
+
+func TestRenderTree_FullPipeline(t *testing.T) {
+	// webfuzz の全モードで検出されたデータが /attackdata で見えること
+	tree := NewAttackDataTree("10.10.11.100", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+
+	// dir モード: endpoint 検出
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/login", 200)
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/api", 301)
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+
+	// param モード: パラメータ検出
+	tree.AddParameter("10.10.11.100", 80, "/login", "user", "query")
+	tree.AddParameter("10.10.11.100", 80, "/login", "pass", "query")
+	tree.CompleteTask("10.10.11.100", 80, "/login", TaskParamFuzz)
+
+	// value モード: finding 検出
+	tree.AddFinding("10.10.11.100", 80, "/login", Finding{
+		Param:    "user",
+		Category: "sqli",
+		Evidence: "500 + MySQL syntax error",
+		Severity: "high",
+	})
+
+	// vhost モード
+	tree.AddVhost("10.10.11.100", 80, "dev.example.com")
+	tree.CompleteTask("10.10.11.100", 80, "", TaskVhostDiscov)
+
+	output := tree.RenderTree()
+	t.Logf("RenderTree output:\n%s", output)
+
+	checks := []string{
+		"80/http Apache",
+		"vhost_discovery: complete",
+		"/login",
+		"/api",
+		"param: user (query)",
+		"param: pass (query)",
+		`finding: param "user"`,
+		"sqli",
+		"[vhost] dev.example.com",
+		"endpoint_enum: complete", // port root "/"
+	}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("RenderTree missing %q\noutput:\n%s", check, output)
+		}
+	}
+}
+
 // --- RenderIntel active タスクカバレッジ ---
 
 func TestRenderTree_WithActiveTasks(t *testing.T) {

--- a/internal/agent/webfuzz_adapter.go
+++ b/internal/agent/webfuzz_adapter.go
@@ -35,3 +35,22 @@ func (a *webfuzzTreeAdapter) CompleteTask(host string, port int, path string, ta
 	}
 	a.tree.CompleteTask(host, port, path, rt)
 }
+
+func (a *webfuzzTreeAdapter) AddParameter(host string, port int, path string, name string, paramType string) {
+	if a.tree == nil {
+		return
+	}
+	a.tree.AddParameter(host, port, path, name, paramType)
+}
+
+func (a *webfuzzTreeAdapter) AddFinding(host string, port int, path string, param, category, evidence, severity string) {
+	if a.tree == nil {
+		return
+	}
+	a.tree.AddFinding(host, port, path, Finding{
+		Param:    param,
+		Category: category,
+		Evidence: evidence,
+		Severity: severity,
+	})
+}

--- a/internal/agent/webfuzz_adapter_test.go
+++ b/internal/agent/webfuzz_adapter_test.go
@@ -12,6 +12,8 @@ func TestWebfuzzTreeAdapter_NilTree(t *testing.T) {
 	adapter.AddEndpointWithStatus("10.0.0.1", 80, "/", "/admin", 200)
 	adapter.AddVhost("10.0.0.1", 80, "dev.example.com")
 	adapter.CompleteTask("10.0.0.1", 80, "/", 0)
+	adapter.AddParameter("10.0.0.1", 80, "/", "id", "query")
+	adapter.AddFinding("10.0.0.1", 80, "/", "id", "sqli", "error", "high")
 }
 
 func TestWebfuzzTreeAdapter_InvalidTaskType(t *testing.T) {
@@ -64,4 +66,131 @@ func TestWebfuzzTreeAdapter_DelegatesCorrectly(t *testing.T) {
 		t.Error("expected vhost to be added via adapter")
 	}
 	tree.mu.RUnlock()
+}
+
+// --- 統合テスト: webfuzz adapter → AttackDataTree パイプライン ---
+
+func TestWebfuzzTreeAdapter_EndpointPipeline(t *testing.T) {
+	// webfuzz dir モードのフルパイプライン:
+	// WebfuzzTool.hitFn → webfuzzTreeAdapter.AddEndpointWithStatus → AttackDataTree.AddEndpointWithStatus
+	tree := NewAttackDataTree("172.30.0.30", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	adapter := &webfuzzTreeAdapter{tree: tree}
+
+	// webfuzz の hitFn が呼ぶのと同じ引数パターンをシミュレート
+	// webfuzz dir -u http://172.30.0.30/FUZZ → parentPath="/", newPath="/admin", httpStatus=200
+	adapter.AddEndpointWithStatus("172.30.0.30", 80, "/", "/admin", 200)
+	adapter.AddEndpointWithStatus("172.30.0.30", 80, "/", "/login", 200)
+	adapter.AddEndpointWithStatus("172.30.0.30", 80, "/", "/api", 301)
+
+	// ツリーに子ノードが追加されたか確認
+	tree.mu.RLock()
+	defer tree.mu.RUnlock()
+
+	if len(tree.Ports) == 0 {
+		t.Fatal("expected port node")
+	}
+	node := tree.Ports[0]
+	if len(node.Children) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(node.Children))
+	}
+
+	// 各子ノードのパスとステータスを確認
+	paths := map[string]bool{}
+	for _, child := range node.Children {
+		paths[child.Path] = true
+		// ホスト名が正しく設定されているか
+		if child.Host != "172.30.0.30" {
+			t.Errorf("child %s: Host = %q, want %q", child.Path, child.Host, "172.30.0.30")
+		}
+		// ポートが正しく設定されているか
+		if child.Port != 80 {
+			t.Errorf("child %s: Port = %d, want 80", child.Path, child.Port)
+		}
+	}
+
+	for _, path := range []string{"/admin", "/login", "/api"} {
+		if !paths[path] {
+			t.Errorf("expected child path %s", path)
+		}
+	}
+
+	// /attackdata コマンドで表示される RenderTree に反映されているか
+	rendered := tree.RenderTree()
+	for _, path := range []string{"/admin", "/login", "/api"} {
+		if !contains(rendered, path) {
+			t.Errorf("RenderTree should contain %s, got:\n%s", path, rendered)
+		}
+	}
+}
+
+func TestWebfuzzTreeAdapter_AddParameter(t *testing.T) {
+	// Bug 3: param モードで発見したパラメーター名がツリーに記録されること
+	tree := NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	// エンドポイントを追加
+	tree.AddEndpointWithStatus("10.0.0.1", 80, "/", "/login", 200)
+
+	adapter := &webfuzzTreeAdapter{tree: tree}
+
+	// AddParameter を呼ぶ（TreeUpdater インターフェースに追加予定）
+	adapter.AddParameter("10.0.0.1", 80, "/login", "username", "query")
+	adapter.AddParameter("10.0.0.1", 80, "/login", "password", "query")
+
+	// パラメーターが記録されたか確認
+	tree.mu.RLock()
+	defer tree.mu.RUnlock()
+
+	portNode := tree.Ports[0]
+	if len(portNode.Children) == 0 {
+		t.Fatal("expected /login endpoint")
+	}
+	loginNode := portNode.Children[0]
+	if len(loginNode.Parameters) != 2 {
+		t.Fatalf("expected 2 parameters, got %d", len(loginNode.Parameters))
+	}
+	if loginNode.Parameters[0].Name != "username" {
+		t.Errorf("expected first param name 'username', got %q", loginNode.Parameters[0].Name)
+	}
+	if loginNode.Parameters[1].Name != "password" {
+		t.Errorf("expected second param name 'password', got %q", loginNode.Parameters[1].Name)
+	}
+}
+
+func TestWebfuzzTreeAdapter_AddFinding(t *testing.T) {
+	// Bug 4: TreeUpdater 経由で finding を追加できること
+	tree := NewAttackDataTree("10.0.0.1", 2, 3)
+	tree.AddPort(80, "http", "Apache")
+	tree.AddEndpointWithStatus("10.0.0.1", 80, "/", "/login", 200)
+
+	adapter := &webfuzzTreeAdapter{tree: tree}
+
+	// AddFinding を呼ぶ（フラットパラメータ → adapter 内で Finding 構造体に変換）
+	adapter.AddFinding("10.0.0.1", 80, "/login", "username", "sqli", "500 + MySQL syntax error on single quote", "high")
+
+	// finding が記録されたか確認
+	tree.mu.RLock()
+	defer tree.mu.RUnlock()
+
+	portNode := tree.Ports[0]
+	loginNode := portNode.Children[0]
+	if len(loginNode.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(loginNode.Findings))
+	}
+	if loginNode.Findings[0].Category != "sqli" {
+		t.Errorf("expected finding category 'sqli', got %q", loginNode.Findings[0].Category)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/tools/webfuzz/adapter.go
+++ b/internal/tools/webfuzz/adapter.go
@@ -17,6 +17,8 @@ type TreeUpdater interface {
 	AddEndpointWithStatus(host string, port int, parentPath, newPath string, httpStatus int)
 	AddVhost(parentHost string, port int, vhostName string)
 	CompleteTask(host string, port int, path string, taskType int)
+	AddParameter(host string, port int, path string, name string, paramType string)
+	AddFinding(host string, port int, path string, param, category, evidence, severity string)
 }
 
 // WebfuzzTool は InternalTool を実装し、結果を AttackDataTree に直接書き込む。
@@ -67,9 +69,8 @@ func (w *WebfuzzTool) Execute(ctx context.Context, args []string, lineCh chan<- 
 			vhostName := hit.Input + "." + domain
 			w.tree.AddVhost(w.host, port, vhostName)
 		case "param":
-			// パラメーターファジングはタスク完了のみ
-			// TaskParamFuzz = 1 (agent パッケージの定数値)
-			w.tree.CompleteTask(w.host, port, parentPath, 1)
+			// ヒットしたパラメーター名をツリーに記録
+			w.tree.AddParameter(w.host, port, parentPath, hit.Input, "query")
 		}
 	}
 
@@ -87,11 +88,20 @@ func (w *WebfuzzTool) Execute(ctx context.Context, args []string, lineCh chan<- 
 		return 1, err
 	}
 
-	// dir モードの場合、列挙完了をマーク
-	if w.tree != nil && opts.Mode == "dir" {
+	// 各モードの列挙完了をマーク
+	if w.tree != nil {
 		port, parentPath := extractPortAndPath(opts.URL)
-		// TaskEndpointEnum = 0 (agent パッケージの定数値)
-		w.tree.CompleteTask(w.host, port, parentPath, 0)
+		switch opts.Mode {
+		case "dir":
+			// TaskEndpointEnum = 0 (agent パッケージの定数値)
+			w.tree.CompleteTask(w.host, port, parentPath, 0)
+		case "vhost":
+			// TaskVhostDiscov = 4 (agent パッケージの定数値)
+			w.tree.CompleteTask(w.host, port, parentPath, 4)
+		case "param":
+			// TaskParamFuzz = 1 (agent パッケージの定数値)
+			w.tree.CompleteTask(w.host, port, parentPath, 1)
+		}
 	}
 
 	return 0, nil

--- a/internal/tools/webfuzz/adapter_test.go
+++ b/internal/tools/webfuzz/adapter_test.go
@@ -16,10 +16,22 @@ import (
 
 // mockTreeUpdater は TreeUpdater のテスト用モック。
 type mockTreeUpdater struct {
-	mu        sync.Mutex
-	endpoints []endpointRecord
-	vhosts    []vhostRecord
-	completed []completeRecord
+	mu         sync.Mutex
+	endpoints  []endpointRecord
+	vhosts     []vhostRecord
+	completed  []completeRecord
+	parameters []parameterRecord
+	findings   []findingRecord
+}
+
+type parameterRecord struct {
+	host, path, name, paramType string
+	port                        int
+}
+
+type findingRecord struct {
+	host, path, param, category, evidence, severity string
+	port                                            int
 }
 
 type endpointRecord struct {
@@ -54,6 +66,18 @@ func (m *mockTreeUpdater) CompleteTask(host string, port int, path string, taskT
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.completed = append(m.completed, completeRecord{host: host, port: port, path: path, taskType: taskType})
+}
+
+func (m *mockTreeUpdater) AddParameter(host string, port int, path string, name string, paramType string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.parameters = append(m.parameters, parameterRecord{host: host, port: port, path: path, name: name, paramType: paramType})
+}
+
+func (m *mockTreeUpdater) AddFinding(host string, port int, path string, param, category, evidence, severity string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.findings = append(m.findings, findingRecord{host: host, port: port, path: path, param: param, category: category, evidence: evidence, severity: severity})
 }
 
 func TestWebfuzzTool_Execute_DirMode(t *testing.T) {
@@ -382,6 +406,96 @@ func TestWebfuzzTool_Execute_ParamMode(t *testing.T) {
 	defer tree.mu.Unlock()
 	if len(tree.completed) == 0 {
 		t.Error("expected CompleteTask to be called for param mode")
+	}
+}
+
+func TestWebfuzzTool_Execute_VhostMode_CompletesTask(t *testing.T) {
+	// Bug 2: vhost モードで列挙完了後に CompleteTask(taskType=4=TaskVhostDiscov) が呼ばれることを確認
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "default")
+	}))
+	defer srv.Close()
+
+	wordlist := createTempWordlist(t, "dev\n")
+
+	tree := &mockTreeUpdater{}
+	tool := NewWebfuzzTool(tree, "10.0.0.1")
+
+	lineCh := make(chan tools.OutputLine, 256)
+	go func() {
+		for range lineCh {
+		}
+	}()
+
+	exitCode, err := tool.Execute(context.Background(),
+		[]string{"vhost", "-u", srv.URL, "-w", wordlist, "-H", "Host: FUZZ.example.com", "-fs", "99999", "-t", "1"},
+		lineCh)
+	close(lineCh)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	// vhost モード完了で CompleteTask(taskType=4=TaskVhostDiscov) が呼ばれるべき
+	tree.mu.Lock()
+	defer tree.mu.Unlock()
+	found := false
+	for _, c := range tree.completed {
+		if c.taskType == 4 { // TaskVhostDiscov
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected CompleteTask(taskType=4=TaskVhostDiscov) for vhost mode completion")
+	}
+}
+
+func TestWebfuzzTool_Execute_ParamMode_NoHits_CompletesTask(t *testing.T) {
+	// Bug 2 (related): param モードでヒットが0件でも CompleteTask が呼ばれることを確認
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		fmt.Fprint(w, "not found")
+	}))
+	defer srv.Close()
+
+	wordlist := createTempWordlist(t, "id\nname\n")
+
+	tree := &mockTreeUpdater{}
+	tool := NewWebfuzzTool(tree, "10.0.0.1")
+
+	lineCh := make(chan tools.OutputLine, 256)
+	go func() {
+		for range lineCh {
+		}
+	}()
+
+	exitCode, err := tool.Execute(context.Background(),
+		[]string{"param", "-u", srv.URL + "/page?FUZZ=test", "-w", wordlist, "-mc", "200", "-t", "1"},
+		lineCh)
+	close(lineCh)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	// ヒット0件でも CompleteTask(taskType=1=TaskParamFuzz) が呼ばれるべき
+	tree.mu.Lock()
+	defer tree.mu.Unlock()
+	found := false
+	for _, c := range tree.completed {
+		if c.taskType == 1 { // TaskParamFuzz
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected CompleteTask(taskType=1=TaskParamFuzz) for param mode completion even with 0 hits")
 	}
 }
 

--- a/internal/tools/webfuzz/webfuzz.go
+++ b/internal/tools/webfuzz/webfuzz.go
@@ -27,23 +27,17 @@ type Hit struct {
 // ワードリストの各エントリについて HTTP リクエストを送り、マッチ条件に合致したらヒットとして通知する。
 // hitFn: ヒットごとに呼ばれるコールバック（AttackDataTree 更新用）
 // lineFn: TUI 表示用のサマリー行コールバック（例: "[HIT] /admin [301] [1234B]"）
+//
+// ワードリストはストリーミングで読み込み、1行ずつワーカーに送信する。
+// これにより大きなワードリストでもメモリを大量消費せず、GC pause を抑制する。
 func Run(ctx context.Context, opts Options, hitFn func(Hit), lineFn func(string)) error {
-	// 1. ワードリスト読み込み
-	words, err := loadWordlist(opts.Wordlist)
+	// 1. ワードリストファイルを開く（fail fast: 存在しなければ即エラー）
+	f, err := os.Open(opts.Wordlist)
 	if err != nil {
 		return fmt.Errorf("failed to load wordlist: %w", err)
 	}
 
-	// 2. extensions 展開（dir モードのみ）
-	words = expandExtensions(words, opts.Mode, opts.Extensions)
-
-	total := len(words)
-	if total == 0 {
-		lineFn("[DONE] 0 requests, 0 hits")
-		return nil
-	}
-
-	// 3. HTTP クライアント生成
+	// 2. HTTP クライアント生成
 	client := &http.Client{
 		Timeout: opts.Timeout,
 		Transport: &http.Transport{
@@ -55,15 +49,13 @@ func Run(ctx context.Context, opts Options, hitFn func(Hit), lineFn func(string)
 		},
 	}
 
-	// 4. Worker pool
+	// 3. Worker pool
 	threads := opts.Threads
 	if threads <= 0 {
 		threads = 1
 	}
-	if threads > total {
-		threads = total
-	}
 
+	var sent atomic.Int64
 	var hitCount atomic.Int64
 	var wg sync.WaitGroup
 	ch := make(chan string, threads)
@@ -94,60 +86,56 @@ func Run(ctx context.Context, opts Options, hitFn func(Hit), lineFn func(string)
 		}()
 	}
 
-	// ワードをチャネルに送信
-	for _, word := range words {
-		if ctx.Err() != nil {
-			break
+	// 4. Producer goroutine: ファイルからストリーミング送信
+	// ワードリスト全体を []string に読み込まず、1行ずつワーカーチャネルへ送信する。
+	// これにより大量のヒープ割り当てと GC pressure を回避する。
+	var scanErr error
+	go func() {
+		defer close(ch)
+		defer func() { _ = f.Close() }()
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			// ワード送信（ctx キャンセルで早期終了）
+			if !sendWord(ctx, ch, line, &sent) {
+				return
+			}
+			// dir モード: 拡張子付きバージョンもインライン送信
+			if opts.Mode == "dir" {
+				for _, ext := range opts.Extensions {
+					if !sendWord(ctx, ch, line+ext, &sent) {
+						return
+					}
+				}
+			}
 		}
-		select {
-		case <-ctx.Done():
-		case ch <- word:
-		}
-	}
-	close(ch)
+		scanErr = scanner.Err()
+	}()
+
 	wg.Wait()
 
-	lineFn(fmt.Sprintf("[DONE] %d requests, %d hits", total, hitCount.Load()))
+	// scanErr の読み取りは安全: close(ch) → workers drain → wg.Wait() 完了後
+	if scanErr != nil {
+		return fmt.Errorf("wordlist read error: %w", scanErr)
+	}
+
+	lineFn(fmt.Sprintf("[DONE] %d requests, %d hits", sent.Load(), hitCount.Load()))
 	return nil
 }
 
-// loadWordlist はワードリストファイルを読み込み、空行とコメント行をスキップして返す。
-func loadWordlist(path string) ([]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
+// sendWord はワードをチャネルに送信し、カウンターを増やす。
+// ctx がキャンセルされた場合は false を返す。
+func sendWord(ctx context.Context, ch chan<- string, word string, sent *atomic.Int64) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- word:
+		sent.Add(1)
+		return true
 	}
-	defer func() { _ = f.Close() }()
-
-	var words []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		words = append(words, line)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return words, nil
-}
-
-// expandExtensions は dir モードの場合、各ワードに拡張子付きバージョンを追加する。
-func expandExtensions(words []string, mode string, extensions []string) []string {
-	if mode != "dir" || len(extensions) == 0 {
-		return words
-	}
-
-	expanded := make([]string, 0, len(words)*(1+len(extensions)))
-	for _, w := range words {
-		expanded = append(expanded, w)
-		for _, ext := range extensions {
-			expanded = append(expanded, w+ext)
-		}
-	}
-	return expanded
 }
 
 // fuzzOne は1つのワードに対してリクエストを送り、マッチ判定を行う。

--- a/internal/tools/webfuzz/webfuzz_test.go
+++ b/internal/tools/webfuzz/webfuzz_test.go
@@ -668,12 +668,56 @@ func TestShouldReport(t *testing.T) {
 	}
 }
 
-func TestExpandExtensions_NonDirMode(t *testing.T) {
-	words := []string{"admin", "test"}
-	// param モードでは extensions を展開しない
-	result := expandExtensions(words, "param", []string{".php"})
-	if len(result) != 2 {
-		t.Errorf("param mode should not expand extensions, got %d words", len(result))
+func TestRun_ParamMode_IgnoresExtensions(t *testing.T) {
+	// param モードでは Extensions が設定されていても展開しないことを確認
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "ok")
+	}))
+	defer ts.Close()
+
+	wl := writeWordlist(t, []string{"id", "name"})
+	opts := Options{
+		Mode:        "param",
+		URL:         ts.URL + "/search?FUZZ=test",
+		Wordlist:    wl,
+		Method:      "GET",
+		Threads:     1,
+		Timeout:     5 * time.Second,
+		Extensions:  []string{".php", ".html"}, // param モードでは無視される
+		MatchStatus: nil,                        // 全マッチ
+	}
+
+	var mu sync.Mutex
+	var hits []Hit
+	var lines []string
+	hitFn := func(h Hit) {
+		mu.Lock()
+		defer mu.Unlock()
+		hits = append(hits, h)
+	}
+	lineFn := func(s string) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, s)
+	}
+
+	err := Run(context.Background(), opts, hitFn, lineFn)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	// param モードでは "id", "name" の2つのみ（拡張子展開なし）
+	if len(hits) != 2 {
+		t.Errorf("param mode: got %d hits, want 2 (extensions should be ignored)", len(hits))
+	}
+
+	// [DONE] メッセージに 2 requests と記載されること
+	mu.Lock()
+	defer mu.Unlock()
+	last := lines[len(lines)-1]
+	if !strings.Contains(last, "2 requests") {
+		t.Errorf("last line = %q, want to contain '2 requests'", last)
 	}
 }
 


### PR DESCRIPTION
## Summary
- AttackDataTree の記録バグ3件を修正（vhost CompleteTask 漏れ、AddParameter/AddFinding 未実装）
- `/attackdata` 表示修正（パラメーター・Finding・ルート "/" ノードの表示、vhost 表記統一）
- webfuzz ワードリスト読み込みをストリーミング化し、GC pause による TUI 入力遅延を解消

Closes #125

## Test plan
- [x] `go build ./...` パス
- [x] `go vet ./...` パス
- [x] `go test ./internal/tools/webfuzz/...` — 全40テスト PASS
- [x] `go test ./internal/agent/...` — webfuzz adapter テスト6件含む全テスト PASS
- [x] `go test ./internal/...` — 全パッケージ PASS
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)