### PR TITLE
feat: harden action JSON parsing and add log copy mode

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -24,6 +24,8 @@ const (
 	maxConsecutiveFailures = 3
 )
 
+const invalidJSONRetryHint = "[SYSTEM] Previous model response was invalid or truncated JSON. Return STRICT JSON only. Keep command concise (<=300 chars) and do not embed long report bodies."
+
 // commandEntry はコマンド履歴の1エントリを保持する。
 type commandEntry struct {
 	Command  string
@@ -288,13 +290,21 @@ func (l *Loop) Run(ctx context.Context) {
 
 		var action *schema.Action
 		var brainErr error
+		retryHint := ""
 		for attempt := 1; attempt <= maxBrainRetries; attempt++ {
 			l.brMu.Lock()
 			currentBrain := l.br
 			l.brMu.Unlock()
+			toolOutput := l.lastToolOutput
+			if retryHint != "" {
+				if toolOutput != "" {
+					toolOutput += "\n\n"
+				}
+				toolOutput += retryHint
+			}
 			action, brainErr = currentBrain.Think(ctx, brain.Input{
 				TargetSnapshot: l.buildSnapshot(),
-				ToolOutput:     l.lastToolOutput,
+				ToolOutput:     toolOutput,
 				LastCommand:    l.lastCommand,
 				LastExitCode:   l.lastExitCode,
 				CommandHistory: l.buildHistory(),
@@ -306,6 +316,7 @@ func (l *Loop) Run(ctx context.Context) {
 			if brainErr == nil {
 				break
 			}
+			retryHint = buildBrainRetryHint(brainErr)
 			if attempt < maxBrainRetries {
 				l.emit(Event{Type: EventLog, Source: SourceSystem,
 					Message: fmt.Sprintf("Brain error: %v — retrying (%d/%d)", brainErr, attempt, maxBrainRetries)})
@@ -718,6 +729,7 @@ func (l *Loop) handleEventDrivenTrigger(ctx context.Context, userMsg string) {
 func (l *Loop) thinkOnEvent(ctx context.Context, userMsg string) (*schema.Action, error) {
 	var action *schema.Action
 	var brainErr error
+	retryHint := ""
 	for attempt := 1; attempt <= maxBrainRetries; attempt++ {
 		l.brMu.Lock()
 		currentBrain := l.br
@@ -725,9 +737,16 @@ func (l *Loop) thinkOnEvent(ctx context.Context, userMsg string) (*schema.Action
 		if currentBrain == nil {
 			return nil, fmt.Errorf("brain is not configured")
 		}
+		toolOutput := l.lastToolOutput
+		if retryHint != "" {
+			if toolOutput != "" {
+				toolOutput += "\n\n"
+			}
+			toolOutput += retryHint
+		}
 		action, brainErr = currentBrain.Think(ctx, brain.Input{
 			TargetSnapshot: l.buildSnapshot(),
-			ToolOutput:     l.lastToolOutput,
+			ToolOutput:     toolOutput,
 			LastCommand:    l.lastCommand,
 			LastExitCode:   l.lastExitCode,
 			CommandHistory: l.buildHistory(),
@@ -739,6 +758,7 @@ func (l *Loop) thinkOnEvent(ctx context.Context, userMsg string) (*schema.Action
 		if brainErr == nil {
 			return action, nil
 		}
+		retryHint = buildBrainRetryHint(brainErr)
 		if attempt < maxBrainRetries {
 			select {
 			case <-ctx.Done():
@@ -748,6 +768,17 @@ func (l *Loop) thinkOnEvent(ctx context.Context, userMsg string) (*schema.Action
 		}
 	}
 	return nil, fmt.Errorf("brain error after %d retries: %w", maxBrainRetries, brainErr)
+}
+
+func buildBrainRetryHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "invalid json from llm") || strings.Contains(msg, "unexpected end of json input") {
+		return invalidJSONRetryHint
+	}
+	return "[SYSTEM] Previous model response caused an error. Return STRICT JSON only."
 }
 
 func (l *Loop) handleEventDrivenAction(ctx context.Context, action *schema.Action) {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -396,6 +396,43 @@ func TestLoop_Run_BrainError_Retries(t *testing.T) {
 	}
 }
 
+func TestLoop_Run_BrainError_JSONParseRetryHintInjected(t *testing.T) {
+	target := agent.NewTarget(1, "10.0.0.1")
+	mb := &mockBrain{
+		actions: []*schema.Action{
+			nil, // 1st call -> error
+			{Thought: "retry with short command", Action: schema.ActionThink}, // 2nd call -> success
+		},
+		errors: []error{
+			fmt.Errorf("anthropic: parse action: invalid JSON from LLM: unexpected end of JSON input"),
+			nil,
+		},
+	}
+
+	loop, events, _, _ := newTestLoop(target, mb)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go loop.Run(ctx)
+
+	deadline := time.After(8 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Type == agent.EventComplete {
+				if len(mb.inputs) < 2 {
+					t.Fatalf("expected at least 2 Think() calls, got %d", len(mb.inputs))
+				}
+				if !strings.Contains(mb.inputs[1].ToolOutput, "invalid or truncated JSON") {
+					t.Fatalf("expected retry hint in second Think() ToolOutput, got: %q", mb.inputs[1].ToolOutput)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout: expected completion after retry")
+		}
+	}
+}
+
 func TestLoop_Run_BrainError_MaxRetries_Fails(t *testing.T) {
 	target := agent.NewTarget(1, "10.0.0.1")
 	// 3 consecutive errors → should fail

--- a/internal/brain/anthropic.go
+++ b/internal/brain/anthropic.go
@@ -17,6 +17,7 @@ const (
 	defaultAnthropicBaseURL = "https://api.anthropic.com"
 	anthropicMessagesPath   = "/v1/messages"
 	anthropicVersion        = "2023-06-01"
+	anthropicThinkMaxTokens = 2048
 )
 
 type anthropicBrain struct {
@@ -38,7 +39,7 @@ func (b *anthropicBrain) Think(ctx context.Context, input Input) (*schema.Action
 
 	body := map[string]any{
 		"model":      b.cfg.Model,
-		"max_tokens": 1024,
+		"max_tokens": anthropicThinkMaxTokens,
 		"system":     buildSystemPromptForConfig(b.cfg),
 		"messages": []map[string]string{
 			{"role": "user", "content": prompt},

--- a/internal/brain/prompt.go
+++ b/internal/brain/prompt.go
@@ -68,6 +68,9 @@ SECURITY ASSESSMENT GUIDELINES:
 - Use run for standard reconnaissance and vulnerability verification
 - Use propose for credential testing, active exploitation, or post-access activities
 - The "command" field must be a full shell command (e.g. "nmap -sV -p- 10.0.0.5")
+- Keep "command" concise (target: <= 300 characters).
+- Never embed full report bodies or large documents in "command" (no huge heredoc payloads).
+- If detailed reporting is needed, use memory/think for summary and run a short command only.
 - Record important findings with the memory action
 - When you discover new hosts, use add_target to expand the assessment scope
 - Prefer targeted, precise commands over broad scans
@@ -479,6 +482,13 @@ func hasNonASCII(s string) bool {
 // jsonBlockRe は LLM がコードブロックで JSON を返した場合に抽出するパターン。
 var jsonBlockRe = regexp.MustCompile("(?s)```(?:json)?\\s*({.*?})\\s*```")
 
+const (
+	// Keep parse errors readable in logs/TUI by truncating raw model output.
+	maxActionParseErrorRawRunes = 800
+	// Oversized command payloads (e.g., full report heredoc) frequently cause JSON truncation.
+	maxActionCommandRunes = 600
+)
+
 // parseActionJSON は LLM のレスポンステキストから schema.Action を抽出・パースする。
 func parseActionJSON(text string) (*schema.Action, error) {
 	text = strings.TrimSpace(text)
@@ -497,12 +507,97 @@ func parseActionJSON(text string) (*schema.Action, error) {
 
 	var action schema.Action
 	if err := json.Unmarshal([]byte(text), &action); err != nil {
-		return nil, fmt.Errorf("invalid JSON from LLM: %w\nraw: %s", err, text)
+		if repaired, ok := repairLikelyTruncatedJSONObject(text); ok {
+			if err2 := json.Unmarshal([]byte(repaired), &action); err2 == nil {
+				if err3 := validateParsedAction(&action); err3 != nil {
+					return nil, err3
+				}
+				return &action, nil
+			}
+		}
+		return nil, fmt.Errorf("invalid JSON from LLM: %w\nraw: %s", err, truncateForError(text, maxActionParseErrorRawRunes))
 	}
 
-	if action.Action == "" {
-		return nil, fmt.Errorf("LLM response missing 'action' field: %s", text)
+	if err := validateParsedAction(&action); err != nil {
+		return nil, err
 	}
 
 	return &action, nil
+}
+
+func validateParsedAction(action *schema.Action) error {
+	if action.Action == "" {
+		return fmt.Errorf("LLM response missing 'action' field")
+	}
+
+	switch action.Action {
+	case schema.ActionRun, schema.ActionPropose:
+		cmd := strings.TrimSpace(action.Command)
+		if cmd == "" {
+			return fmt.Errorf("LLM response missing 'command' for action %q", action.Action)
+		}
+		if len([]rune(cmd)) > maxActionCommandRunes {
+			return fmt.Errorf(
+				"LLM command too long (%d > %d runes): use a concise command without embedding long report bodies",
+				len([]rune(cmd)),
+				maxActionCommandRunes,
+			)
+		}
+	}
+	return nil
+}
+
+func repairLikelyTruncatedJSONObject(s string) (string, bool) {
+	if s == "" {
+		return "", false
+	}
+
+	inString := false
+	escaped := false
+	braceBalance := 0
+
+	for _, r := range s {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch r {
+		case '\\':
+			if inString {
+				escaped = true
+			}
+		case '"':
+			inString = !inString
+		case '{':
+			if !inString {
+				braceBalance++
+			}
+		case '}':
+			if !inString && braceBalance > 0 {
+				braceBalance--
+			}
+		}
+	}
+
+	// Only auto-repair missing trailing braces when outside a string.
+	if inString || braceBalance <= 0 {
+		return "", false
+	}
+	return s + strings.Repeat("}", braceBalance), true
+}
+
+func truncateForError(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	rs := []rune(s)
+	if len(rs) <= maxRunes {
+		return s
+	}
+	const suffix = "...(truncated)"
+	suffixRunes := []rune(suffix)
+	if maxRunes <= len(suffixRunes) {
+		return string(rs[:maxRunes])
+	}
+	return string(rs[:maxRunes-len(suffixRunes)]) + suffix
 }

--- a/internal/brain/prompt_test.go
+++ b/internal/brain/prompt_test.go
@@ -243,6 +243,39 @@ func TestParseActionJSON_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestParseActionJSON_TruncatedMissingBrace_Repaired(t *testing.T) {
+	raw := `{"thought":"continue","action":"think"`
+	action, err := parseActionJSON(raw)
+	if err != nil {
+		t.Fatalf("parseActionJSON (truncated brace repair): %v", err)
+	}
+	if action.Action != "think" {
+		t.Errorf("Action: got %q, want %q", action.Action, "think")
+	}
+}
+
+func TestParseActionJSON_RunCommandTooLong(t *testing.T) {
+	raw := `{"thought":"report","action":"run","command":"` + strings.Repeat("A", maxActionCommandRunes+1) + `"}`
+	_, err := parseActionJSON(raw)
+	if err == nil {
+		t.Fatal("expected error for oversized command, got nil")
+	}
+	if !strings.Contains(err.Error(), "command too long") {
+		t.Fatalf("expected oversized command error, got: %v", err)
+	}
+}
+
+func TestParseActionJSON_ErrorRawIsTruncated(t *testing.T) {
+	raw := `{"thought":"x","action":"run","command":"` + strings.Repeat("A", maxActionParseErrorRawRunes+200)
+	_, err := parseActionJSON(raw)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "...(truncated)") {
+		t.Fatalf("expected truncated raw marker in error, got: %v", err)
+	}
+}
+
 func TestParseActionJSON_MissingActionField(t *testing.T) {
 	raw := `{"thought":"analyzing"}`
 	_, err := parseActionJSON(raw)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -87,6 +87,12 @@ type App struct {
 	selectIdx   int
 	selectCb    func(a *App, value string)
 
+	// Copy mode state (line-based selection over wrapped output lines).
+	copyCursor   int
+	copyAnchor   int
+	copyLastYank string
+	copyPrevMode InputMode
+
 	// Display state
 	logsExpanded bool
 	outputScroll int  // number of lines scrolled up from bottom in output pane
@@ -155,6 +161,8 @@ func NewApp(targets []*agent.Target) *App {
 		inputLines:      []string{""},
 		uiEvents:        make(chan uiEventMsg, 1024),
 		outputFollow:    true,
+		copyAnchor:      -1,
+		copyPrevMode:    ModeNormal,
 	}
 	a.typedInput.Store("")
 	return a
@@ -402,6 +410,17 @@ func (a *App) handleKeyEvent(e *tcell.EventKey) bool {
 		a.mu.Unlock()
 		return false
 
+	case tcell.KeyCtrlY:
+		if a.inputMode == ModeCopy {
+			a.yankCopySelectionLocked()
+			a.exitCopyModeLocked()
+		} else {
+			a.enterCopyModeLocked()
+		}
+		a.syncLegacyInputStateLocked()
+		a.mu.Unlock()
+		return false
+
 	case tcell.KeyCtrlC:
 		if a.inputMode == ModeConfirmQuit {
 			a.mu.Unlock()
@@ -418,6 +437,13 @@ func (a *App) handleKeyEvent(e *tcell.EventKey) bool {
 			a.mu.Unlock()
 			return true
 		}
+	}
+
+	if a.inputMode == ModeCopy {
+		a.handleCopyModeKeyLocked(e)
+		a.syncLegacyInputStateLocked()
+		a.mu.Unlock()
+		return false
 	}
 
 	switch e.Key() {
@@ -515,6 +541,305 @@ func (a *App) handleMouseEvent(e *tcell.EventMouse) bool {
 	changed = a.outputScroll != beforeScroll || a.outputFollow != beforeFollow
 	a.mu.Unlock()
 	return changed
+}
+
+func (a *App) enterCopyModeLocked() {
+	if a.inputMode == ModeCopy {
+		return
+	}
+	a.copyPrevMode = a.inputMode
+	a.inputMode = ModeCopy
+	a.copyAnchor = -1
+
+	width := a.width
+	if width <= 0 {
+		width = defaultWidth
+	}
+	lines := a.wrappedOutputLinesLocked(width)
+	if len(lines) == 0 {
+		a.copyCursor = 0
+		a.outputScroll = 0
+		a.outputFollow = true
+		return
+	}
+
+	cursor := len(lines) - 1 - a.outputScroll
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= len(lines) {
+		cursor = len(lines) - 1
+	}
+	a.copyCursor = cursor
+	a.ensureCopyCursorVisibleLocked(len(lines))
+}
+
+func (a *App) exitCopyModeLocked() {
+	if a.inputMode != ModeCopy {
+		return
+	}
+	restoreMode := a.copyPrevMode
+	if restoreMode == ModeCopy {
+		restoreMode = ModeNormal
+	}
+	a.inputMode = restoreMode
+	a.copyPrevMode = ModeNormal
+	a.copyAnchor = -1
+}
+
+func (a *App) handleCopyModeKeyLocked(e *tcell.EventKey) {
+	switch e.Key() {
+	case tcell.KeyEscape:
+		a.exitCopyModeLocked()
+		return
+	case tcell.KeyUp:
+		a.moveCopyCursorLocked(-1)
+		return
+	case tcell.KeyDown:
+		a.moveCopyCursorLocked(1)
+		return
+	case tcell.KeyPgUp:
+		a.moveCopyCursorLocked(-a.outputPageStepLocked())
+		return
+	case tcell.KeyPgDn:
+		a.moveCopyCursorLocked(a.outputPageStepLocked())
+		return
+	case tcell.KeyHome:
+		a.copyCursor = 0
+	case tcell.KeyEnd:
+		width := a.width
+		if width <= 0 {
+			width = defaultWidth
+		}
+		lines := a.wrappedOutputLinesLocked(width)
+		if len(lines) > 0 {
+			a.copyCursor = len(lines) - 1
+		}
+	case tcell.KeyRune:
+		switch strings.ToLower(string(e.Rune())) {
+		case "q":
+			a.exitCopyModeLocked()
+			return
+		case " ":
+			if a.copyAnchor >= 0 {
+				a.copyAnchor = -1
+			} else {
+				a.copyAnchor = a.copyCursor
+			}
+			return
+		case "y":
+			a.yankCopySelectionLocked()
+			a.exitCopyModeLocked()
+			return
+		}
+	default:
+		return
+	}
+
+	width := a.width
+	if width <= 0 {
+		width = defaultWidth
+	}
+	lines := a.wrappedOutputLinesLocked(width)
+	if len(lines) <= 0 {
+		a.copyCursor = 0
+		return
+	}
+	if a.copyCursor < 0 {
+		a.copyCursor = 0
+	}
+	if a.copyCursor >= len(lines) {
+		a.copyCursor = len(lines) - 1
+	}
+	a.ensureCopyCursorVisibleLocked(len(lines))
+}
+
+func (a *App) moveCopyCursorLocked(delta int) {
+	width := a.width
+	if width <= 0 {
+		width = defaultWidth
+	}
+	lines := a.wrappedOutputLinesLocked(width)
+	if len(lines) == 0 {
+		a.copyCursor = 0
+		return
+	}
+
+	a.copyCursor += delta
+	if a.copyCursor < 0 {
+		a.copyCursor = 0
+	}
+	if a.copyCursor >= len(lines) {
+		a.copyCursor = len(lines) - 1
+	}
+	a.ensureCopyCursorVisibleLocked(len(lines))
+}
+
+func (a *App) yankCopySelectionLocked() {
+	width := a.width
+	if width <= 0 {
+		width = defaultWidth
+	}
+	lines := a.wrappedOutputLinesLocked(width)
+	start, end, ok := a.copySelectionBoundsLocked(len(lines))
+	if !ok {
+		msg := "Nothing to yank."
+		if t := a.activeTargetLocked(); t != nil {
+			t.AddBlock(agent.NewSystemBlock(msg))
+		} else {
+			a.globalLogs = append(a.globalLogs, msg)
+		}
+		a.invalidateOutputCacheLocked()
+		return
+	}
+
+	buf := make([]string, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		buf = append(buf, lines[i].text)
+	}
+	yanked := strings.Join(buf, "\n")
+	a.copyLastYank = yanked
+	if a.screen != nil {
+		a.screen.SetClipboard([]byte(yanked))
+	}
+
+	msg := fmt.Sprintf("Yanked %d line(s) to clipboard (terminal support dependent).", end-start+1)
+	if t := a.activeTargetLocked(); t != nil {
+		t.AddBlock(agent.NewSystemBlock(msg))
+	} else {
+		a.globalLogs = append(a.globalLogs, msg)
+	}
+	a.invalidateOutputCacheLocked()
+}
+
+func (a *App) copySelectionBoundsLocked(total int) (int, int, bool) {
+	if total <= 0 {
+		return 0, 0, false
+	}
+
+	cursor := a.copyCursor
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= total {
+		cursor = total - 1
+	}
+
+	anchor := a.copyAnchor
+	if anchor < 0 || anchor >= total {
+		anchor = cursor
+	}
+
+	start := anchor
+	end := cursor
+	if start > end {
+		start, end = end, start
+	}
+	return start, end, true
+}
+
+func (a *App) ensureCopyCursorVisibleLocked(totalLines int) {
+	if totalLines <= 0 {
+		a.outputScroll = 0
+		a.outputFollow = true
+		return
+	}
+
+	w := a.width
+	if w <= 0 {
+		w = defaultWidth
+	}
+	h := a.height
+	if h <= 0 {
+		h = defaultHeight
+	}
+	outputHeight := a.outputPaneHeightLocked(w, h)
+	if outputHeight <= 0 {
+		return
+	}
+
+	maxScroll := totalLines - outputHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if a.outputScroll < 0 {
+		a.outputScroll = 0
+	}
+	if a.outputScroll > maxScroll {
+		a.outputScroll = maxScroll
+	}
+
+	start, end := outputWindowRange(totalLines, outputHeight, a.outputScroll)
+	if a.copyCursor < start {
+		newStart := a.copyCursor
+		if newStart < 0 {
+			newStart = 0
+		}
+		newEnd := newStart + outputHeight
+		if newEnd > totalLines {
+			newEnd = totalLines
+		}
+		a.outputScroll = totalLines - newEnd
+	} else if a.copyCursor >= end {
+		newEnd := a.copyCursor + 1
+		if newEnd > totalLines {
+			newEnd = totalLines
+		}
+		a.outputScroll = totalLines - newEnd
+	}
+
+	if a.outputScroll < 0 {
+		a.outputScroll = 0
+	}
+	if a.outputScroll > maxScroll {
+		a.outputScroll = maxScroll
+	}
+	a.outputFollow = a.outputScroll == 0
+}
+
+func (a *App) outputPaneHeightLocked(width, height int) int {
+	inputRows := a.inputRenderRowsLocked()
+	maxInputRows := height - 2 // divider + status
+	if maxInputRows < 1 {
+		maxInputRows = 1
+	}
+	if len(inputRows) > maxInputRows {
+		inputRows = inputRows[len(inputRows)-maxInputRows:]
+	}
+
+	reserved := 2 + len(inputRows) // divider + status + input rows
+	if reserved > height {
+		reserved = height
+	}
+	outputHeight := height - reserved
+	if outputHeight < 0 {
+		outputHeight = 0
+	}
+	return outputHeight
+}
+
+func (a *App) inputRenderRowsLocked() []inputRenderLine {
+	inputLines := cloneStrings(a.inputLines)
+	if len(inputLines) == 0 {
+		inputLines = []string{""}
+	}
+
+	rows := make([]inputRenderLine, 0, len(inputLines)+1)
+	if hint := a.modeHintLocked(); hint != "" {
+		rows = append(rows, inputRenderLine{text: hint, logical: -1})
+	}
+	for i, l := range inputLines {
+		prefix := ""
+		if i == 0 {
+			prefix = "> "
+		}
+		rows = append(rows, inputRenderLine{
+			text:    prefix + l,
+			logical: i,
+			prefix:  prefix,
+		})
+	}
+	return rows
 }
 
 func (a *App) ensureInputBufferLocked() {
@@ -913,6 +1238,10 @@ func (a *App) draw() {
 	}
 
 	status := ""
+	copyMode := false
+	copyCursor := -1
+	copyStart, copyEnd := 0, 0
+	copyHasRange := false
 	a.mu.Lock()
 	if outputScroll != outputScrollOrig || outputFollow != outputFollowOrig {
 		a.outputScroll = outputScroll
@@ -921,9 +1250,18 @@ func (a *App) draw() {
 	a.outputPrevWrapped = len(outputLines)
 	a.outputPrevWrapWidth = w
 	status = a.buildStatusTextLocked()
+	copyMode = a.inputMode == ModeCopy
+	copyCursor = a.copyCursor
+	copyStart, copyEnd, copyHasRange = a.copySelectionBoundsLocked(len(outputLines))
 	a.mu.Unlock()
 
-	visibleOutput := windowOutputLines(outputLines, outputHeight, outputScroll)
+	visibleStart, visibleEnd := outputWindowRange(len(outputLines), outputHeight, outputScroll)
+	visibleOutput := []outputLine{}
+	if visibleStart >= 0 && visibleEnd >= visibleStart {
+		visibleOutput = outputLines[visibleStart:visibleEnd]
+	} else {
+		visibleStart = 0
+	}
 	defaultStyle := tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorBlack)
 	dividerStyle := tcell.StyleDefault.Foreground(tcell.ColorGray).Background(tcell.ColorBlack)
 	statusStyle := tcell.StyleDefault.Foreground(tcell.ColorLightBlue).Background(tcell.ColorBlack)
@@ -938,6 +1276,15 @@ func (a *App) draw() {
 			style = spinnerStyle
 		case outputLineUser:
 			style = userLineStyle
+		}
+		if copyMode {
+			absIdx := visibleStart + y
+			if copyHasRange && absIdx >= copyStart && absIdx <= copyEnd {
+				style = style.Reverse(true)
+			}
+			if absIdx == copyCursor {
+				style = style.Reverse(true).Underline(true)
+			}
 		}
 		drawLine(s, y, line.text, style, w)
 	}
@@ -1186,6 +1533,8 @@ func (a *App) modeHintLocked() string {
 		}
 	case ModeConfirmQuit:
 		return "Quit Pentecter? [y/n]"
+	case ModeCopy:
+		return "copy mode [up/down, space mark, y yank, q/esc close]"
 	}
 	return ""
 }
@@ -1272,28 +1621,36 @@ func wrapLine(line string, width int) []string {
 }
 
 func windowOutputLines(lines []outputLine, n int, scroll int) []outputLine {
-	if n <= 0 {
+	start, end := outputWindowRange(len(lines), n, scroll)
+	if start < 0 || end < 0 {
 		return nil
+	}
+	return lines[start:end]
+}
+
+func outputWindowRange(total, n, scroll int) (start, end int) {
+	if n <= 0 {
+		return -1, -1
 	}
 	if scroll < 0 {
 		scroll = 0
 	}
-	if len(lines) <= n {
-		return lines
+	if total <= n {
+		return 0, total
 	}
 
-	end := len(lines) - scroll
+	end = total - scroll
 	if end < 0 {
 		end = 0
 	}
-	start := end - n
+	start = end - n
 	if start < 0 {
 		start = 0
 	}
 	if end < start {
 		end = start
 	}
-	return lines[start:end]
+	return start, end
 }
 
 func cloneStrings(in []string) []string {
@@ -1407,6 +1764,19 @@ func (a *App) buildStatusTextLocked() string {
 	if a.outputScroll > 0 {
 		parts = append(parts, fmt.Sprintf("scroll:%d (PgDn/Ctrl+End)", a.outputScroll))
 	}
+	if a.inputMode == ModeCopy {
+		width := a.width
+		if width <= 0 {
+			width = defaultWidth
+		}
+		lines := a.wrappedOutputLinesLocked(width)
+		start, end, ok := a.copySelectionBoundsLocked(len(lines))
+		if ok {
+			parts = append(parts, fmt.Sprintf("COPY %d-%d y:yank q:exit", start+1, end+1))
+		} else {
+			parts = append(parts, "COPY y:yank q:exit")
+		}
+	}
 
 	if len(parts) == 0 {
 		return ""
@@ -1513,7 +1883,7 @@ func (a *App) printWelcome() {
 	}
 	lines = append(lines,
 		"Input: ip/domain or /target HOST",
-		"Commands: /targets, /model, /approve, /attackdata, /skip-recon, /fold, /status",
+		"Commands: /targets, /model, /approve, /attackdata, /copy, /skip-recon, /fold, /status",
 	)
 	if a.CurrentModel != "" {
 		lines = append(lines, fmt.Sprintf("Model: %s/%s", a.CurrentProvider, a.CurrentModel))

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
+
 	"github.com/0x6d61/pentecter/internal/agent"
 )
 
@@ -65,7 +67,7 @@ func TestBuildPrompt_NoTarget(t *testing.T) {
 	if !strings.Contains(prompt, ">") {
 		t.Error("prompt should contain > character")
 	}
-	// Simple prompt — no dividers
+	// Simple prompt - no dividers
 	if strings.Contains(prompt, "─") {
 		t.Error("prompt should not contain dividers")
 	}
@@ -197,7 +199,7 @@ func TestPrintWelcome_NoTargets(t *testing.T) {
 	if output == "" {
 		t.Error("expected non-empty welcome output")
 	}
-	if !strings.Contains(output, "Commands: /targets, /model, /approve, /attackdata, /skip-recon, /fold, /status") {
+	if !strings.Contains(output, "Commands: /targets, /model, /approve, /attackdata, /copy, /skip-recon, /fold, /status") {
 		t.Error("welcome output should include command list")
 	}
 	if !strings.Contains(output, "Input: ip/domain or /target HOST") {
@@ -217,7 +219,7 @@ func TestPrintWelcome_WithTargets(t *testing.T) {
 	if output == "" {
 		t.Error("expected non-empty welcome output")
 	}
-	if !strings.Contains(output, "Commands: /targets, /model, /approve, /attackdata, /skip-recon, /fold, /status") {
+	if !strings.Contains(output, "Commands: /targets, /model, /approve, /attackdata, /copy, /skip-recon, /fold, /status") {
 		t.Error("welcome output should include command list")
 	}
 	if !strings.Contains(output, "Input: ip/domain or /target HOST") {
@@ -300,7 +302,7 @@ func TestPromptEchoLines_EmptyText(t *testing.T) {
 func TestPromptEchoLines_WrappingText(t *testing.T) {
 	a := NewApp(nil)
 	a.width = 20
-	// blank(1) + "> " + 30 chars = 32 → ceil(32/20) = 2 input lines
+	// blank(1) + "> " + 30 chars = 32 -> ceil(32/20) = 2 input lines
 	// 1 + 2 = 3
 	longText := strings.Repeat("x", 30)
 	n := a.promptEchoLines(longText)
@@ -312,7 +314,7 @@ func TestPromptEchoLines_WrappingText(t *testing.T) {
 func TestPromptEchoLines_ExactWidthNoWrap(t *testing.T) {
 	a := NewApp(nil)
 	a.width = 80
-	// blank(1) + "> " + 78 chars = 80 → 1 input line
+	// blank(1) + "> " + 78 chars = 80 -> 1 input line
 	// 1 + 1 = 2
 	text := strings.Repeat("a", 78)
 	n := a.promptEchoLines(text)
@@ -324,7 +326,7 @@ func TestPromptEchoLines_ExactWidthNoWrap(t *testing.T) {
 func TestPromptEchoLines_OneCharOverWidth(t *testing.T) {
 	a := NewApp(nil)
 	a.width = 80
-	// blank(1) + "> " + 79 chars = 81 → ceil(81/80) = 2 input lines
+	// blank(1) + "> " + 79 chars = 81 -> ceil(81/80) = 2 input lines
 	// 1 + 2 = 3
 	text := strings.Repeat("a", 79)
 	n := a.promptEchoLines(text)
@@ -335,14 +337,14 @@ func TestPromptEchoLines_OneCharOverWidth(t *testing.T) {
 
 func TestClearPromptEcho_TestMode(t *testing.T) {
 	a := newTestApp(nil)
-	// Should not panic in test mode (testWriter != nil → no-op)
+	// Should not panic in test mode (testWriter != nil -> no-op)
 	a.clearPromptEcho("test")
 }
 
 func TestBuildStatusText_Empty(t *testing.T) {
 	a := NewApp(nil)
 	a.width = 80
-	// No target, no model → buildStatusText() == ""
+	// No target, no model -> buildStatusText() == ""
 	status := a.buildStatusText()
 	if status != "" {
 		t.Errorf("expected empty status, got %q", status)
@@ -410,9 +412,9 @@ func TestPromptEchoLines_MultilineMode(t *testing.T) {
 	a.width = 80
 	a.multilineMode = true
 
-	// Empty prompt + text → promptEchoLines should return 1
+	// Empty prompt + text -> promptEchoLines should return 1
 	n := a.promptEchoLines("hello")
-	// "hello" = 5 chars → fits in 80 cols → 1 line
+	// "hello" = 5 chars -> fits in 80 cols -> 1 line
 	if n != 1 {
 		t.Errorf("expected 1 line for multiline prompt, got %d", n)
 	}
@@ -499,27 +501,24 @@ func TestPrintAttackData_BoxOutput(t *testing.T) {
 	a.testWriter = &buf
 	a.width = 60
 
-	treeOutput := "10.0.0.5\n├── :22 (ssh) [Done]\n└── :80 (http) [InProgress]"
+	treeOutput := "10.0.0.5\n+-- :22 (ssh) [Done]\n+-- :80 (http) [InProgress]"
 	a.printAttackData("10.0.0.5", treeOutput)
 
 	output := buf.String()
-	// Should contain the title
 	if !strings.Contains(output, "ATTACK DATA") {
 		t.Error("expected output to contain 'ATTACK DATA'")
 	}
 	if !strings.Contains(output, "10.0.0.5") {
 		t.Error("expected output to contain host '10.0.0.5'")
 	}
-	// Should contain the tree content
 	if !strings.Contains(output, ":22") {
 		t.Error("expected output to contain port ':22'")
 	}
 	if !strings.Contains(output, ":80") {
 		t.Error("expected output to contain port ':80'")
 	}
-	// Should contain rounded border characters
-	if !strings.Contains(output, "╭") || !strings.Contains(output, "╰") {
-		t.Error("expected output to contain rounded border characters")
+	if !strings.Contains(output, "+") || !strings.Contains(output, "|") {
+		t.Error("expected output to contain ASCII box border characters")
 	}
 }
 
@@ -529,12 +528,131 @@ func TestPrintAttackData_NarrowWidth(t *testing.T) {
 	a.testWriter = &buf
 	a.width = 30
 
-	a.printAttackData("host", "tree")
+	a.printAttackData("host", "this-is-a-very-long-line-that-must-be-clipped")
 
-	output := buf.String()
-	// Should still produce bordered output
-	if !strings.Contains(output, "╭") || !strings.Contains(output, "╰") {
+	output := strings.TrimSuffix(buf.String(), "\n")
+	if !strings.Contains(output, "+") || !strings.Contains(output, "|") {
 		t.Error("expected bordered output even at narrow width")
+	}
+	for i, line := range strings.Split(output, "\n") {
+		if w := displayWidth(line); w > a.width {
+			t.Fatalf("line %d width exceeds app width: got %d > %d (%q)", i, w, a.width, line)
+		}
+	}
+}
+
+func TestPrintAttackData_FullWidthKeepsBoxAligned(t *testing.T) {
+	var buf bytes.Buffer
+	a := NewApp(nil)
+	a.testWriter = &buf
+	a.width = 80
+
+	treeOutput := "/\n+-- finding: \u7ba1\u7406\u8005\u30d1\u30cd\u30eb \u8a8d\u8a3c\u56de\u907f"
+	a.printAttackData("10.0.0.5", treeOutput)
+
+	output := strings.TrimSuffix(buf.String(), "\n")
+	lines := strings.Split(output, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 lines, got %d", len(lines))
+	}
+	wantW := displayWidth(lines[0])
+	for i, line := range lines {
+		if gotW := displayWidth(line); gotW != wantW {
+			t.Fatalf("line %d width mismatch: got %d, want %d (%q)", i, gotW, wantW, line)
+		}
+	}
+}
+
+func TestPrintAttackData_SanitizesAndTruncatesRows(t *testing.T) {
+	var buf bytes.Buffer
+	a := NewApp(nil)
+	a.testWriter = &buf
+	a.width = 28
+
+	treeOutput := "finding: <html><body>very long long long payload</body></html>\nrow\twith\rcontrols\x07bell"
+	a.printAttackData("host", treeOutput)
+
+	output := strings.TrimSuffix(buf.String(), "\n")
+	if strings.Contains(output, "\t") || strings.Contains(output, "\r") || strings.Contains(output, "\x07") {
+		t.Fatal("expected control/tab characters to be sanitized in attack data output")
+	}
+	if !strings.Contains(output, "...") {
+		t.Fatal("expected long row to be truncated with ellipsis")
+	}
+	for i, line := range strings.Split(output, "\n") {
+		if w := displayWidth(line); w > a.width {
+			t.Fatalf("line %d width exceeds app width: got %d > %d (%q)", i, w, a.width, line)
+		}
+	}
+}
+
+func TestHandleKeyEvent_CtrlY_EntersCopyMode(t *testing.T) {
+	a := NewApp(nil)
+	a.width = 80
+	a.height = 24
+	a.globalLogs = []string{"alpha", "beta", "gamma"}
+
+	quit := a.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlY, 0, tcell.ModNone))
+	if quit {
+		t.Fatal("Ctrl+Y should not request quit")
+	}
+	if a.inputMode != ModeCopy {
+		t.Fatalf("expected ModeCopy after Ctrl+Y, got %d", a.inputMode)
+	}
+}
+
+func TestCopyMode_ExitRestoresPreviousMode(t *testing.T) {
+	a := NewApp(nil)
+	a.width = 80
+	a.height = 24
+	a.inputMode = ModeProposal
+	a.globalLogs = []string{"alpha", "beta"}
+
+	quit := a.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlY, 0, tcell.ModNone))
+	if quit {
+		t.Fatal("Ctrl+Y should not request quit")
+	}
+	if a.inputMode != ModeCopy {
+		t.Fatalf("expected ModeCopy after Ctrl+Y, got %d", a.inputMode)
+	}
+
+	quit = a.handleKeyEvent(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	if quit {
+		t.Fatal("Esc in copy mode should not request quit")
+	}
+	if a.inputMode != ModeProposal {
+		t.Fatalf("expected mode to restore to ModeProposal, got %d", a.inputMode)
+	}
+}
+
+func TestCopyMode_YankSelectionToClipboard(t *testing.T) {
+	sim := tcell.NewSimulationScreen("")
+	if err := sim.Init(); err != nil {
+		t.Fatalf("simulation screen init failed: %v", err)
+	}
+	defer sim.Fini()
+
+	a := NewApp(nil)
+	a.SetScreen(sim)
+	a.width = 80
+	a.height = 24
+	a.globalLogs = []string{"line-a", "line-b", "line-c"}
+
+	a.mu.Lock()
+	a.enterCopyModeLocked()
+	if a.copyCursor != 2 {
+		a.mu.Unlock()
+		t.Fatalf("expected copy cursor at latest line index 2, got %d", a.copyCursor)
+	}
+	a.copyAnchor = a.copyCursor
+	a.moveCopyCursorLocked(-1)
+	a.yankCopySelectionLocked()
+	a.exitCopyModeLocked()
+	a.mu.Unlock()
+
+	got := string(sim.GetClipboardData())
+	if got != "line-b\nline-c" {
+		t.Fatalf("unexpected yanked clipboard content: %q", got)
 	}
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -38,6 +38,9 @@ func (a *App) handleCommand(fullText string) bool {
 	case "/status":
 		a.printStatusLine()
 		return true
+	case "/copy":
+		a.handleCopyCommand()
+		return true
 	default:
 		return false
 	}
@@ -254,4 +257,11 @@ func (a *App) handleSkipReconCommand() {
 	pending := rt.CountPending()
 	rt.Unlock()
 	a.logSystem(fmt.Sprintf("RECON phase unlocked (%d pending tasks skipped). Agent will proceed to ANALYZE.", pending))
+}
+
+// handleCopyCommand enters log copy mode.
+func (a *App) handleCopyCommand() {
+	a.mu.Lock()
+	a.enterCopyModeLocked()
+	a.mu.Unlock()
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -18,6 +18,7 @@ const (
 	ModeSelect                       // numbered selection UI
 	ModeProposal                     // y/n/e proposal approval
 	ModeConfirmQuit                  // y/n quit confirmation
+	ModeCopy                         // log copy/select mode
 )
 
 // SelectOption represents a single option in a selection UI.
@@ -42,6 +43,9 @@ func (a *App) handleInputLine(line string) bool {
 		return false
 	case ModeSelect:
 		a.handleSelectInput(line)
+		return false
+	case ModeCopy:
+		a.handleCopyInput(line)
 		return false
 	default:
 		a.handleNormalInput(line)
@@ -146,6 +150,21 @@ func (a *App) handleSelectInput(line string) {
 
 	if cb != nil {
 		cb(a, value)
+	}
+}
+
+// handleCopyInput processes line input while copy mode is active.
+func (a *App) handleCopyInput(line string) {
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "q", "quit", "exit":
+		a.mu.Lock()
+		a.exitCopyModeLocked()
+		a.mu.Unlock()
+	case "y", "yes", "yank":
+		a.mu.Lock()
+		a.yankCopySelectionLocked()
+		a.exitCopyModeLocked()
+		a.mu.Unlock()
 	}
 }
 

--- a/internal/tui/input_test.go
+++ b/internal/tui/input_test.go
@@ -286,6 +286,17 @@ func TestHandleCommand_Status(t *testing.T) {
 	a.handleCommand("/status")
 }
 
+func TestHandleCommand_Copy(t *testing.T) {
+	a := newTestApp(nil)
+
+	if !a.handleCommand("/copy") {
+		t.Fatal("expected /copy command to be handled")
+	}
+	if a.inputMode != ModeCopy {
+		t.Fatalf("expected ModeCopy after /copy, got %d", a.inputMode)
+	}
+}
+
 func TestHandleTargetsCommand_SwitchToProposalTarget(t *testing.T) {
 	t1 := agent.NewTarget(1, "10.0.0.1")
 	t2 := agent.NewTarget(2, "10.0.0.2")

--- a/internal/tui/output.go
+++ b/internal/tui/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/0x6d61/pentecter/internal/agent"
 )
@@ -82,40 +83,47 @@ func (a *App) clearAndReprint() {
 
 // printAttackData appends attack data tree output as a system block.
 func (a *App) printAttackData(host, treeOutput string) {
-	title := "ATTACK DATA - " + host
-	body := strings.Split(treeOutput, "\n")
-	rows := append([]string{title}, body...)
+	a.mu.Lock()
+	width := a.width
+	a.mu.Unlock()
+	if width <= 0 {
+		width = defaultWidth
+	}
 
-	maxW := 0
+	maxContentWidth := width - 4 // "| " + " |"
+	if maxContentWidth < 1 {
+		maxContentWidth = 1
+	}
+
+	body := strings.Split(treeOutput, "\n")
+	rows := make([]string, 0, len(body)+1)
+	rows = append(rows, trimToDisplayWidth(sanitizeAttackDataRow("ATTACK DATA - "+host), maxContentWidth))
+	for _, row := range body {
+		rows = append(rows, trimToDisplayWidth(sanitizeAttackDataRow(row), maxContentWidth))
+	}
+
+	maxW := 1
 	for _, row := range rows {
-		if w := runeLen(row); w > maxW {
+		if w := displayWidth(row); w > maxW {
 			maxW = w
 		}
 	}
-	if maxW < 1 {
-		maxW = 1
-	}
 
 	var b strings.Builder
-	b.WriteString("╭")
-	b.WriteString(strings.Repeat("─", maxW+2))
-	b.WriteString("╮\n")
+	b.WriteString("+")
+	b.WriteString(strings.Repeat("-", maxW+2))
+	b.WriteString("+\n")
 	for i, row := range rows {
-		pad := maxW - runeLen(row)
-		if pad < 0 {
-			pad = 0
-		}
-		b.WriteString("│ ")
-		b.WriteString(row)
-		b.WriteString(strings.Repeat(" ", pad))
-		b.WriteString(" │")
+		b.WriteString("| ")
+		b.WriteString(padRightDisplayWidth(row, maxW))
+		b.WriteString(" |")
 		if i < len(rows)-1 {
 			b.WriteString("\n")
 		}
 	}
-	b.WriteString("\n╰")
-	b.WriteString(strings.Repeat("─", maxW+2))
-	b.WriteString("╯")
+	b.WriteString("\n+")
+	b.WriteString(strings.Repeat("-", maxW+2))
+	b.WriteString("+")
 
 	msg := b.String()
 
@@ -131,6 +139,76 @@ func (a *App) printAttackData(host, treeOutput string) {
 		_, _ = fmt.Fprintln(a.testWriter, msg)
 	}
 	a.mu.Unlock()
+}
+
+func sanitizeAttackDataRow(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	lastWasSpace := false
+	for _, r := range s {
+		switch {
+		case r == '\r' || r == '\n' || r == '\t':
+			if !lastWasSpace {
+				b.WriteByte(' ')
+				lastWasSpace = true
+			}
+		case unicode.IsControl(r):
+			// Drop control characters from display-only output.
+		default:
+			b.WriteRune(r)
+			lastWasSpace = r == ' '
+		}
+	}
+	return strings.TrimRight(b.String(), " ")
+}
+
+func trimToDisplayWidth(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if displayWidth(s) <= maxWidth {
+		return s
+	}
+
+	const ellipsis = "..."
+	ellipsisWidth := displayWidth(ellipsis)
+
+	limit := maxWidth
+	appendEllipsis := false
+	if maxWidth > ellipsisWidth {
+		limit = maxWidth - ellipsisWidth
+		appendEllipsis = true
+	}
+
+	var b strings.Builder
+	curW := 0
+	for _, r := range s {
+		rw := displayWidth(string(r))
+		if rw == 0 {
+			b.WriteRune(r)
+			continue
+		}
+		if curW+rw > limit {
+			break
+		}
+		b.WriteRune(r)
+		curW += rw
+	}
+	if appendEllipsis {
+		b.WriteString(ellipsis)
+	}
+	return b.String()
+}
+
+func padRightDisplayWidth(s string, width int) string {
+	pad := width - displayWidth(s)
+	if pad <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", pad)
 }
 
 // printStatusLine writes current status into the log stream.


### PR DESCRIPTION
## Summary
- harden Brain action JSON parsing and retry hints for truncated/invalid LLM responses
- increase Anthropic think max tokens and add guardrails for oversized commands
- add TUI log copy mode (/copy, Ctrl+Y, selection + yank) and improve AttackData rendering for wide/unicode content
- fix copy mode exit to restore the previous input mode instead of always forcing normal mode

## Test
- go test ./internal/tui -count=1
- go test ./...