### PR TITLE
openrouter: dynamic /model selection and thinking display fixes

### DIFF
--- a/cmd/pentecter/main.go
+++ b/cmd/pentecter/main.go
@@ -27,7 +27,7 @@ func main() {
 	_ = godotenv.Load()
 
 	var (
-		provider    = flag.String("provider", "", "LLM provider: anthropic, openai, ollama (auto-detect if empty)")
+		provider    = flag.String("provider", "openrouter", "LLM provider (fixed: openrouter)")
 		model       = flag.String("model", "", "Model name (default: provider's default)")
 		autoApprove = flag.Bool("auto-approve", false, "Auto-approve all commands without proposal")
 	)
@@ -42,16 +42,14 @@ Flags:
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, `
 Environment:
-  ANTHROPIC_API_KEY          Anthropic API key
-  CLAUDE_CODE_OAUTH_TOKEN    Claude Code OAuth token (claude setup-token)
-  OPENAI_API_KEY        OpenAI API key
-  OLLAMA_BASE_URL       Ollama server URL (default: http://localhost:11434)
-  OLLAMA_MODEL          Ollama model name (default: llama3.2)
+  OPENROUTER_API_KEY    OpenRouter API key
+  OPENROUTER_BASE_URL   OpenRouter API base URL (default: https://openrouter.ai/api/v1)
+  OPENROUTER_MODEL      OpenRouter model (default: openai/gpt-4o-mini)
 
 Examples:
   pentecter                                          # Start without targets (add via chat)
   pentecter 10.0.0.5                                 # Start with a target
-  pentecter -provider ollama 10.0.0.5 10.0.0.8       # Multiple targets
+  pentecter -provider openrouter 10.0.0.5 10.0.0.8   # Multiple targets
 
 Chat commands:
   10.0.0.5             Enter an IP address to add a target
@@ -62,17 +60,18 @@ Chat commands:
 	flag.Parse()
 
 	// --- Brain ---
-	// Auto-detect provider if not specified
 	selectedProvider := brain.Provider(*provider)
-	if *provider == "" {
-		detected := brain.DetectAvailableProviders()
-		if len(detected) == 0 {
-			fmt.Fprintln(os.Stderr, "No LLM provider detected. Set one of:")
-			fmt.Fprintln(os.Stderr, "  ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, OPENAI_API_KEY, or OLLAMA_BASE_URL")
-			os.Exit(1)
-		}
-		selectedProvider = detected[0]
-		fmt.Fprintf(os.Stderr, "Auto-detected provider: %s\n", selectedProvider)
+	if selectedProvider == "" {
+		selectedProvider = brain.ProviderOpenRouter
+	}
+	if selectedProvider != brain.ProviderOpenRouter {
+		fmt.Fprintf(
+			os.Stderr,
+			"Unsupported provider %q. Only %q is allowed.\n",
+			selectedProvider,
+			brain.ProviderOpenRouter,
+		)
+		os.Exit(1)
 	}
 
 	// --- Tools ---（Brain より先にロードし、ツール名をシステムプロンプトに注入する）
@@ -128,7 +127,7 @@ Chat commands:
 	}
 
 	// --- SubBrain for SmartSubAgent ---
-	// Defaults to same config as main brain; override with SUBAGENT_MODEL / SUBAGENT_PROVIDER.
+	// Defaults to same config as main brain; override with SUBAGENT_MODEL.
 	// IsSubAgent = true により SubAgent 用のシンプルなプロンプトが使われる
 	// （spawn_task 等の無限ループを防ぐ）。
 	subBrainCfg := brainCfg // copy main config
@@ -138,17 +137,8 @@ Chat commands:
 		subBrainCfg.Model = model
 	}
 	if provider := os.Getenv("SUBAGENT_PROVIDER"); provider != "" {
-		subBrainCfg.Provider = brain.Provider(provider)
-		// Reload config for the new provider
-		reloaded, err := brain.LoadConfig(brain.ConfigHint{
-			Provider: brain.Provider(provider),
-			Model:    subBrainCfg.Model,
-		})
-		if err == nil {
-			subBrainCfg = reloaded
-			subBrainCfg.ToolNames = toolNames
-			subBrainCfg.IsSubAgent = true
-			subBrainCfg.IsEventDrivenMain = false
+		if brain.Provider(provider) != brain.ProviderOpenRouter {
+			log.Printf("SUBAGENT_PROVIDER=%q ignored: only openrouter is supported", provider)
 		}
 	}
 	subBrain, err := brain.New(subBrainCfg)

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -1,5 +1,5 @@
 // Package brain は LLM クライアントを共通インターフェースで抽象化する。
-// Anthropic（API キー）、OpenAI、Ollama をサポートする。
+// Anthropic（API キー）、OpenAI、Ollama、OpenRouter をサポートする。
 package brain
 
 import (
@@ -17,10 +17,14 @@ type Provider string
 const (
 	ProviderAnthropic Provider = "anthropic"
 	ProviderOpenAI    Provider = "openai"
+	// ProviderOpenRouter は OpenAI 互換 API 経由で OpenRouter に接続する。
+	ProviderOpenRouter Provider = "openrouter"
 	// ProviderOllama は OpenAI 互換 API 経由でローカル/リモートの Ollama サーバーに接続する。
 	// API キー不要。OLLAMA_BASE_URL でサーバーを指定する（デフォルト: http://localhost:11434）。
 	ProviderOllama Provider = "ollama"
 )
+
+const defaultOpenRouterBaseURL = "https://openrouter.ai/api/v1"
 
 // AuthType は認証方式を識別する。
 type AuthType string
@@ -117,6 +121,16 @@ func New(cfg Config) (Brain, error) {
 		}
 		return newOpenAIBrain(cfg)
 
+	case ProviderOpenRouter:
+		if cfg.Token == "" {
+			return nil, errors.New("brain: OpenRouter API key is required")
+		}
+		if cfg.BaseURL == "" {
+			cfg.BaseURL = defaultOpenRouterBaseURL
+		}
+		cfg.BaseURL = ensureV1Path(cfg.BaseURL)
+		return newOpenRouterBrain(cfg)
+
 	case ProviderOllama:
 		// Ollama は認証不要。Token が空でも動く。
 		if cfg.Token == "" {
@@ -129,7 +143,10 @@ func New(cfg Config) (Brain, error) {
 		return newOllamaBrain(cfg) // 変更に強い薄いラッパー経由で実行
 
 	default:
-		return nil, fmt.Errorf("brain: unknown provider %q (supported: anthropic, openai, ollama)", cfg.Provider)
+		return nil, fmt.Errorf(
+			"brain: unknown provider %q (supported: anthropic, openai, openrouter, ollama)",
+			cfg.Provider,
+		)
 	}
 }
 
@@ -187,6 +204,11 @@ type ConfigHint struct {
 // OpenAI:
 //  1. OPENAI_API_KEY          → AuthAPIKey
 //
+// OpenRouter:
+//  1. OPENROUTER_API_KEY      → AuthAPIKey
+//  2. OPENROUTER_BASE_URL     → BaseURL（デフォルト: https://openrouter.ai/api/v1）
+//  3. OPENROUTER_MODEL        → Model（デフォルト: openai/gpt-4o-mini）
+//
 // Ollama:
 //  1. OLLAMA_BASE_URL         → サーバー URL（デフォルト: http://localhost:11434）
 //  2. 認証不要
@@ -227,6 +249,31 @@ func LoadConfig(hint ConfigHint) (Config, error) {
 		}
 		return cfg, errors.New(
 			"brain: OpenAI credentials not found, set OPENAI_API_KEY",
+		)
+
+	case ProviderOpenRouter:
+		if cfg.BaseURL == "" {
+			cfg.BaseURL = os.Getenv("OPENROUTER_BASE_URL")
+		}
+		if cfg.BaseURL == "" {
+			cfg.BaseURL = defaultOpenRouterBaseURL
+		}
+		cfg.BaseURL = ensureV1Path(cfg.BaseURL)
+
+		if cfg.Model == "" {
+			cfg.Model = os.Getenv("OPENROUTER_MODEL")
+		}
+		if cfg.Model == "" {
+			cfg.Model = "openai/gpt-4o-mini"
+		}
+
+		if key := os.Getenv("OPENROUTER_API_KEY"); key != "" {
+			cfg.Token = key
+			cfg.AuthType = AuthAPIKey
+			return cfg, nil
+		}
+		return cfg, errors.New(
+			"brain: OpenRouter credentials not found, set OPENROUTER_API_KEY",
 		)
 
 	case ProviderOllama:

--- a/internal/brain/openrouter.go
+++ b/internal/brain/openrouter.go
@@ -1,0 +1,33 @@
+package brain
+
+import (
+	"context"
+
+	"github.com/0x6d61/pentecter/pkg/schema"
+)
+
+// openRouterBrain は OpenRouter の OpenAI 互換 API を使う Brain 実装。
+type openRouterBrain struct {
+	inner *openAIBrain
+}
+
+func newOpenRouterBrain(cfg Config) (*openRouterBrain, error) {
+	inner, err := newOpenAIBrain(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &openRouterBrain{inner: inner}, nil
+}
+
+// Provider はプロバイダー名を返す。
+func (b *openRouterBrain) Provider() string { return string(ProviderOpenRouter) }
+
+// Think は OpenRouter に思考させる。OpenAI 互換 API 経由で委譲する。
+func (b *openRouterBrain) Think(ctx context.Context, input Input) (*schema.Action, error) {
+	return b.inner.Think(ctx, input)
+}
+
+// ExtractTarget はユーザーテキストからターゲットホストを抽出する。
+func (b *openRouterBrain) ExtractTarget(ctx context.Context, userText string) (string, string, error) {
+	return b.inner.ExtractTarget(ctx, userText)
+}

--- a/internal/brain/openrouter_models.go
+++ b/internal/brain/openrouter_models.go
@@ -1,0 +1,81 @@
+package brain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// OpenRouterModel is the minimal model metadata used by /model command.
+type OpenRouterModel struct {
+	ID   string
+	Name string
+}
+
+type openRouterModelsResponse struct {
+	Data []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"data"`
+}
+
+// FetchOpenRouterModels fetches available models from OpenRouter API.
+func FetchOpenRouterModels(ctx context.Context) ([]OpenRouterModel, error) {
+	cfg, err := LoadConfig(ConfigHint{Provider: ProviderOpenRouter})
+	if err != nil {
+		return nil, err
+	}
+
+	base := ensureV1Path(cfg.BaseURL)
+	url := strings.TrimRight(base, "/") + "/models"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("openrouter: create models request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openrouter: request models: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("openrouter: models API error %d", resp.StatusCode)
+	}
+
+	var payload openRouterModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("openrouter: decode models response: %w", err)
+	}
+
+	models := make([]OpenRouterModel, 0, len(payload.Data))
+	seen := make(map[string]struct{}, len(payload.Data))
+	for _, m := range payload.Data {
+		id := strings.TrimSpace(m.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		models = append(models, OpenRouterModel{
+			ID:   id,
+			Name: strings.TrimSpace(m.Name),
+		})
+	}
+
+	sort.Slice(models, func(i, j int) bool {
+		return strings.ToLower(models[i].ID) < strings.ToLower(models[j].ID)
+	})
+
+	return models, nil
+}

--- a/internal/brain/openrouter_models_test.go
+++ b/internal/brain/openrouter_models_test.go
@@ -1,0 +1,46 @@
+package brain_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/0x6d61/pentecter/internal/brain"
+)
+
+func TestFetchOpenRouterModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/v1/models" {
+			http.Error(w, "bad path", http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id": "openai/gpt-4o-mini", "name": "GPT-4o Mini"},
+				{"id": "anthropic/claude-3.5-sonnet", "name": "Claude 3.5 Sonnet"},
+				{"id": "openai/gpt-4o-mini", "name": "dup"}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-test")
+	t.Setenv("OPENROUTER_BASE_URL", srv.URL+"/v1")
+
+	models, err := brain.FetchOpenRouterModels(context.Background())
+	if err != nil {
+		t.Fatalf("FetchOpenRouterModels: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 unique models, got %d", len(models))
+	}
+	if models[0].ID != "anthropic/claude-3.5-sonnet" {
+		t.Fatalf("expected sorted models, first=%q", models[0].ID)
+	}
+}

--- a/internal/brain/openrouter_test.go
+++ b/internal/brain/openrouter_test.go
@@ -1,0 +1,60 @@
+package brain_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0x6d61/pentecter/internal/brain"
+)
+
+func TestLoadConfig_OpenRouter_Defaults(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-test")
+	t.Setenv("OPENROUTER_BASE_URL", "")
+	t.Setenv("OPENROUTER_MODEL", "")
+
+	cfg, err := brain.LoadConfig(brain.ConfigHint{
+		Provider: brain.ProviderOpenRouter,
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig openrouter: %v", err)
+	}
+	if cfg.Token != "sk-or-test" {
+		t.Errorf("Token: got %q, want sk-or-test", cfg.Token)
+	}
+	if cfg.AuthType != brain.AuthAPIKey {
+		t.Errorf("AuthType: got %q, want %q", cfg.AuthType, brain.AuthAPIKey)
+	}
+	if cfg.BaseURL != "https://openrouter.ai/api/v1" {
+		t.Errorf("BaseURL: got %q, want https://openrouter.ai/api/v1", cfg.BaseURL)
+	}
+	if cfg.Model != "openai/gpt-4o-mini" {
+		t.Errorf("Model: got %q, want openai/gpt-4o-mini", cfg.Model)
+	}
+}
+
+func TestOpenRouterBrain_Think(t *testing.T) {
+	action := `{"thought":"test","action":"wait","seconds":1}`
+	srv := mockOpenAIServer(t, openAIResponse(action))
+	t.Cleanup(srv.Close)
+
+	b, err := brain.New(brain.Config{
+		Provider: brain.ProviderOpenRouter,
+		Model:    "openai/gpt-4o-mini",
+		Token:    "sk-or-test",
+		BaseURL:  srv.URL + "/v1",
+	})
+	if err != nil {
+		t.Fatalf("brain.New (openrouter): %v", err)
+	}
+	if b.Provider() != "openrouter" {
+		t.Errorf("Provider(): got %q, want openrouter", b.Provider())
+	}
+
+	got, err := b.Think(context.Background(), brain.Input{})
+	if err != nil {
+		t.Fatalf("Think (openrouter): %v", err)
+	}
+	if got == nil || got.Action != "wait" {
+		t.Fatalf("Think action: got %#v, want action=wait", got)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -67,10 +67,11 @@ type App struct {
 	globalLogs []string
 
 	// External dependencies
-	CurrentProvider string
-	CurrentModel    string
-	Runner          *tools.CommandRunner
-	BrainFactory    func(brain.ConfigHint) (brain.Brain, error)
+	CurrentProvider        string
+	CurrentModel           string
+	Runner                 *tools.CommandRunner
+	BrainFactory           func(brain.ConfigHint) (brain.Brain, error)
+	OpenRouterModelFetcher func(ctx context.Context) ([]brain.OpenRouterModel, error)
 
 	// For tests
 	testWriter io.Writer

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -1,9 +1,12 @@
 package tui
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/0x6d61/pentecter/internal/brain"
 )
@@ -43,66 +46,109 @@ func (a *App) handleCommand(fullText string) bool {
 	}
 }
 
-// modelsForProvider returns a list of models for the given provider.
-func modelsForProvider(p brain.Provider) []SelectOption {
-	switch p {
-	case brain.ProviderAnthropic:
-		return []SelectOption{
-			{Label: "claude-sonnet-4-6 (recommended)", Value: "claude-sonnet-4-6"},
-			{Label: "claude-opus-4-6", Value: "claude-opus-4-6"},
-			{Label: "claude-haiku-4-5", Value: "claude-haiku-4-5-20251001"},
-		}
-	case brain.ProviderOpenAI:
-		return []SelectOption{
-			{Label: "gpt-4o (recommended)", Value: "gpt-4o"},
-			{Label: "gpt-4o-mini", Value: "gpt-4o-mini"},
-			{Label: "o3-mini", Value: "o3-mini"},
-		}
-	case brain.ProviderOllama:
-		return []SelectOption{
-			{Label: "llama3.2 (recommended)", Value: "llama3.2"},
-			{Label: "llama3.2:3b", Value: "llama3.2:3b"},
-			{Label: "qwen2.5:7b", Value: "qwen2.5:7b"},
-			{Label: "gemma2:9b", Value: "gemma2:9b"},
-		}
-	default:
-		return nil
+func parseModelArg(fullText string) string {
+	fields := strings.Fields(fullText)
+	if len(fields) < 2 {
+		return ""
 	}
+	return strings.TrimSpace(strings.Join(fields[1:], " "))
+}
+
+func modelOptionsFromOpenRouter(models []brain.OpenRouterModel) []SelectOption {
+	opts := make([]SelectOption, 0, len(models))
+	for _, m := range models {
+		label := m.ID
+		if m.Name != "" && !strings.EqualFold(m.Name, m.ID) {
+			label = fmt.Sprintf("%s (%s)", m.ID, m.Name)
+		}
+		opts = append(opts, SelectOption{Label: label, Value: m.ID})
+	}
+	return opts
+}
+
+func resolveOpenRouterModel(query string, models []brain.OpenRouterModel) (string, bool) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return "", false
+	}
+	for _, m := range models {
+		if strings.EqualFold(m.ID, q) {
+			return m.ID, true
+		}
+	}
+	return "", false
+}
+
+func filterOpenRouterModels(query string, models []brain.OpenRouterModel) []brain.OpenRouterModel {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return models
+	}
+	filtered := make([]brain.OpenRouterModel, 0, len(models))
+	for _, m := range models {
+		id := strings.ToLower(m.ID)
+		name := strings.ToLower(m.Name)
+		if strings.Contains(id, q) || strings.Contains(name, q) {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
+func (a *App) fetchOpenRouterModels(ctx context.Context) ([]brain.OpenRouterModel, error) {
+	if a.OpenRouterModelFetcher != nil {
+		return a.OpenRouterModelFetcher(ctx)
+	}
+	return brain.FetchOpenRouterModels(ctx)
 }
 
 // handleModelCommand processes /model commands.
-func (a *App) handleModelCommand(_ string) {
-	detected := brain.DetectAvailableProviders()
-	if len(detected) == 0 {
-		a.logSystem("No providers detected. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or OLLAMA_BASE_URL.")
+func (a *App) handleModelCommand(fullText string) {
+	if os.Getenv("OPENROUTER_API_KEY") == "" {
+		a.logSystem("No providers detected. Set OPENROUTER_API_KEY.")
 		return
 	}
 
-	options := make([]SelectOption, len(detected))
-	for i, p := range detected {
-		options[i] = SelectOption{
-			Label: string(p),
-			Value: string(p),
+	provider := brain.ProviderOpenRouter
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	models, err := a.fetchOpenRouterModels(ctx)
+	if err != nil {
+		a.logSystem(fmt.Sprintf("Failed to fetch OpenRouter models: %v", err))
+		return
+	}
+	if len(models) == 0 {
+		a.logSystem("No models returned by OpenRouter.")
+		return
+	}
+
+	arg := parseModelArg(fullText)
+	if arg != "" {
+		if exact, ok := resolveOpenRouterModel(arg, models); ok {
+			a.switchModel(provider, exact)
+			return
 		}
+		filtered := filterOpenRouterModels(arg, models)
+		if len(filtered) == 0 {
+			a.logSystem(fmt.Sprintf("No OpenRouter model matches: %s", arg))
+			return
+		}
+		a.showSelect(
+			fmt.Sprintf("Select model (%s, %d matches):", provider, len(filtered)),
+			modelOptionsFromOpenRouter(filtered),
+			func(a *App, modelValue string) {
+				a.switchModel(provider, modelValue)
+			},
+		)
+		return
 	}
 
 	a.showSelect(
-		"Select provider:",
-		options,
-		func(a *App, providerValue string) {
-			provider := brain.Provider(providerValue)
-			models := modelsForProvider(provider)
-			if len(models) == 0 {
-				a.switchModel(provider, "")
-				return
-			}
-			a.showSelect(
-				fmt.Sprintf("Select model (%s):", providerValue),
-				models,
-				func(a *App, modelValue string) {
-					a.switchModel(provider, modelValue)
-				},
-			)
+		fmt.Sprintf("Select model (%s, %d total):", provider, len(models)),
+		modelOptionsFromOpenRouter(models),
+		func(a *App, modelValue string) {
+			a.switchModel(provider, modelValue)
 		},
 	)
 }

--- a/internal/tui/extract_test.go
+++ b/internal/tui/extract_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/0x6d61/pentecter/internal/agent"
@@ -126,15 +127,17 @@ func newTestApp(targets []*agent.Target) *App {
 	return a
 }
 
-func TestHandleModelCommand_ListProviders(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
-	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
-	t.Setenv("OPENAI_API_KEY", "")
-	t.Setenv("OLLAMA_BASE_URL", "")
+func TestHandleModelCommand_ListModels(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-test")
 
 	target := agent.NewTarget(1, "10.0.0.1")
 	a := newTestApp([]*agent.Target{target})
+	a.OpenRouterModelFetcher = func(context.Context) ([]brain.OpenRouterModel, error) {
+		return []brain.OpenRouterModel{
+			{ID: "openai/gpt-4o-mini", Name: "GPT-4o Mini"},
+			{ID: "anthropic/claude-3.5-sonnet", Name: "Claude 3.5 Sonnet"},
+		}, nil
+	}
 
 	a.handleModelCommand("/model")
 
@@ -142,45 +145,48 @@ func TestHandleModelCommand_ListProviders(t *testing.T) {
 		t.Errorf("expected ModeSelect mode, got %d", a.inputMode)
 	}
 	if len(a.selectOpts) < 1 {
-		t.Error("expected at least 1 provider in select options")
+		t.Error("expected at least 1 model in select options")
 	}
 	found := false
 	for _, opt := range a.selectOpts {
-		if opt.Value == "anthropic" {
+		if opt.Value == "openai/gpt-4o-mini" {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected 'anthropic' in select options")
+		t.Error("expected 'openai/gpt-4o-mini' in select options")
 	}
 }
 
-func TestHandleModelCommand_WithArgs_ShowsSelectUI(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
-	t.Setenv("OPENAI_API_KEY", "")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
-	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
-	t.Setenv("OLLAMA_BASE_URL", "")
+func TestHandleModelCommand_WithExactArg_SwitchesDirectly(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-test")
 
 	target := agent.NewTarget(1, "10.0.0.1")
 	a := newTestApp([]*agent.Target{target})
+	a.OpenRouterModelFetcher = func(context.Context) ([]brain.OpenRouterModel, error) {
+		return []brain.OpenRouterModel{
+			{ID: "openai/gpt-4o", Name: "GPT-4o"},
+		}, nil
+	}
 	a.BrainFactory = func(hint brain.ConfigHint) (brain.Brain, error) {
 		return nil, nil
 	}
 
 	a.handleModelCommand("/model openai/gpt-4o")
 
-	if a.inputMode != ModeSelect {
-		t.Errorf("expected ModeSelect mode, got %d", a.inputMode)
+	if a.inputMode == ModeSelect {
+		t.Errorf("expected direct switch mode, got select")
+	}
+	if a.CurrentProvider != "openrouter" {
+		t.Errorf("CurrentProvider: got %q, want openrouter", a.CurrentProvider)
+	}
+	if a.CurrentModel != "openai/gpt-4o" {
+		t.Errorf("CurrentModel: got %q, want openai/gpt-4o", a.CurrentModel)
 	}
 }
 
 func TestHandleModelCommand_NoProviders(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "")
-	t.Setenv("OPENAI_API_KEY", "")
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
-	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
-	t.Setenv("OLLAMA_BASE_URL", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
 
 	target := agent.NewTarget(1, "10.0.0.1")
 	a := newTestApp([]*agent.Target{target})

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -299,5 +299,9 @@ func (a *App) showSelect(title string, options []SelectOption, callback func(a *
 			_, _ = fmt.Fprintf(a.testWriter, "  %d. %s\n", i+1, opt.Label)
 		}
 		_, _ = fmt.Fprintf(a.testWriter, "  [1-%d/q]\n", len(options))
+		return
 	}
+
+	// In line-mode runtime, mode changes are not visible until we re-render.
+	a.clearAndReprint()
 }

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -86,7 +86,7 @@ func renderCommandBlock(b *agent.DisplayBlock, width int, expanded bool) string 
 }
 
 // renderThinkingBlock は思考中/処理中ブロックをレンダリングする。
-// 処理中: <spinnerFrame> Thinking... (アニメーション付きスピナー)
+// 処理中: … Thinking...
 // 完了: ✻ Completed in Xs
 func renderThinkingBlock(b *agent.DisplayBlock, _ string, expanded bool) string {
 	if !expanded {
@@ -101,7 +101,7 @@ func renderThinkingBlock(b *agent.DisplayBlock, _ string, expanded bool) string 
 	if !b.ThinkingDone {
 		// Keep spinner animation in the prompt only, but keep a colored
 		// thinking marker in the log stream.
-		return "\n" + style.Render("✻ Thinking...") + "\n\n"
+		return "\n" + style.Render("… Thinking...") + "\n\n"
 	}
 
 	dur := formatDuration(b.ThinkDuration)

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -203,6 +203,9 @@ func TestRenderThinkingBlock_InProgress(t *testing.T) {
 	if !strings.Contains(result, "Thinking...") {
 		t.Errorf("expected 'Thinking...' for in-progress thinking block, got: %q", result)
 	}
+	if strings.Contains(result, "✻") {
+		t.Errorf("in-progress thinking should not contain completion marker, got: %q", result)
+	}
 }
 
 func TestRenderThinkingBlock_InProgress_WithSpinner(t *testing.T) {
@@ -227,6 +230,9 @@ func TestRenderThinkingBlock_Completed(t *testing.T) {
 
 	result := renderThinkingBlock(b, "⠋", true)
 
+	if !strings.Contains(result, "✻") {
+		t.Error("expected '✻' in completed thinking block")
+	}
 	if !strings.Contains(result, "Completed in 12s") {
 		t.Errorf("expected 'Completed in 12s', got: %q", result)
 	}


### PR DESCRIPTION
## Summary
- add OpenRouter provider support via OpenAI-compatible client
- make runtime provider effectively OpenRouter-only in main flow
- fetch OpenRouter model list dynamically from /v1/models
- update /model command to support full-list selection, exact-id switch, and keyword filtering
- fix select UI redraw so model list is visible immediately
- clarify thinking markers: in-progress is … Thinking..., completed is ✻ Completed in ...

## Validation
- go test ./internal/brain/...
- go test ./internal/tui/...
- go test ./...