### PR TITLE
feat: エンドポイント優先度（EndpointPriority）を追加

### DIFF
--- a/internal/agent/attack_data_tree.go
+++ b/internal/agent/attack_data_tree.go
@@ -106,6 +106,8 @@ type AttackDataNode struct {
 	Path    string // "/", "/api", "/api/v1" (endpoint nodes only)
 	// HTTPStatus is the observed status code for endpoint nodes (0 = unknown/not recorded).
 	HTTPStatus int
+	// Priority はパス名に基づくエンドポイント優先度（0=High, 1=Normal, 2=Low）
+	Priority EndpointPriority
 
 	// タスクステータス（ノードタイプによって使うフィールドが異なる）
 	EndpointEnum AttackDataStatus
@@ -293,6 +295,55 @@ func isStaticFileExt(ext string) bool {
 	return staticFileExts[ext]
 }
 
+// EndpointPriority はエンドポイントの攻撃価値に基づく優先度。
+type EndpointPriority int
+
+const (
+	// PriorityHigh は攻撃面が広い高価値エンドポイント（/api, /admin 等）
+	PriorityHigh EndpointPriority = iota
+	// PriorityNormal はデフォルト優先度
+	PriorityNormal
+	// PriorityLow は静的リソースディレクトリ（/static, /js 等）
+	PriorityLow
+)
+
+// highPrioritySegments は攻撃価値の高いパスの先頭セグメント。
+var highPrioritySegments = map[string]bool{
+	"api": true, "admin": true, "login": true, "auth": true,
+	"dashboard": true, "panel": true, "manage": true, "user": true,
+	"account": true, "upload": true, "config": true, "settings": true,
+	"debug": true, "console": true, "graphql": true, "webhook": true,
+}
+
+// lowPrioritySegments は静的リソースディレクトリの先頭セグメント。
+var lowPrioritySegments = map[string]bool{
+	"static": true, "js": true, "css": true, "images": true,
+	"img": true, "fonts": true, "assets": true, "media": true,
+	"vendor": true, "lib": true, "node_modules": true,
+	"bower_components": true, "public": true, "dist": true,
+	"build": true, "bundle": true,
+}
+
+// endpointPriority はパスの先頭セグメントに基づいて優先度を返す。
+func endpointPriority(p string) EndpointPriority {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return PriorityNormal
+	}
+	// 先頭セグメントを取得
+	seg := strings.ToLower(trimmed)
+	if idx := strings.Index(seg, "/"); idx > 0 {
+		seg = seg[:idx]
+	}
+	if highPrioritySegments[seg] {
+		return PriorityHigh
+	}
+	if lowPrioritySegments[seg] {
+		return PriorityLow
+	}
+	return PriorityNormal
+}
+
 // AddEndpoint は ffuf で発見した endpoint を親ノードの子として追加する。
 // httpStatus=0 として AddEndpointWithStatus に委譲する（後方互換）。
 func (t *AttackDataTree) AddEndpoint(host string, port int, parentPath, newPath string) {
@@ -368,6 +419,14 @@ func (t *AttackDataTree) AddEndpointWithStatus(host string, port int, parentPath
 		profiling = StatusNone
 	}
 
+	// Low priority path check: 静的リソースディレクトリは ParamFuzz/ValueFuzz/Profiling をスキップ
+	prio := endpointPriority(newPath)
+	if paramFuzz != StatusNone && prio == PriorityLow {
+		paramFuzz = StatusNone
+		valueFuzz = StatusNone
+		profiling = StatusNone
+	}
+
 	// Depth check: if beyond MaxDepth, skip directory enumeration
 	if endpointEnum != StatusNone && t.MaxDepth > 0 && pathDepth(newPath) > t.MaxDepth {
 		endpointEnum = StatusNone
@@ -378,6 +437,7 @@ func (t *AttackDataTree) AddEndpointWithStatus(host string, port int, parentPath
 		Port:         port,
 		Path:         newPath,
 		HTTPStatus:   httpStatus,
+		Priority:     prio,
 		EndpointEnum: endpointEnum,
 		ParamFuzz:    paramFuzz,
 		ValueFuzz:    valueFuzz,
@@ -523,19 +583,23 @@ func (t *AttackDataTree) NextBatch() []*ReconTask {
 	return tasks
 }
 
-// collectPending は指定タイプの pending タスクを DFS で収集する
+// collectPending は指定タイプの pending タスクを DFS で収集し、優先度順にソートする
 func (t *AttackDataTree) collectPending(tasks *[]*ReconTask, taskType ReconTaskType, limit int) {
+	startIdx := len(*tasks)
 	for _, node := range t.Ports {
-		if len(*tasks) >= limit {
-			return
-		}
-		t.collectPendingFromNode(tasks, node, taskType, limit)
+		t.collectPendingFromNode(tasks, node, taskType, limit*2) // ソート用に多めに収集
 	}
 	for _, node := range t.Vhosts {
-		if len(*tasks) >= limit {
-			return
-		}
-		t.collectPendingFromNode(tasks, node, taskType, limit)
+		t.collectPendingFromNode(tasks, node, taskType, limit*2)
+	}
+	// 同一タスクタイプ内で優先度順にソート（High → Normal → Low）
+	newTasks := (*tasks)[startIdx:]
+	sort.SliceStable(newTasks, func(i, j int) bool {
+		return newTasks[i].Node.Priority < newTasks[j].Node.Priority
+	})
+	// limit を超えた分を切り詰め
+	if len(*tasks) > startIdx+limit {
+		*tasks = (*tasks)[:startIdx+limit]
 	}
 }
 

--- a/internal/agent/attack_data_tree_test.go
+++ b/internal/agent/attack_data_tree_test.go
@@ -2934,3 +2934,172 @@ func TestSnapshotRestore_PreservesCredentialAndInsight(t *testing.T) {
 		t.Fatalf("restored insight topic = %q, want default_credentials", node.Insights[0].Topic)
 	}
 }
+
+// --- EndpointPriority テスト ---
+
+func TestEndpointPriority_Classification(t *testing.T) {
+	tests := []struct {
+		path string
+		want EndpointPriority
+	}{
+		// High priority
+		{"/api", PriorityHigh},
+		{"/admin", PriorityHigh},
+		{"/login", PriorityHigh},
+		{"/auth", PriorityHigh},
+		{"/dashboard", PriorityHigh},
+		{"/upload", PriorityHigh},
+		{"/config", PriorityHigh},
+		{"/debug", PriorityHigh},
+		{"/console", PriorityHigh},
+		{"/graphql", PriorityHigh},
+
+		// Low priority
+		{"/static", PriorityLow},
+		{"/js", PriorityLow},
+		{"/css", PriorityLow},
+		{"/images", PriorityLow},
+		{"/img", PriorityLow},
+		{"/fonts", PriorityLow},
+		{"/assets", PriorityLow},
+		{"/vendor", PriorityLow},
+		{"/node_modules", PriorityLow},
+		{"/dist", PriorityLow},
+		{"/build", PriorityLow},
+
+		// Normal priority (デフォルト)
+		{"/", PriorityNormal},
+		{"/about", PriorityNormal},
+		{"/contact", PriorityNormal},
+		{"/blog", PriorityNormal},
+		{"/products", PriorityNormal},
+	}
+
+	for _, tt := range tests {
+		got := endpointPriority(tt.path)
+		if got != tt.want {
+			t.Errorf("endpointPriority(%q) = %d, want %d", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestEndpointPriority_NestedPath(t *testing.T) {
+	// 先頭セグメントで判定するため、/api/static は High
+	tests := []struct {
+		path string
+		want EndpointPriority
+	}{
+		{"/api/static", PriorityHigh},   // 先頭 = api → High
+		{"/api/v1/users", PriorityHigh}, // 先頭 = api → High
+		{"/static/api", PriorityLow},    // 先頭 = static → Low
+		{"/js/app.js", PriorityLow},     // 先頭 = js → Low
+		{"/admin/users", PriorityHigh},  // 先頭 = admin → High
+	}
+
+	for _, tt := range tests {
+		got := endpointPriority(tt.path)
+		if got != tt.want {
+			t.Errorf("endpointPriority(%q) = %d, want %d", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestNextBatch_EndpointPriorityOrder(t *testing.T) {
+	// High 優先度のエンドポイントが Low より先に返されること
+	tree := NewAttackDataTree("10.10.11.100", 10, 0) // 高い max_parallel で全部返す
+	tree.AddPort(80, "http", "Apache")
+
+	// Low → Normal → High の順で追加（逆順）
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/static", 200)
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/js", 200)
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/about", 200)
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/api", 200)
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/admin", 200)
+
+	// ポートレベルのタスクを完了にして、子タスクだけにする
+	tree.CompleteTask("10.10.11.100", 80, "", TaskEndpointEnum)
+	tree.CompleteTask("10.10.11.100", 80, "", TaskVhostDiscov)
+
+	batch := tree.NextBatch()
+	if len(batch) == 0 {
+		t.Fatal("NextBatch returned empty")
+	}
+
+	// endpoint_enum タスクだけ取り出して順序確認
+	var enumTasks []*ReconTask
+	for _, task := range batch {
+		if task.Type == TaskEndpointEnum {
+			enumTasks = append(enumTasks, task)
+		}
+	}
+
+	if len(enumTasks) < 2 {
+		t.Fatalf("expected at least 2 endpoint_enum tasks, got %d", len(enumTasks))
+	}
+
+	// High 優先度のタスクが先に来ていること
+	for i := 0; i < len(enumTasks)-1; i++ {
+		if enumTasks[i].Node.Priority > enumTasks[i+1].Node.Priority {
+			t.Errorf("endpoint_enum tasks not sorted by priority: [%d]=%q(prio=%d) before [%d]=%q(prio=%d)",
+				i, enumTasks[i].Path, enumTasks[i].Node.Priority,
+				i+1, enumTasks[i+1].Path, enumTasks[i+1].Node.Priority)
+		}
+	}
+}
+
+func TestAddEndpointWithStatus_LowPrioritySkipsParamFuzz(t *testing.T) {
+	tree := NewAttackDataTree("10.10.11.100", 2, 0)
+	tree.AddPort(80, "http", "Apache")
+
+	// Low 優先度パス
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/static", 200)
+	// High 優先度パス
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/api", 200)
+	// Normal 優先度パス
+	tree.AddEndpointWithStatus("10.10.11.100", 80, "/", "/about", 200)
+
+	port := tree.Ports[0]
+
+	// /static は EndpointEnum のみ Pending、ParamFuzz/ValueFuzz/Profiling は None
+	for _, child := range port.Children {
+		switch child.Path {
+		case "/static":
+			if child.Priority != PriorityLow {
+				t.Errorf("/static Priority = %d, want Low(%d)", child.Priority, PriorityLow)
+			}
+			if child.EndpointEnum != StatusPending {
+				t.Errorf("/static EndpointEnum = %d, want Pending", child.EndpointEnum)
+			}
+			if child.ParamFuzz != StatusNone {
+				t.Errorf("/static ParamFuzz = %d, want None (low priority skip)", child.ParamFuzz)
+			}
+			if child.ValueFuzz != StatusNone {
+				t.Errorf("/static ValueFuzz = %d, want None (low priority skip)", child.ValueFuzz)
+			}
+			if child.Profiling != StatusNone {
+				t.Errorf("/static Profiling = %d, want None (low priority skip)", child.Profiling)
+			}
+
+		case "/api":
+			if child.Priority != PriorityHigh {
+				t.Errorf("/api Priority = %d, want High(%d)", child.Priority, PriorityHigh)
+			}
+			// High パスは全タスク Pending
+			if child.ParamFuzz != StatusPending {
+				t.Errorf("/api ParamFuzz = %d, want Pending", child.ParamFuzz)
+			}
+			if child.ValueFuzz != StatusPending {
+				t.Errorf("/api ValueFuzz = %d, want Pending", child.ValueFuzz)
+			}
+
+		case "/about":
+			if child.Priority != PriorityNormal {
+				t.Errorf("/about Priority = %d, want Normal(%d)", child.Priority, PriorityNormal)
+			}
+			// Normal パスも全タスク Pending
+			if child.ParamFuzz != StatusPending {
+				t.Errorf("/about ParamFuzz = %d, want Pending", child.ParamFuzz)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- EndpointPriority型（High/Normal/Low）をパス先頭セグメントで分類
- High: /api, /admin, /login, /auth, /dashboard等
- Low: /static, /js, /css, /images, /fonts, /assets等
- NextBatch内で同一タスクタイプを優先度順にソート
- Lowパスは ParamFuzz/ValueFuzz/Profiling を自動スキップ
- 新規テスト4件追加、既存テスト全パス
